### PR TITLE
Create reaction from the scratch/import from the file

### DIFF
--- a/ui/src/common/components/FormModal/FormModal.tsx
+++ b/ui/src/common/components/FormModal/FormModal.tsx
@@ -16,14 +16,15 @@
 import type { ReactNode } from 'react';
 import { Button, Flex, Modal } from '@mantine/core';
 
-interface CreateDatasetLayoutProps {
+interface FormModalProps {
   onClose: () => void;
   onSubmit: () => void;
   title: string;
   children: ReactNode;
+  submitTitle?: string;
 }
 
-export function CreateDatasetLayout({ onClose, onSubmit, title, children }: Readonly<CreateDatasetLayoutProps>) {
+export function FormModal({ onClose, onSubmit, title, children, submitTitle }: Readonly<FormModalProps>) {
   return (
     <Modal
       opened
@@ -48,7 +49,7 @@ export function CreateDatasetLayout({ onClose, onSubmit, title, children }: Read
             >
               Cancel
             </Button>
-            <Button type="submit">Create Dataset</Button>
+            <Button type="submit">{submitTitle ?? 'Create'}</Button>
           </Flex>
         </Flex>
       </form>

--- a/ui/src/pages/ContributePage/DatasetTopActions/CreateDatasetFromFile/CreateDatasetFromFile.tsx
+++ b/ui/src/pages/ContributePage/DatasetTopActions/CreateDatasetFromFile/CreateDatasetFromFile.tsx
@@ -18,7 +18,7 @@ import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { selectOrderedGroupsList } from 'store/groups/groups.selectors';
 import { useForm, yupResolver } from '@mantine/form';
-import { CreateDatasetLayout } from '../CreateDatasetLayout/CreateDatasetLayout';
+import { FormModal } from 'common/components/FormModal/FormModal';
 import { type CreateDatasetFromFileFormValues, createDatasetFromFileSchema } from './createDatasetFromFile.schema';
 import type { CreateDatasetFromFilePayload } from 'store/datasets/datasets.types';
 import { createDatasetFromFile } from 'store/datasets/datasets.thunks';
@@ -59,10 +59,11 @@ export function CreateDatasetFromFile({ onClose }: Readonly<CreateDatasetFromFil
   );
 
   return (
-    <CreateDatasetLayout
+    <FormModal
       onClose={onClose}
       onSubmit={form.onSubmit(onSubmit)}
       title="Create Dataset from File"
+      submitTitle="Create Dataset"
     >
       <Select
         data={data}
@@ -76,6 +77,6 @@ export function CreateDatasetFromFile({ onClose }: Readonly<CreateDatasetFromFil
         description=".binpb, .txtpb, or .json"
         {...form.getInputProps('file')}
       />
-    </CreateDatasetLayout>
+    </FormModal>
   );
 }

--- a/ui/src/pages/ContributePage/DatasetTopActions/CreateNewDataset/CreateNewDataset.tsx
+++ b/ui/src/pages/ContributePage/DatasetTopActions/CreateNewDataset/CreateNewDataset.tsx
@@ -23,7 +23,7 @@ import type { CreateNewDatasetPayload } from 'store/datasets/datasets.types';
 import { createEmptyDataset } from 'store/datasets/datasets.thunks';
 import { useAppDispatch } from 'store/useAppDispatch';
 import { selectIsDatasetCreating } from 'store/datasets/datasets.selectors';
-import { CreateDatasetLayout } from '../CreateDatasetLayout/CreateDatasetLayout';
+import { FormModal } from 'common/components/FormModal/FormModal';
 
 interface CreateNewDatasetProps {
   onClose: () => void;
@@ -63,10 +63,11 @@ export function CreateNewDataset({ onClose }: Readonly<CreateNewDatasetProps>) {
   );
 
   return (
-    <CreateDatasetLayout
+    <FormModal
       onClose={onClose}
       onSubmit={form.onSubmit(onSubmit)}
       title="Create Dataset from Scratch"
+      submitTitle="Create Dataset"
     >
       <Select
         data={data}
@@ -86,6 +87,6 @@ export function CreateNewDataset({ onClose }: Readonly<CreateNewDatasetProps>) {
         disabled={isLoading}
         {...form.getInputProps('description')}
       />
-    </CreateDatasetLayout>
+    </FormModal>
   );
 }

--- a/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReaction.module.scss
+++ b/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReaction.module.scss
@@ -13,21 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type OrdSchema from 'ord-schema';
-
-export interface ReactionResponse {
-  id: number;
-  name: string;
-  summary: unknown;
-  binpb: string;
+.dropdown {
+  width: 135px;
+  border: none;
+  box-shadow: 0 4px 24px 0 #00000014;
 }
 
-export type Reaction = ReturnType<ReturnType<typeof OrdSchema.Reaction.deserializeBinary>['toObject']>;
-
-export interface ReactionWrapper extends Omit<ReactionResponse, 'binpb'> {
-  data: Reaction;
+.menuItem {
+  padding: 10px 12px;
+  border-radius: 8px;
 }
 
-export interface ImportReactionFromFilePayload {
-  file: File;
+.buttonRoot {
+  border-radius: 8px;
+
+  &:active {
+    transform: none;
+  }
+
+  &[data-expanded='true'] {
+    outline: 3px solid #3c78d899;
+  }
+}
+
+.buttonInner {
+  gap: 6px;
+  font-weight: 400;
 }

--- a/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReactionFromFile/CreateReactionFromFile.module.scss
+++ b/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReactionFromFile/CreateReactionFromFile.module.scss
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type OrdSchema from 'ord-schema';
-
-export interface ReactionResponse {
-  id: number;
-  name: string;
-  summary: unknown;
-  binpb: string;
-}
-
-export type Reaction = ReturnType<ReturnType<typeof OrdSchema.Reaction.deserializeBinary>['toObject']>;
-
-export interface ReactionWrapper extends Omit<ReactionResponse, 'binpb'> {
-  data: Reaction;
-}
-
-export interface ImportReactionFromFilePayload {
-  file: File;
+.fileInput {
+  margin: 30px 0 40px;
 }

--- a/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReactionFromFile/CreateReactionFromFile.tsx
+++ b/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReactionFromFile/CreateReactionFromFile.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback } from 'react';
+import { FileInput } from '@mantine/core';
+import { useForm, yupResolver } from '@mantine/form';
+import { FormModal } from 'common/components/FormModal/FormModal';
+import { importReactionFromFile } from 'store/reactions/reactions.thunks';
+import { useAppDispatch } from 'store/useAppDispatch';
+import { type CreateReactionFromFileFormValues, createReactionFromFileSchema } from './createReactionFromFile.schema';
+import { type ImportReactionFromFilePayload } from 'store/reactions/reactions.types';
+import classes from './CreateReactionFromFile.module.scss';
+import { setReactionUploadOpenedAction } from 'store/reactions/reactions.actions';
+
+export function CreateReactionFromFile() {
+  const dispatch = useAppDispatch();
+
+  const form = useForm<
+    CreateReactionFromFileFormValues,
+    (values: CreateReactionFromFileFormValues) => ImportReactionFromFilePayload
+  >({
+    mode: 'controlled',
+    transformValues: values => ({
+      file: values.file as File,
+    }),
+    validate: yupResolver(createReactionFromFileSchema),
+  });
+
+  const onSubmit = useCallback(
+    (values: ImportReactionFromFilePayload) => {
+      dispatch(importReactionFromFile(values));
+    },
+    [dispatch],
+  );
+
+  const handleClose = useCallback(() => dispatch(setReactionUploadOpenedAction(false)), [dispatch]);
+
+  return (
+    <FormModal
+      onClose={handleClose}
+      onSubmit={form.onSubmit(onSubmit)}
+      title="Import Reaction from File"
+      submitTitle="Save"
+    >
+      <FileInput
+        className={classes.fileInput}
+        withAsterisk
+        label="Reaction file"
+        accept=".pb,.binpb,.txtpb,.pbtxt,application/json"
+        description=".pb, .binpb, .txtpb, .pbtxt or .json"
+        placeholder="Attach file"
+        {...form.getInputProps('file')}
+      />
+    </FormModal>
+  );
+}

--- a/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReactionFromFile/createReactionFromFile.schema.ts
+++ b/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReactionFromFile/createReactionFromFile.schema.ts
@@ -13,21 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type OrdSchema from 'ord-schema';
+import * as yup from 'yup';
 
-export interface ReactionResponse {
-  id: number;
-  name: string;
-  summary: unknown;
-  binpb: string;
-}
+const MAX_FILE_SIZE = 1024 * 1024 * 15;
 
-export type Reaction = ReturnType<ReturnType<typeof OrdSchema.Reaction.deserializeBinary>['toObject']>;
+const MAX_FILE_SIZE_MB = (MAX_FILE_SIZE / 1024 / 1024).toFixed(2);
 
-export interface ReactionWrapper extends Omit<ReactionResponse, 'binpb'> {
-  data: Reaction;
-}
+export const createReactionFromFileSchema = yup.object({
+  file: yup
+    .mixed()
+    .required('Reaction file is required')
+    .label('File')
+    .test({
+      message: `Filesize cannot exceed ${MAX_FILE_SIZE_MB} MB`,
+      test: value => {
+        const file = value as File;
+        return file?.size < MAX_FILE_SIZE;
+      },
+    }),
+});
 
-export interface ImportReactionFromFilePayload {
-  file: File;
-}
+export type CreateReactionFromFileFormValues = yup.InferType<typeof createReactionFromFileSchema>;

--- a/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReactionMenu.tsx
+++ b/ui/src/pages/DatasetPage/ReactionList/CreateReactionMenu/CreateReactionMenu.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback } from 'react';
+import { Button, Menu } from '@mantine/core';
+import { useSelector } from 'react-redux';
+import { createEmptyReaction } from 'store/reactions/reactions.thunks';
+import { useAppDispatch } from 'store/useAppDispatch';
+import { AddCircleIcon, ChevronDownIcon } from 'common/icons';
+import { CreateReactionFromFile } from './CreateReactionFromFile/CreateReactionFromFile';
+import { selectIsReactionUploadOpened } from 'store/reactions/reactions.selectors';
+import { setReactionUploadOpenedAction } from 'store/reactions/reactions.actions';
+import classes from './CreateReaction.module.scss';
+
+export function CreateReactionMenu() {
+  const dispatch = useAppDispatch();
+  const isReactionUploadOpened = useSelector(selectIsReactionUploadOpened);
+
+  const handleReactionCreate = useCallback(() => dispatch(createEmptyReaction()), [dispatch]);
+
+  const handleReactionUpload = useCallback(() => dispatch(setReactionUploadOpenedAction(true)), [dispatch]);
+
+  return (
+    <>
+      <Menu
+        classNames={{
+          dropdown: classes.dropdown,
+          item: classes.menuItem,
+          itemSection: classes.menuItemSection,
+        }}
+      >
+        <Menu.Target>
+          <Button
+            classNames={{ root: classes.buttonRoot, inner: classes.buttonInner }}
+            leftSection={<AddCircleIcon />}
+            rightSection={<ChevronDownIcon />}
+          >
+            Reaction
+          </Button>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Item onClick={handleReactionCreate}>From Scratch</Menu.Item>
+          <Menu.Item onClick={handleReactionUpload}>Import from File</Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+
+      {isReactionUploadOpened && <CreateReactionFromFile />}
+    </>
+  );
+}

--- a/ui/src/pages/DatasetPage/ReactionList/ReactionList.tsx
+++ b/ui/src/pages/DatasetPage/ReactionList/ReactionList.tsx
@@ -16,13 +16,14 @@
 import { useCallback } from 'react';
 import { Pagination } from 'common/components/Pagination/Pagination';
 import { ReactionCard } from './ReactionCard/ReactionCard';
-import { Button, Flex, Paper, Title } from '@mantine/core';
-import classes from './reactionsList.module.scss';
-import { AddCircleIcon, EmptyIcon } from 'common/icons';
+import { Flex, Paper, Title } from '@mantine/core';
+import { EmptyIcon } from 'common/icons';
 import { useSelector } from 'react-redux';
 import { selectReactionsOrder, selectReactionsPagination } from 'store/reactions/reactions.selectors';
 import { getReactionsPage } from 'store/reactions/reactions.thunks';
 import { useAppDispatch } from 'store/useAppDispatch';
+import { CreateReactionMenu } from './CreateReactionMenu/CreateReactionMenu';
+import classes from './reactionsList.module.scss';
 
 export function ReactionList() {
   const dispatch = useAppDispatch();
@@ -60,12 +61,7 @@ export function ReactionList() {
             <span className={classes.counter}>{pagination.total}</span>
           </Flex>
 
-          <Button
-            classNames={{ root: classes.button, section: classes.buttonSection }}
-            leftSection={<AddCircleIcon />}
-          >
-            Reaction
-          </Button>
+          <CreateReactionMenu />
         </Flex>
 
         {!hasReactions && (

--- a/ui/src/pages/DatasetPage/ReactionList/reactionsList.module.scss
+++ b/ui/src/pages/DatasetPage/ReactionList/reactionsList.module.scss
@@ -25,10 +25,6 @@
   font-weight: 400;
 }
 
-.buttonSection {
-  margin-right: 10px;
-}
-
 .emptyText {
   color: var(--color-text-secondary-1);
 }

--- a/ui/src/store/reactions/reactions.actions.ts
+++ b/ui/src/store/reactions/reactions.actions.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import { createActionFactory } from '../../common/store';
-import type { ReactionWrapper } from './reactions.types';
+import type { ImportReactionFromFilePayload, ReactionWrapper } from './reactions.types';
 import type { CurrentPage, Pages } from '../../common/types';
 
-const { createAsyncAction } = createActionFactory('reactions');
+const { createAsyncAction, createAction } = createActionFactory('reactions');
 
 export const getReactionsListActions = createAsyncAction<number, Pages<ReactionWrapper>>('get_list');
 
@@ -26,3 +26,11 @@ export const getReactionPageActions = createAsyncAction<Partial<CurrentPage>, Pa
 export const getReactionActions = createAsyncAction<{ datasetId: number; reactionId: number }, ReactionWrapper>('get');
 
 export const renameReactionActions = createAsyncAction<{ reactionId: number; name: string }, ReactionWrapper>('rename');
+
+export const createEmptyReactionActions = createAsyncAction<void, ReactionWrapper>('create_empty');
+
+export const importReactionFromFileActions = createAsyncAction<ImportReactionFromFilePayload, ReactionWrapper>(
+  'import_from_file',
+);
+
+export const setReactionUploadOpenedAction = createAction<boolean>('set_reaction_upload_opened');

--- a/ui/src/store/reactions/reactions.reducer.ts
+++ b/ui/src/store/reactions/reactions.reducer.ts
@@ -15,10 +15,13 @@
  */
 import { combineReducers, createReducer, isAnyOf } from '@reduxjs/toolkit';
 import {
+  createEmptyReactionActions,
   getReactionActions,
   getReactionPageActions,
   getReactionsListActions,
+  importReactionFromFileActions,
   renameReactionActions,
+  setReactionUploadOpenedAction,
 } from './reactions.actions';
 import { itemsById } from 'common/utils';
 import type { ReactionWrapper } from './reactions.types';
@@ -33,10 +36,18 @@ const activeDatasetId = createReducer<number>(0, builder => {
 });
 
 const reactionsById = createReducer<ItemsById<ReactionWrapper>>({}, builder => {
-  builder.addMatcher(isAnyOf(getReactionActions.success, renameReactionActions.success), (state, action) => ({
-    ...state,
-    [getReactionId(action.payload)]: action.payload,
-  }));
+  builder.addMatcher(
+    isAnyOf(
+      getReactionActions.success,
+      renameReactionActions.success,
+      createEmptyReactionActions.success,
+      importReactionFromFileActions.success,
+    ),
+    (state, action) => ({
+      ...state,
+      [getReactionId(action.payload)]: action.payload,
+    }),
+  );
   builder.addMatcher(isAnyOf(getReactionsListActions.success, getReactionPageActions.success), (_, action) =>
     itemsById(action.payload.items, getReactionId),
   );
@@ -58,6 +69,16 @@ const pagination = createReducer<Pagination>(emptyPagination, builder => {
     total: action.payload.total,
     pages: action.payload.pages,
   }));
+  builder.addMatcher(isAnyOf(createEmptyReactionActions.success, importReactionFromFileActions.success), state => ({
+    ...state,
+    total: state.total + 1,
+    pages: Math.ceil((state.total + 1) / state.size),
+  }));
+});
+
+const isReactionUploadOpened = createReducer<boolean>(false, builder => {
+  builder.addCase(setReactionUploadOpenedAction, (_, action) => action.payload);
+  builder.addCase(importReactionFromFileActions.success, () => false);
 });
 
 export const reactionsReducer = combineReducers({
@@ -65,4 +86,5 @@ export const reactionsReducer = combineReducers({
   reactionsOrder,
   pagination,
   activeDatasetId,
+  isReactionUploadOpened,
 });

--- a/ui/src/store/reactions/reactions.selectors.ts
+++ b/ui/src/store/reactions/reactions.selectors.ts
@@ -32,3 +32,5 @@ export const selectReactionById = (id: number) => (state: AppState) => selectRoo
 export const selectReactionsPagination = (state: AppState) => selectRoot(state).pagination;
 
 export const selectActiveDatasetId = (state: AppState) => selectRoot(state).activeDatasetId;
+
+export const selectIsReactionUploadOpened = (state: AppState) => selectRoot(state).isReactionUploadOpened;

--- a/ui/src/store/reactions/reactions.thunks.ts
+++ b/ui/src/store/reactions/reactions.thunks.ts
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createThunk } from '../../common/store';
+import { createThunk, createThunkWithExplicitResult } from '../../common/store';
 import {
+  createEmptyReactionActions,
   getReactionActions,
   getReactionPageActions,
   getReactionsListActions,
+  importReactionFromFileActions,
   renameReactionActions,
 } from './reactions.actions';
 import axiosInstance from '../../common/config/axiosConfig';
@@ -25,6 +27,7 @@ import type { Pages } from '../../common/types';
 import type { ReactionResponse, ReactionWrapper } from './reactions.types';
 import ordSchema from 'ord-schema';
 import { selectActiveDatasetId, selectReactionsPagination } from './reactions.selectors';
+import { navigate } from 'wouter/use-browser-location';
 
 const parseReaction = ({ binpb, ...rest }: ReactionResponse): ReactionWrapper => ({
   ...rest,
@@ -68,4 +71,27 @@ export const renameReaction = createThunk(renameReactionActions, async (_d, getS
     name,
   });
   return renameReactionActions.success(parseReaction(result.data));
+});
+
+export const createEmptyReaction = createThunkWithExplicitResult(
+  createEmptyReactionActions,
+  async (dispatch, getState) => {
+    const datasetId = selectActiveDatasetId(getState());
+
+    const result = await axiosInstance.post<ReactionResponse>(`/datasets/${datasetId}/reactions`, {});
+    const reaction = parseReaction(result.data);
+    dispatch(createEmptyReactionActions.success(reaction));
+    navigate(`/dataset/${datasetId}/reaction/${reaction.id}`);
+  },
+);
+
+export const importReactionFromFile = createThunk(importReactionFromFileActions, async (_d, getState, { file }) => {
+  const datasetId = selectActiveDatasetId(getState());
+
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const result = await axiosInstance.post<ReactionResponse>(`/datasets/${datasetId}/reactions/upload`, formData);
+  const reaction = parseReaction(result.data);
+  return importReactionFromFileActions.success(reaction);
 });


### PR DESCRIPTION
This PR includes:
- `CreateReactionMenu` and `CreateReactionFromFile` components to support the creation and upload of reaction functionality
- Corresponding store updates
- Renaming of `CreateDatasetLayout` to `FormModal` to enable reuse for reactions