### PR TITLE
340 - User can create dataset with spaces instead of dataset name/description

### DIFF
--- a/ui/src/common/utils/requiredTextField.schema.ts
+++ b/ui/src/common/utils/requiredTextField.schema.ts
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { requiredTextField } from 'common/utils/requiredTextField.schema';
 import * as yup from 'yup';
 
-export const createNewDatasetSchema = yup.object({
-  name: requiredTextField.label('Dataset name'),
-  description: requiredTextField.label('Description'),
-  groupId: yup.string().required(),
-});
+export const emptyFieldMessage = ({ label }: { label: string }) => `${label} should not be empty`;
 
-export type CreateNewDatasetFormValues = yup.InferType<typeof createNewDatasetSchema>;
+export const requiredTextField = yup
+  .string()
+  .label('Field')
+  .required(emptyFieldMessage)
+  .test('no-only-spaces', emptyFieldMessage, value => value?.trim().length > 0);

--- a/ui/src/features/datasets/CreateNewDataset/createNewDataset.schema.ts
+++ b/ui/src/features/datasets/CreateNewDataset/createNewDataset.schema.ts
@@ -16,7 +16,15 @@
 import * as yup from 'yup';
 
 export const createNewDatasetSchema = yup.object({
-  name: yup.string().label('Dataset name').required(),
+  name: yup
+    .string()
+    .label('Dataset name')
+    .required('')
+    .test(
+      'no-only-spaces',
+      'Dataset name cannot be just spaces',
+      value => value === undefined || value === '' || value.trim().length > 0,
+    ),
   groupId: yup.string().required(),
   description: yup.string().label('Description').required(),
 });

--- a/ui/src/features/datasets/CreateNewDataset/createNewDataset.schema.ts
+++ b/ui/src/features/datasets/CreateNewDataset/createNewDataset.schema.ts
@@ -15,18 +15,18 @@
  */
 import * as yup from 'yup';
 
+const emptyFieldMessage = ({ label }: { label: string }) => `${label} should not be empty`;
+
+const requiredTextField = yup
+  .string()
+  .label('Field')
+  .required(emptyFieldMessage)
+  .test('no-only-spaces', emptyFieldMessage, value => value?.trim().length > 0);
+
 export const createNewDatasetSchema = yup.object({
-  name: yup
-    .string()
-    .label('Dataset name')
-    .required('')
-    .test(
-      'no-only-spaces',
-      'Dataset name cannot be just spaces',
-      value => value === undefined || value === '' || value.trim().length > 0,
-    ),
-  groupId: yup.string().required(),
-  description: yup.string().label('Description').required(),
+  name: requiredTextField.label('Dataset name'),
+  description: requiredTextField.label('Description'),
+  groupId: requiredTextField.label('Group name'),
 });
 
 export type CreateNewDatasetFormValues = yup.InferType<typeof createNewDatasetSchema>;

--- a/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.schema.ts
+++ b/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.schema.ts
@@ -13,18 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { requiredTextField } from 'common/utils/requiredTextField.schema';
 import * as yup from 'yup';
 
-const emptyFieldMessage = ({ label }: { label: string }) => `${label} should not be empty`;
-
-const requiredTextField = yup
-  .string()
-  .label('Field')
-  .required(emptyFieldMessage)
-  .test('no-only-spaces', emptyFieldMessage, value => value?.trim().length > 0);
-
 export const saveAsTemplateSchema = yup.object({
-  reaction: requiredTextField.label('Reaction'),
   name: requiredTextField.label('Template name'),
 });
 

--- a/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.schema.ts
+++ b/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.schema.ts
@@ -15,9 +15,17 @@
  */
 import * as yup from 'yup';
 
+const emptyFieldMessage = ({ label }: { label: string }) => `${label} should not be empty`;
+
+const requiredTextField = yup
+  .string()
+  .label('Field')
+  .required(emptyFieldMessage)
+  .test('no-only-spaces', emptyFieldMessage, value => value?.trim().length > 0);
+
 export const saveAsTemplateSchema = yup.object({
-  reaction: yup.string().label('Reaction').required(),
-  name: yup.string().label('Template name').required(),
+  reaction: requiredTextField.label('Reaction'),
+  name: requiredTextField.label('Template name'),
 });
 
 export type SaveAsTemplateSchemaFormValues = yup.InferType<typeof saveAsTemplateSchema>;

--- a/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.tsx
+++ b/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.tsx
@@ -37,7 +37,6 @@ export function SaveAsTemplate({ onClose, reactionPbId, reactionId }: Readonly<S
   >({
     mode: 'controlled',
     initialValues: {
-      reaction: reactionPbId,
       name: `${reactionPbId} Template`,
     },
     validate: yupResolver(saveAsTemplateSchema),
@@ -47,7 +46,7 @@ export function SaveAsTemplate({ onClose, reactionPbId, reactionId }: Readonly<S
     (values: SaveAsTemplateSchemaFormValues) => {
       dispatch(createTemplate({ reactionId, name: values.name }));
     },
-    [dispatch],
+    [dispatch, reactionId],
   );
 
   return (


### PR DESCRIPTION
Issue => https://github.com/open-reaction-database/ord-app/issues/340

Actual Result : Can't save dataset with empty name and description, error message is displayed: Dataset name cannot be just spaces 


https://github.com/user-attachments/assets/6589bb9e-d826-4cfb-b0fc-e9ef2f4d1c05

