### PR TITLE
334 - User mustn't have an ability to add an empty user

### DIFF
--- a/ui/src/features/groups/GroupsSidebar/GroupsDrawer/AddMemberInput/AddMemberInput.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsDrawer/AddMemberInput/AddMemberInput.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Button, Group, TextInput } from '@mantine/core';
 import { AlertCircleIcon } from 'common/icons';
@@ -35,6 +36,11 @@ export function AddMemberInput() {
 
   const isGroupUpdating = useSelector(selectIsGroupUpdating);
   const { isAdmin } = useSelector(selectMemberRoles);
+
+  const isAddDisabled = useMemo(
+    () => !isAdmin || !!inputError || isGroupUpdating || !inputValue?.trim(),
+    [isAdmin, inputError, isGroupUpdating, inputValue],
+  );
 
   const handleAddMember = async () => {
     dispatch(addGroupMember(inputValue));
@@ -67,7 +73,7 @@ export function AddMemberInput() {
 
       <Button
         onClick={handleAddMember}
-        disabled={!isAdmin || !!inputError || isGroupUpdating}
+        disabled={isAddDisabled}
       >
         Add User
       </Button>


### PR DESCRIPTION
Issue => https://github.com/open-reaction-database/ord-app/issues/334 

- [x] "Add User" button isn't clickable if "Add User" field is empty;

https://github.com/user-attachments/assets/0f1a79ba-1d7d-455f-aa49-d6ddd8e70b13

