### PR TITLE
Download individual reactions

### DIFF
--- a/ui/src/pages/dataset/DatasetPage/DatasetPage.module.scss
+++ b/ui/src/pages/dataset/DatasetPage/DatasetPage.module.scss
@@ -79,3 +79,13 @@
 .emptyText {
   color: var(--color-text-secondary-1);
 }
+
+.target {
+  &:active {
+    transform: none;
+  }
+
+  &[data-expanded='true'] {
+    outline: 3px solid #3c78d899;
+  }
+}

--- a/ui/src/pages/dataset/DatasetPage/DatasetPage.tsx
+++ b/ui/src/pages/dataset/DatasetPage/DatasetPage.tsx
@@ -22,15 +22,21 @@ import { useAppDispatch } from 'store/useAppDispatch';
 import { getDataset } from 'store/datasets/datasets.thunks';
 import { ReactionList } from './ReactionList/ReactionList';
 import { DataField } from '../../../common/components/DataField/DataField';
-import { DownloadMenu } from './DownloadMenu/DownloadMenu';
+import { DownloadMenu, type DownloadMenuOptions } from './DownloadMenu/DownloadMenu';
 import { UserField } from '../../../common/components/UserField/UserField';
-import { formatDate } from '../../../common/utils';
+import { downloadFile, formatDate } from '../../../common/utils';
 import { generateMockReactions } from '../../../common/mocks/generateMockReactions';
-import classes from './DatasetPage.module.scss';
 import { CopyButton, type CopyButtonOptions } from './CopyButton/CopyButton';
-import { AddCircleIcon, EmptyIcon } from 'common/icons';
+import { AddCircleIcon, ChevronDownIcon, EmptyIcon } from 'common/icons';
+import classes from './DatasetPage.module.scss';
 
 const mockData = generateMockReactions(200);
