### PR TITLE
Add an endpoint for reaction summaries

### DIFF
--- a/ord_app/api/editor/reactions.py
+++ b/ord_app/api/editor/reactions.py
@@ -14,9 +14,12 @@
 
 """Reaction API endpoints."""
 import gzip
+from base64 import b64decode
 from uuid import uuid4
 
 from fastapi import APIRouter, Response
+from ord_schema.proto.reaction_pb2 import Reaction
+from pydantic import BaseModel
 
 from ord_app.api import send_message, write_message
 from ord_app.api.database import add_dataset, get_cursor, get_dataset
@@ -94,3 +97,21 @@ def delete_reaction(user_id: str, dataset_name: str, index: int):
         del dataset.reactions[index]
         add_dataset(user_id, dataset, cursor)
     return Response(status_code=200)
+
+
+class ReactionRequest(BaseModel):
+    """Request body for a serialized reaction."""
+
+    proto: str  # Serialized Reaction protocol buffer (base64).
+
+    @property
+    def reaction(self) -> Reaction:
+        return Reaction.FromString(b64decode(self.proto))
+
+
+@router.post("/summarize_reaction")
+def summarize_reaction(request: ReactionRequest):
+    """Returns summary information for the reaction card view."""
+    # TODO(skearnes): Implement something useful here.
+    assert request.reaction.reaction_id == "test_reaction-0"
+    return {"provenance": {"doi": "foo"}, "summary": {"yield": 25.5}}

--- a/ord_app/api/editor/reactions.py
+++ b/ord_app/api/editor/reactions.py
@@ -101,6 +101,6 @@ def delete_reaction(user_id: str, dataset_name: str, index: int):
 async def summarize_reaction(request: Request):
     """Returns summary information for the reaction card view."""
     # TODO(skearnes): Implement something useful here.
-    del request  # Unused.
-    # reaction = Reaction.FromString(await request.body())
+    reaction = Reaction.FromString(await request.body())
+    del reaction  # Unused.
     return {"provenance": {"doi": "foo"}, "summary": {"yield": 25.5}}

--- a/ord_app/api/editor/reactions.py
+++ b/ord_app/api/editor/reactions.py
@@ -14,12 +14,10 @@
 
 """Reaction API endpoints."""
 import gzip
-from base64 import b64decode
 from uuid import uuid4
 
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, Request, Response
 from ord_schema.proto.reaction_pb2 import Reaction
-from pydantic import BaseModel
 
 from ord_app.api import send_message, write_message
 from ord_app.api.database import add_dataset, get_cursor, get_dataset
@@ -99,19 +97,10 @@ def delete_reaction(user_id: str, dataset_name: str, index: int):
     return Response(status_code=200)
 
 
-class ReactionRequest(BaseModel):
-    """Request body for a serialized reaction."""
-
-    proto: str  # Serialized Reaction protocol buffer (base64).
-
-    @property
-    def reaction(self) -> Reaction:
-        return Reaction.FromString(b64decode(self.proto))
-
-
 @router.post("/summarize_reaction")
-def summarize_reaction(request: ReactionRequest):
+async def summarize_reaction(request: Request):
     """Returns summary information for the reaction card view."""
     # TODO(skearnes): Implement something useful here.
     del request  # Unused.
+    # reaction = Reaction.FromString(await request.body())
     return {"provenance": {"doi": "foo"}, "summary": {"yield": 25.5}}

--- a/ord_app/api/editor/reactions.py
+++ b/ord_app/api/editor/reactions.py
@@ -113,5 +113,5 @@ class ReactionRequest(BaseModel):
 def summarize_reaction(request: ReactionRequest):
     """Returns summary information for the reaction card view."""
     # TODO(skearnes): Implement something useful here.
-    assert request.reaction.reaction_id == "test_reaction-0"
+    del request  # Unused.
     return {"provenance": {"doi": "foo"}, "summary": {"yield": 25.5}}

--- a/ord_app/api/editor/reactions_test.py
+++ b/ord_app/api/editor/reactions_test.py
@@ -107,6 +107,7 @@ def test_summarize_reaction(test_client):
         params={"user_id": TEST_USER_ID, "dataset_name": "Deoxyfluorination screen", "index": 0},
     )
     response.raise_for_status()
-    summary = test_client.post("/api/editor/summarize_reaction", json={"proto": response.json()}).json()
+    reaction = Reaction.FromString(b64decode(response.json()))
+    summary = test_client.post("/api/editor/summarize_reaction", data=reaction.SerializeToString()).json()
     assert "provenance" in summary
     assert "summary" in summary

--- a/ord_app/api/editor/reactions_test.py
+++ b/ord_app/api/editor/reactions_test.py
@@ -99,3 +99,14 @@ def test_delete_reaction(test_client):
     response.raise_for_status()
     dataset = Dataset.FromString(b64decode(response.json()))
     assert len(dataset.reactions) == 79
+
+
+def test_summarize_reaction(test_client):
+    response = test_client.get(
+        "/api/editor/fetch_reaction",
+        params={"user_id": TEST_USER_ID, "dataset_name": "Deoxyfluorination screen", "index": 0},
+    )
+    response.raise_for_status()
+    summary = test_client.post("/api/editor/summarize_reaction", json={"proto": response.json()}).json()
+    assert "provenance" in summary
+    assert "summary" in summary


### PR DESCRIPTION
Adds an API endpoint that takes a serialized Reaction message (generated by `reaction.serializeBinary()`) and returns a JSON dict of dicts containing reaction summary information. There are two sets of information:
* `provenance`: Dictionary of reaction metadata that should be shown immediately under the reaction ID.
* `summary`: Dictionary of conditions, analysis, notes, etc. info that should be shown under the schematic.