### PR TITLE
300: Remove reaction from the dataset

### DIFF
--- a/ui/src/features/reactions/ReactionHeader/ReactionHeader.tsx
+++ b/ui/src/features/reactions/ReactionHeader/ReactionHeader.tsx
@@ -26,8 +26,9 @@ import classes from 'features/reactions/ReactionHeader/reactionHeader.module.scs
 import { useDisclosure } from '@mantine/hooks';
 import { useAppDispatch } from 'store/useAppDispatch.ts';
 import { InputModal } from 'common/components/InputModal/InputModal.tsx';
-import { addUpdateReactionField } from 'store/entities/reactions/reactions.thunks.ts';
+import { addUpdateReactionField, removeReaction } from 'store/entities/reactions/reactions.thunks.ts';
 import { ReactionPreview } from 'features/reactions/ReactionPreview/ReactionPreview.tsx';
+import { ConfirmPopover } from 'common/components/ConfirmPopover/ConfirmPopover.tsx';
 
 interface ReactionHeaderProps {
   datasetId: number;
@@ -56,6 +57,13 @@ export function ReactionHeader({ datasetId, reactionId }: Readonly<ReactionHeade
     ],
     [reactionId, location],
   );
+
+  const [confirmationOpened, { open: openConfirmation, close: closeConfirmation }] = useDisclosure();
+
+  const onRemove = useCallback(() => {
+    dispatch(removeReaction(reactionId));
+    closeConfirmation();
+  }, [closeConfirmation, dispatch, reactionId]);
 
   return (
     <Paper
@@ -89,13 +97,23 @@ export function ReactionHeader({ datasetId, reactionId }: Readonly<ReactionHeade
             align="center"
             gap="sm"
           >
-            <Button
-              variant="transparent"
-              color="red"
-              leftSection={<TrashIcon />}
-            >
-              Remove
-            </Button>
+            <ConfirmPopover
+              title={`Remove this reaction`}
+              text={`Are you sure to remove this reaction?`}
+              opened={confirmationOpened}
+              onConfirm={onRemove}
+              onCancel={closeConfirmation}
+              target={
+                <Button
+                  onClick={openConfirmation}
+                  variant="transparent"
+                  color="red"
+                  leftSection={<TrashIcon />}
+                >
+                  Remove
+                </Button>
+              }
+            />
             <Button
               variant="transparent"
               leftSection={<CheckListIcon />}

--- a/ui/src/features/reactions/ReactionHeader/ReactionHeader.tsx
+++ b/ui/src/features/reactions/ReactionHeader/ReactionHeader.tsx
@@ -99,7 +99,7 @@ export function ReactionHeader({ datasetId, reactionId }: Readonly<ReactionHeade
           >
             <ConfirmPopover
               title={`Remove this reaction`}
-              text={`Are you sure to remove this reaction?`}
+              text={`Are you sure you want to remove this reaction?`}
               opened={confirmationOpened}
               onConfirm={onRemove}
               onCancel={closeConfirmation}

--- a/ui/src/store/entities/reactions/reactions.actions.ts
+++ b/ui/src/store/entities/reactions/reactions.actions.ts
@@ -45,4 +45,4 @@ export const addUpdateReactionFieldActions = createAsyncAction<
 
 export const deleteReactionFieldActions = createAsyncAction<UpdateReactionPayload, void>('deleteField');
 
-export const removeReactionActions = createAsyncAction<number, { reactionId: number }>('remove_dataset');
+export const removeReactionActions = createAsyncAction<number, number>('remove_dataset');

--- a/ui/src/store/entities/reactions/reactions.actions.ts
+++ b/ui/src/store/entities/reactions/reactions.actions.ts
@@ -45,4 +45,4 @@ export const addUpdateReactionFieldActions = createAsyncAction<
 
 export const deleteReactionFieldActions = createAsyncAction<UpdateReactionPayload, void>('deleteField');
 
-export const removeReactionActions = createAsyncAction<number>('remove_dataset');
+export const removeReactionActions = createAsyncAction<number, { reactionId: number }>('remove_dataset');

--- a/ui/src/store/entities/reactions/reactions.actions.ts
+++ b/ui/src/store/entities/reactions/reactions.actions.ts
@@ -44,3 +44,5 @@ export const addUpdateReactionFieldActions = createAsyncAction<
 >('addUpdateField');
 
 export const deleteReactionFieldActions = createAsyncAction<UpdateReactionPayload, void>('deleteField');
+
+export const removeReactionActions = createAsyncAction<number>('remove_dataset');

--- a/ui/src/store/entities/reactions/reactions.reducer.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.ts
@@ -82,7 +82,7 @@ const reactionsById = createReducer<ItemsById<ReactionWrapper>>({}, builder => {
       },
     };
   });
-  builder.addCase(removeReactionActions.success, (state, { payload: { reactionId } }) => {
+  builder.addCase(removeReactionActions.success, (state, { payload: reactionId }) => {
     const { [reactionId]: _, ...rest } = state;
     return rest;
   });
@@ -106,7 +106,7 @@ const reactionsById = createReducer<ItemsById<ReactionWrapper>>({}, builder => {
 
 const reactionsOrder = createReducer<Array<number>>([], builder => {
   builder.addCase(getReactionsListActions.request, () => []);
-  builder.addCase(removeReactionActions.success, (state, { payload: { reactionId } }) =>
+  builder.addCase(removeReactionActions.success, (state, { payload: reactionId }) =>
     state.filter(id => id !== reactionId),
   );
   builder.addMatcher(isAnyOf(getReactionsListActions.request, getReactionPageActions.request), () => []);

--- a/ui/src/store/entities/reactions/reactions.reducer.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.ts
@@ -23,6 +23,7 @@ import {
   renameReactionActions,
   addUpdateReactionFieldActions,
   deleteReactionFieldActions,
+  removeReactionActions,
 } from './reactions.actions.ts';
 import { itemsById } from 'common/utils';
 import type { AppReaction, ReactionWrapper } from './reactions.types.ts';
@@ -81,6 +82,10 @@ const reactionsById = createReducer<ItemsById<ReactionWrapper>>({}, builder => {
       },
     };
   });
+  builder.addCase(removeReactionActions.success, (state, { payload: { reactionId } }) => {
+    const { [reactionId]: _, ...rest } = state;
+    return rest;
+  });
   builder.addMatcher(
     isAnyOf(
       getReactionActions.success,
@@ -105,6 +110,9 @@ const reactionsOrder = createReducer<Array<number>>([], builder => {
   builder.addMatcher(isAnyOf(getReactionsListActions.success, getReactionPageActions.success), (_, action) =>
     action.payload.items.map(getReactionId),
   );
+  builder.addCase(removeReactionActions.success, (state, { payload: { reactionId } }) =>
+    state.filter(id => id !== reactionId),
+  );
 });
 
 const pagination = createReducer<Pagination>(emptyPagination, builder => {
@@ -119,6 +127,11 @@ const pagination = createReducer<Pagination>(emptyPagination, builder => {
     ...state,
     total: state.total + 1,
     pages: Math.ceil((state.total + 1) / state.size),
+  }));
+  builder.addMatcher(isAnyOf(removeReactionActions.success), state => ({
+    ...state,
+    total: state.total - 1,
+    pages: Math.ceil((state.total - 1) / state.size),
   }));
 });
 

--- a/ui/src/store/entities/reactions/reactions.reducer.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.ts
@@ -106,12 +106,12 @@ const reactionsById = createReducer<ItemsById<ReactionWrapper>>({}, builder => {
 
 const reactionsOrder = createReducer<Array<number>>([], builder => {
   builder.addCase(getReactionsListActions.request, () => []);
+  builder.addCase(removeReactionActions.success, (state, { payload: { reactionId } }) =>
+    state.filter(id => id !== reactionId),
+  );
   builder.addMatcher(isAnyOf(getReactionsListActions.request, getReactionPageActions.request), () => []);
   builder.addMatcher(isAnyOf(getReactionsListActions.success, getReactionPageActions.success), (_, action) =>
     action.payload.items.map(getReactionId),
-  );
-  builder.addCase(removeReactionActions.success, (state, { payload: { reactionId } }) =>
-    state.filter(id => id !== reactionId),
   );
 });
 

--- a/ui/src/store/entities/reactions/reactions.thunks.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.ts
@@ -149,10 +149,8 @@ export const removeReaction = createThunkWithExplicitResult(
   removeReactionActions,
   async (dispatch, getState, reactionId) => {
     const datasetId = selectActiveDatasetId(getState());
-    console.log('Remove reaction', datasetId, reactionId);
     await axiosInstance.delete(`/datasets/${datasetId}/reactions/${reactionId}`);
-    dispatch(removeReactionActions.success());
+    dispatch(removeReactionActions.success({ reactionId }));
     navigate(`/datasets/${datasetId}`);
-    // navigate(`/datasets`);
   },
 );

--- a/ui/src/store/entities/reactions/reactions.thunks.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.ts
@@ -150,7 +150,7 @@ export const removeReaction = createThunkWithExplicitResult(
   async (dispatch, getState, reactionId) => {
     const datasetId = selectActiveDatasetId(getState());
     await axiosInstance.delete(`/datasets/${datasetId}/reactions/${reactionId}`);
-    dispatch(removeReactionActions.success({ reactionId }));
+    dispatch(removeReactionActions.success(reactionId));
     navigate(`/datasets/${datasetId}`);
   },
 );

--- a/ui/src/store/entities/reactions/reactions.thunks.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.ts
@@ -23,6 +23,7 @@ import {
   renameReactionActions,
   addUpdateReactionFieldActions,
   deleteReactionFieldActions,
+  removeReactionActions,
 } from './reactions.actions.ts';
 import axiosInstance from 'store/axiosInstance.ts';
 import type { Pages } from 'common/types';
@@ -143,3 +144,15 @@ export const deleteReactionField = createThunk(deleteReactionFieldActions, async
   await updateReaction(reactionId, getState);
   return deleteReactionFieldActions.success();
 });
+
+export const removeReaction = createThunkWithExplicitResult(
+  removeReactionActions,
+  async (dispatch, getState, reactionId) => {
+    const datasetId = selectActiveDatasetId(getState());
+    console.log('Remove reaction', datasetId, reactionId);
+    await axiosInstance.delete(`/datasets/${datasetId}/reactions/${reactionId}`);
+    dispatch(removeReactionActions.success());
+    navigate(`/datasets/${datasetId}`);
+    // navigate(`/datasets`);
+  },
+);


### PR DESCRIPTION
#300 

- Added functionality to remove reaction from datasets;
- When "Remove" button clicked Confirmation popup is opened;
- After reaction removed user redirected to Dataset page;
- Order of reactions and count of reactions are updated.

https://github.com/user-attachments/assets/7c51b6e7-c191-431d-9fd8-00f409bc8956