+
+const datasetDownloadOptions: DownloadMenuOptions[] = [
+  { label: '.pb', format: 'binpb' },
+  { label: '.pbtxt', format: 'txtpb' },
+  { label: '.json', format: 'json' },
+];
 
 export function DatasetPage() {
   const dispatch = useAppDispatch();
@@ -40,6 +46,11 @@ export function DatasetPage() {
   useEffect(() => {
     dispatch(getDataset(Number(datasetId)));
   }, [dispatch, datasetId]);
+
+  const handleDatasetDownload = (format: string) => {
+    const url = `/datasets/${datasetId}/download?file_format=${format}`;
+    downloadFile(url, `Dataset_${datasetId}`);
+  };
 
   const copyToClipboardOptions: CopyButtonOptions[] = [
     { label: 'Copy Dataset Link', value: window.location.href },
@@ -96,7 +107,19 @@ export function DatasetPage() {
         </div>
 
         <div className={classes.buttonContainer}>
-          <DownloadMenu datasetId={Number(datasetId)} />
+          <DownloadMenu
+            options={datasetDownloadOptions}
+            onClick={handleDatasetDownload}
+            target={
+              <Button
+                className={classes.target}
+                rightSection={<ChevronDownIcon />}
+                title="Download dataset"
+              >
+                Download as
+              </Button>
+            }
+          />
         </div>
       </Paper>
 

--- a/ui/src/pages/dataset/DatasetPage/DownloadMenu/DownloadMenu.tsx
+++ b/ui/src/pages/dataset/DatasetPage/DownloadMenu/DownloadMenu.tsx
@@ -13,27 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Button, Menu } from '@mantine/core';
-import { downloadFile } from 'common/utils';
-import { ChevronDownIcon, DownloadIcon } from 'common/icons';
+import { Menu } from '@mantine/core';
+import { DownloadIcon } from 'common/icons';
 import classes from './DownloadMenu.module.scss';
 
-interface DownloadMenuProps {
-  datasetId: number;
+export interface DownloadMenuOptions {
+  label: string;
+  format: string;
 }
 
-const downloadOptions = [
-  { label: '.pb', format: 'binpb' },
-  { label: '.pbtxt', format: 'txtpb' },
-  { label: '.json', format: 'json' },
-];
+interface DownloadMenuProps {
+  options: DownloadMenuOptions[];
+  target: JSX.Element;
+  onClick: (format: string) => void;
+}
 
-export function DownloadMenu({ datasetId }: Readonly<DownloadMenuProps>) {
-  const handleDownload = (format: string) => {
-    const url = `/datasets/${datasetId}/download?file_format=${format}`;
-    downloadFile(url, `Dataset_${datasetId}`);
-  };
-
+export function DownloadMenu({ options, target, onClick }: Readonly<DownloadMenuProps>) {
   return (
     <Menu
       classNames={{
@@ -43,22 +38,14 @@ export function DownloadMenu({ datasetId }: Readonly<DownloadMenuProps>) {
       }}
       width={140}
     >
-      <Menu.Target>
-        <Button
-          className={classes.target}
-          rightSection={<ChevronDownIcon />}
-          title="Download dataset"
-        >
-          Download as
-        </Button>
-      </Menu.Target>
+      <Menu.Target>{target}</Menu.Target>
 
       <Menu.Dropdown>
-        {downloadOptions.map(option => (
+        {options.map(option => (
           <Menu.Item
             key={option.format}
             leftSection={<DownloadIcon />}
-            onClick={() => handleDownload(option.format)}
+            onClick={() => onClick(option.format)}
           >
             {option.label}
           </Menu.Item>

--- a/ui/src/pages/dataset/DatasetPage/ReactionCard/ReactionCard.module.scss
+++ b/ui/src/pages/dataset/DatasetPage/ReactionCard/ReactionCard.module.scss
@@ -54,3 +54,9 @@
 .infoTitle {
   font-weight: 700;
 }
+
+.target {
+  &:active {
+    transform: none;
+  }
+}

--- a/ui/src/pages/dataset/DatasetPage/ReactionCard/ReactionCard.tsx
+++ b/ui/src/pages/dataset/DatasetPage/ReactionCard/ReactionCard.tsx
@@ -14,19 +14,33 @@
  * limitations under the License.
  */
 import { Button, Flex, Paper } from '@mantine/core';
-import { Link } from 'wouter';
+import { Link, useParams } from 'wouter';
 import { CopyButton, type CopyButtonOptions } from '../CopyButton/CopyButton';
 import { CheckListIcon, ChevronDownIcon, DotsIcon, DownloadIcon } from 'common/icons';
 import type { Reaction } from '../../../../common/model/reaction';
+import { DownloadMenu, type DownloadMenuOptions } from '../DownloadMenu/DownloadMenu';
 import classes from './ReactionCard.module.scss';
+import { downloadFile } from 'common/utils';
 
 interface ReactionCardProps {
   reaction: Reaction;
   index: number;
 }
 
+const reactionDownloadOptions: DownloadMenuOptions[] = [
+  { label: '.pb', format: 'binpb' },
+  { label: '.pbtxt', format: 'txtpb' },
+];
+
 export function ReactionCard({ reaction, index }: Readonly<ReactionCardProps>) {
+  const { datasetId } = useParams();
   const { id, name, summary, conditions, analysis } = reaction;
+
+  const handleReactionDownload = (format: string) => {
+    // TODO: Replace index with reaction id when reaction information is pulled from BE
+    const url = `/datasets/${datasetId}/reactions/${index}/download?file_format=${format}`;
+    downloadFile(url, `Dataset_${datasetId}_Reaction_${id}`);
+  };
 
   const copyToClipboardOptions: CopyButtonOptions[] = [
     { label: 'Copy Reaction Link', value: `${window.location.href}/reaction/${id}` },
@@ -70,13 +84,20 @@ export function ReactionCard({ reaction, index }: Readonly<ReactionCardProps>) {
             Save as a Template
           </Button>
 
-          <Button
-            leftSection={<DownloadIcon />}
-            rightSection={<ChevronDownIcon />}
-            variant="white"
-          >
-            Download Reaction
-          </Button>
+          <DownloadMenu
+            options={reactionDownloadOptions}
+            onClick={handleReactionDownload}
+            target={
+              <Button
+                className={classes.target}
+                leftSection={<DownloadIcon />}
+                rightSection={<ChevronDownIcon />}
+                variant="white"
+              >
+                Download Reaction
+              </Button>
+            }
+          />
 
           <Button
             leftSection={<DotsIcon />}


### PR DESCRIPTION
This PR updates the `DownloadMenu` component and adds the ability to download individual reactions from the dataset view