### PR TITLE
209 - Implement Loading Indicator for Dataset Reactions/Datasets/Group Views

### DIFF
--- a/ui/src/common/components/interactions/Pagination/Pagination.module.scss
+++ b/ui/src/common/components/interactions/Pagination/Pagination.module.scss
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+.paginationContainer {
+  margin-top: 20px;
+}
+
 .controlButton {
   color: var(--color-text-primary);
 

--- a/ui/src/common/components/interactions/Pagination/Pagination.tsx
+++ b/ui/src/common/components/interactions/Pagination/Pagination.tsx
@@ -35,7 +35,10 @@ export function Pagination({
   onRowsPerPageChange,
 }: Readonly<PaginationProps>) {
   return (
-    <Group justify="space-between">
+    <Group
+      justify="space-between"
+      className={classes.paginationContainer}
+    >
       <Group align="center">
         <Button
           className={classes.controlButton}

--- a/ui/src/features/datasets/DatasetTable/DatasetTable.module.scss
+++ b/ui/src/features/datasets/DatasetTable/DatasetTable.module.scss
@@ -16,7 +16,6 @@
 .tableContainer {
   display: flex;
   flex-direction: column;
-  gap: 20px;
   padding: 20px;
   flex-grow: 1;
 }

--- a/ui/src/features/datasets/DatasetTable/DatasetTable.tsx
+++ b/ui/src/features/datasets/DatasetTable/DatasetTable.tsx
@@ -27,7 +27,8 @@ import { useAppDispatch } from 'store/useAppDispatch.ts';
 import { useCallback } from 'react';
 import { getDatasetsPage } from 'store/entities/datasets/datasets.thunks.ts';
 import { useLocation } from 'wouter';
-import { Paper } from '@mantine/core';
+import { Flex, Loader, Paper, Title } from '@mantine/core';
+import { Counter } from 'common/components/display/Counter/Counter.tsx';
 
 export function DatasetTable() {
   const dispatch = useAppDispatch();
@@ -52,6 +53,19 @@ export function DatasetTable() {
 
   return (
     <Paper className={classes.tableContainer}>
+      <Flex
+        justify="space-between"
+        align="center"
+      >
+        <Flex
+          align="center"
+          gap="sm"
+        >
+          <Title order={1}>Datasets</Title>
+          {isLoading ? <Loader size="sm" /> : <Counter amount={pagination.total} />}
+        </Flex>
+      </Flex>
+
       <DataTable
         columns={columns}
         data={datasets}

--- a/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupMembersList/GroupMembersList.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupMembersList/GroupMembersList.tsx
@@ -30,7 +30,7 @@ import { PermissionsModal } from '../PermissionModal/PermissionModal.tsx';
 import { InfoCircleIcon } from 'common/icons';
 import classes from './GroupMembersList.module.scss';
 import { UserDataField } from './UserDataField/UserDataField.tsx';
-import { selectEditingGroupId } from 'store/features/groups/groups.selectors.ts';
+import { selectEditingGroupId, selectIsAddingMember } from 'store/features/groups/groups.selectors.ts';
 
 const roleOrder = [USER_ROLES.ADMIN, USER_ROLES.EDITOR, USER_ROLES.VIEWER];
 
@@ -41,6 +41,7 @@ export function GroupMembersList() {
   const groupId = useSelector(selectEditingGroupId);
   const groupMembers = useSelector(selectGroupMembersByGroupId(Number(groupId)));
   const isGroupUpdating = useSelector(selectIsGroupUpdating);
+  const isAddingMember = useSelector(selectIsAddingMember);
 
   const handleRoleChange = (user_id: number, role: USER_ROLES) => {
     dispatch(updateGroupMembers({ user_id, role }));
@@ -74,7 +75,13 @@ export function GroupMembersList() {
           gap="8"
         >
           <div className={classes.title}>Members</div>
-          <div className={classes.counter}>{groupMembers?.length}</div>
+          {isAddingMember ? (
+            <>
+              <Loader size="sm" />
+            </>
+          ) : (
+            <div className={classes.counter}>{groupMembers?.length}</div>
+          )}
         </Flex>
         <Group
           className={classes.rolesButton}
@@ -86,9 +93,11 @@ export function GroupMembersList() {
         </Group>
       </Flex>
 
-      {!groupMembers?.length ? (
+      {isGroupUpdating ? (
         <Flex justify="center">
-          <Loader />
+          <>
+            <Loader />
+          </>
         </Flex>
       ) : (
         sortedGroupMembers.map(({ role, user: { id, avatar_url, name, email, external_id, orcid_id } }) => (

--- a/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupMembersList/GroupMembersList.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupMembersList/GroupMembersList.tsx
@@ -75,13 +75,7 @@ export function GroupMembersList() {
           gap="8"
         >
           <div className={classes.title}>Members</div>
-          {isAddingMember ? (
-            <>
-              <Loader size="sm" />
-            </>
-          ) : (
-            <div className={classes.counter}>{groupMembers?.length}</div>
-          )}
+          {isAddingMember ? <Loader size="sm" /> : <div className={classes.counter}>{groupMembers?.length}</div>}
         </Flex>
         <Group
           className={classes.rolesButton}
@@ -95,9 +89,7 @@ export function GroupMembersList() {
 
       {isGroupUpdating ? (
         <Flex justify="center">
-          <>
-            <Loader />
-          </>
+          <Loader />
         </Flex>
       ) : (
         sortedGroupMembers.map(({ role, user: { id, avatar_url, name, email, external_id, orcid_id } }) => (

--- a/ui/src/features/reactions/ReactionList/ReactionList.tsx
+++ b/ui/src/features/reactions/ReactionList/ReactionList.tsx
@@ -53,63 +53,61 @@ export function ReactionList() {
   );
 
   return (
-    <>
-      <Paper
-        radius="sm"
-        p="lg"
-      >
-        <Flex justify="space-between">
-          <Flex
-            align="center"
-            gap="sm"
-          >
-            <Title order={2}>Dataset Reactions</Title>
-            {isLoading ? <Loader size="sm" /> : <Counter amount={pagination.total} />}
-          </Flex>
-          <CreateReactionMenu />
+    <Paper
+      radius="sm"
+      p="lg"
+    >
+      <Flex justify="space-between">
+        <Flex
+          align="center"
+          gap="sm"
+        >
+          <Title order={2}>Dataset Reactions</Title>
+          {isLoading ? <Loader size="sm" /> : <Counter amount={pagination.total} />}
         </Flex>
+        <CreateReactionMenu />
+      </Flex>
 
-        {isLoading ? (
+      {isLoading ? (
+        <Flex
+          justify="center"
+          align="center"
+          style={{ height: '100px' }}
+        >
+          <Loader size="lg" />
+        </Flex>
+      ) : !hasReactions ? (
+        <Flex
+          align="center"
+          justify="center"
+        >
           <Flex
-            justify="center"
+            direction="column"
             align="center"
-            style={{ height: '100px' }}
+            gap="8"
           >
-            <Loader size="lg" />
+            <EmptyIcon />
+            <div className={classes.emptyText}>There are no reactions in the dataset yet</div>
           </Flex>
-        ) : !hasReactions ? (
-          <Flex
-            align="center"
-            justify="center"
-          >
-            <Flex
-              direction="column"
-              align="center"
-              gap="8"
-            >
-              <EmptyIcon />
-              <div className={classes.emptyText}>There are no reactions in the dataset yet</div>
-            </Flex>
-          </Flex>
-        ) : (
-          <>
-            {reactionsIds.map((id, index) => (
-              <ReactionCard
-                key={id}
-                id={id}
-                index={(pagination.page - 1) * pagination.size + index + 1}
-              />
-            ))}
-            <Pagination
-              currentPage={pagination.page}
-              onPageChange={handlePageChange}
-              rowsPerPage={pagination.size}
-              onRowsPerPageChange={handleRowsPerPageChange}
-              totalPages={pagination.pages}
+        </Flex>
+      ) : (
+        <>
+          {reactionsIds.map((id, index) => (
+            <ReactionCard
+              key={id}
+              id={id}
+              index={(pagination.page - 1) * pagination.size + index + 1}
             />
-          </>
-        )}
-      </Paper>
-    </>
+          ))}
+          <Pagination
+            currentPage={pagination.page}
+            onPageChange={handlePageChange}
+            rowsPerPage={pagination.size}
+            onRowsPerPageChange={handleRowsPerPageChange}
+            totalPages={pagination.pages}
+          />
+        </>
+      )}
+    </Paper>
   );
 }

--- a/ui/src/features/reactions/ReactionList/ReactionList.tsx
+++ b/ui/src/features/reactions/ReactionList/ReactionList.tsx
@@ -16,11 +16,15 @@
 import { useCallback } from 'react';
 import { Pagination } from 'common/components/interactions/Pagination/Pagination.tsx';
 import { ReactionCard } from './ReactionCard/ReactionCard.tsx';
-import { Flex, Paper, Title } from '@mantine/core';
+import { Flex, Paper, Title, Loader } from '@mantine/core';
 import { EmptyIcon } from 'common/icons';
 import classes from './reactionsList.module.scss';
 import { useSelector } from 'react-redux';
-import { selectReactionsOrder, selectReactionsPagination } from 'store/entities/reactions/reactions.selectors.ts';
+import {
+  selectReactionsLoading,
+  selectReactionsOrder,
+  selectReactionsPagination,
+} from 'store/entities/reactions/reactions.selectors.ts';
 import { getReactionsPage } from 'store/entities/reactions/reactions.thunks.ts';
 import { useAppDispatch } from 'store/useAppDispatch.ts';
 import { CreateReactionMenu } from './CreateReactionMenu/CreateReactionMenu.tsx';
@@ -30,6 +34,7 @@ export function ReactionList() {
   const dispatch = useAppDispatch();
   const reactionsIds = useSelector(selectReactionsOrder);
   const pagination = useSelector(selectReactionsPagination);
+  const isLoading = useSelector(selectReactionsLoading);
 
   const hasReactions = reactionsIds.length > 0;
 
@@ -59,13 +64,20 @@ export function ReactionList() {
             gap="sm"
           >
             <Title order={2}>Dataset Reactions</Title>
-            <Counter amount={pagination.total} />
+            {isLoading ? <Loader size="sm" /> : <Counter amount={pagination.total} />}
           </Flex>
-
           <CreateReactionMenu />
         </Flex>
 
-        {!hasReactions && (
+        {isLoading ? (
+          <Flex
+            justify="center"
+            align="center"
+            style={{ height: '100px' }}
+          >
+            <Loader size="lg" />
+          </Flex>
+        ) : !hasReactions ? (
           <Flex
             align="center"
             justify="center"
@@ -79,26 +91,25 @@ export function ReactionList() {
               <div className={classes.emptyText}>There are no reactions in the dataset yet</div>
             </Flex>
           </Flex>
+        ) : (
+          <>
+            {reactionsIds.map((id, index) => (
+              <ReactionCard
+                key={id}
+                id={id}
+                index={(pagination.page - 1) * pagination.size + index + 1}
+              />
+            ))}
+            <Pagination
+              currentPage={pagination.page}
+              onPageChange={handlePageChange}
+              rowsPerPage={pagination.size}
+              onRowsPerPageChange={handleRowsPerPageChange}
+              totalPages={pagination.pages}
+            />
+          </>
         )}
       </Paper>
-      {hasReactions && (
-        <>
-          {reactionsIds.map((id, index) => (
-            <ReactionCard
-              key={id}
-              id={id}
-              index={(pagination.page - 1) * pagination.size + index + 1}
-            />
-          ))}
-          <Pagination
-            currentPage={pagination.page}
-            onPageChange={handlePageChange}
-            rowsPerPage={pagination.size}
-            onRowsPerPageChange={handleRowsPerPageChange}
-            totalPages={pagination.pages}
-          />
-        </>
-      )}
     </>
   );
 }

--- a/ui/src/features/reactions/ReactionList/ReactionList.tsx
+++ b/ui/src/features/reactions/ReactionList/ReactionList.tsx
@@ -72,7 +72,7 @@ export function ReactionList() {
         <Flex
           justify="center"
           align="center"
-          style={{ height: '100px' }}
+          className={classes.loaderContainer}
         >
           <Loader size="lg" />
         </Flex>
@@ -84,7 +84,7 @@ export function ReactionList() {
           <Flex
             direction="column"
             align="center"
-            gap="8"
+            gap="sm"
           >
             <EmptyIcon />
             <div className={classes.emptyText}>There are no reactions in the dataset yet</div>

--- a/ui/src/features/reactions/ReactionList/reactionsList.module.scss
+++ b/ui/src/features/reactions/ReactionList/reactionsList.module.scss
@@ -20,3 +20,7 @@
 .emptyText {
   color: var(--color-text-secondary-1);
 }
+
+.loaderContainer {
+  height: 100px;
+}

--- a/ui/src/store/entities/reactions/reactions.reducer.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.ts
@@ -135,10 +135,24 @@ const isReactionCreating = createReducer<boolean>(false, builder => {
   );
 });
 
+const areReactionsLoading = createReducer<boolean>(false, builder => {
+  builder.addMatcher(isAnyOf(getReactionsListActions.request, getReactionPageActions.request), () => true);
+  builder.addMatcher(
+    isAnyOf(
+      getReactionsListActions.success,
+      getReactionsListActions.failure,
+      getReactionPageActions.success,
+      getReactionPageActions.failure,
+    ),
+    () => false,
+  );
+});
+
 export const reactionsReducer = combineReducers({
   reactionsById,
   reactionsOrder,
   pagination,
   activeDatasetId,
   isReactionCreating,
+  areReactionsLoading,
 });

--- a/ui/src/store/entities/reactions/reactions.selectors.ts
+++ b/ui/src/store/entities/reactions/reactions.selectors.ts
@@ -32,6 +32,8 @@ export const selectActiveDatasetId = buildSelector(state => state.activeDatasetI
 
 export const selectIsReactionCreating = buildSelector(state => state.isReactionCreating);
 
+export const selectReactionsLoading = buildSelector(state => state.areReactionsLoading);
+
 export const selectReactionComponents = (id: number, input: string) =>
   buildSelector(state => state.reactionsById[id].data.inputs[input]?.components || []);
 

--- a/ui/src/store/features/groups/groups.reducer.ts
+++ b/ui/src/store/features/groups/groups.reducer.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { combineReducers, createReducer } from '@reduxjs/toolkit';
+import { combineReducers, createReducer, isAnyOf } from '@reduxjs/toolkit';
 import { setActiveGroupIdAction, setEditingGroupIdAction } from './groups.actions.ts';
 import { addGroupMemberActions, createGroupActions } from 'store/entities/groups/groups.actions.ts';
 
@@ -26,10 +26,9 @@ const editingGroupId = createReducer<number | null>(null, builder => {
   builder.addCase(createGroupActions.success, (_, action) => action.payload.id);
 });
 
-export const isAddingMember = createReducer<boolean>(false, builder => {
-  builder.addCase(addGroupMemberActions.request, () => true);
-  builder.addCase(addGroupMemberActions.success, () => false);
-  builder.addCase(addGroupMemberActions.failure, () => false);
+const isAddingMember = createReducer<boolean>(false, builder => {
+  builder.addMatcher(isAnyOf(addGroupMemberActions.request), () => true);
+  builder.addMatcher(isAnyOf(addGroupMemberActions.success, addGroupMemberActions.failure), () => false);
 });
 
 export const groupsSidebar = combineReducers({

--- a/ui/src/store/features/groups/groups.reducer.ts
+++ b/ui/src/store/features/groups/groups.reducer.ts
@@ -15,7 +15,7 @@
  */
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 import { setActiveGroupIdAction, setEditingGroupIdAction } from './groups.actions.ts';
-import { createGroupActions } from 'store/entities/groups/groups.actions.ts';
+import { addGroupMemberActions, createGroupActions } from 'store/entities/groups/groups.actions.ts';
 
 const activeGroupId = createReducer<number | null>(null, builder => {
   builder.addCase(setActiveGroupIdAction, (_, action) => action.payload);
@@ -26,7 +26,14 @@ const editingGroupId = createReducer<number | null>(null, builder => {
   builder.addCase(createGroupActions.success, (_, action) => action.payload.id);
 });
 
+export const isAddingMember = createReducer<boolean>(false, builder => {
+  builder.addCase(addGroupMemberActions.request, () => true);
+  builder.addCase(addGroupMemberActions.success, () => false);
+  builder.addCase(addGroupMemberActions.failure, () => false);
+});
+
 export const groupsSidebar = combineReducers({
   activeGroupId,
   editingGroupId,
+  isAddingMember,
 });

--- a/ui/src/store/features/groups/groups.selectors.ts
+++ b/ui/src/store/features/groups/groups.selectors.ts
@@ -20,3 +20,5 @@ const { buildSelector } = createSelectorFactory(state => state.features.groupsSi
 export const selectActiveGroupId = buildSelector(state => state.activeGroupId);
 
 export const selectEditingGroupId = buildSelector(state => state.editingGroupId);
+
+export const selectIsAddingMember = buildSelector(state => state.isAddingMember);


### PR DESCRIPTION
Issue => https://github.com/open-reaction-database/ord-app/issues/209

- [x] Display 2 loading icons when opening a dataset, or navigating between reaction pages.
- [x] Display 2 loading icons when opening a datasets page, or navigating between datasets pages.
- [x] Display 2 loading icons when opening a Group Management sidebar when loading members.
- [x] Add **Datasets** title and counter





https://github.com/user-attachments/assets/50b6e1d1-4fd4-4f7a-973b-d627ffe4b009

