### PR TITLE
Update texts for "Edit Dataset" modal window

### DIFF
--- a/ui/src/common/components/InputModal/InputModal.tsx
+++ b/ui/src/common/components/InputModal/InputModal.tsx
@@ -16,6 +16,7 @@
 import { Button, Flex, Modal, TextInput } from '@mantine/core';
 import { useForm, yupResolver } from '@mantine/form';
 import classes from './InputModal.module.scss';
+import { requiredTextField } from 'common/utils/requiredTextField.schema';
 import { useEffect } from 'react';
 import * as yup from 'yup';
 
@@ -51,9 +52,10 @@ export function InputModal({
     },
     validate: yupResolver(
       yup.object({
-        value: yup.string().required().label(inputLabel),
+        value: requiredTextField(inputLabel),
       }),
     ),
+    validateInputOnChange: true,
   });
 
   useEffect(() => {

--- a/ui/src/common/utils/requiredTextField.schema.ts
+++ b/ui/src/common/utils/requiredTextField.schema.ts
@@ -15,10 +15,11 @@
  */
 import * as yup from 'yup';
 
-export const emptyFieldMessage = ({ label }: { label: string }) => `${label} should not be empty`;
+export const emptyFieldMessage = (label: string) => `${label} should not be empty`;
 
-export const requiredTextField = yup
-  .string()
-  .label('Field')
-  .required(emptyFieldMessage)
-  .test('no-only-spaces', emptyFieldMessage, value => value?.trim().length > 0);
+export const requiredTextField = (label: string) =>
+  yup
+    .string()
+    .label(label)
+    .required(emptyFieldMessage(label))
+    .test('no-only-spaces', emptyFieldMessage(label), value => value?.trim().length > 0);

--- a/ui/src/features/datasets/CreateNewDataset/createNewDataset.schema.ts
+++ b/ui/src/features/datasets/CreateNewDataset/createNewDataset.schema.ts
@@ -17,8 +17,8 @@ import { requiredTextField } from 'common/utils/requiredTextField.schema';
 import * as yup from 'yup';
 
 export const createNewDatasetSchema = yup.object({
-  name: requiredTextField.label('Dataset name'),
-  description: requiredTextField.label('Description'),
+  name: requiredTextField('Dataset name'),
+  description: requiredTextField('Description'),
   groupId: yup.string().required(),
 });
 

--- a/ui/src/features/datasets/DatasetHeader/EditDataset/EditDataset.tsx
+++ b/ui/src/features/datasets/DatasetHeader/EditDataset/EditDataset.tsx
@@ -38,6 +38,7 @@ export function EditDataset({ datasetId, onClose }: Readonly<EditDatasetProps>) 
       description: dataset.description || '',
     },
     validate: yupResolver(editDatasetSchema),
+    validateInputOnChange: true,
   });
 
   const onSubmit = useCallback(
@@ -50,7 +51,7 @@ export function EditDataset({ datasetId, onClose }: Readonly<EditDatasetProps>) 
   return (
     <Modal
       opened
-      title="Edit Group Name"
+      title="Edit Dataset"
       onClose={onClose}
     >
       <form onSubmit={form.onSubmit(onSubmit)}>
@@ -59,7 +60,7 @@ export function EditDataset({ datasetId, onClose }: Readonly<EditDatasetProps>) 
           gap="md"
         >
           <TextInput
-            label="Name"
+            label="Dataset name"
             {...form.getInputProps('name')}
           />
           <Textarea

--- a/ui/src/features/datasets/DatasetHeader/EditDataset/editDataset.schema.ts
+++ b/ui/src/features/datasets/DatasetHeader/EditDataset/editDataset.schema.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { requiredTextField } from 'common/utils/requiredTextField.schema';
 import * as yup from 'yup';
 
 export const editDatasetSchema = yup.object({
-  name: yup.string().required(),
-  description: yup.string().required(),
+  name: requiredTextField('Dataset name'),
+  description: requiredTextField('Description'),
 });
 
 export type EditDatasetFormValues = yup.InferType<typeof editDatasetSchema>;

--- a/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.schema.ts
+++ b/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.schema.ts
@@ -17,8 +17,8 @@ import { requiredTextField } from 'common/utils/requiredTextField.schema';
 import * as yup from 'yup';
 
 export const saveAsTemplateSchema = yup.object({
-  reaction: requiredTextField.label('Reaction ID'),
-  name: requiredTextField.label('Template name'),
+  reaction: requiredTextField('Reaction ID'),
+  name: requiredTextField('Template name'),
 });
 
 export type SaveAsTemplateSchemaFormValues = yup.InferType<typeof saveAsTemplateSchema>;


### PR DESCRIPTION
Issue =>  https://github.com/open-reaction-database/ord-app/issues/346 
- Modal window name is changed to "Edit Dataset" 
- "Name"  changed to "Dataset name"  
- Error messages updated:
    - Dataset name is a required field
    - Description is a required field
 
Issue =>  https://github.com/open-reaction-database/ord-app/issues/340 
Can't save dataset with empty name and description, error message is displayed: Dataset name should not be empty
Added in 
- Dataset Update
- Create Group
- Update Group
- Update Reaction ID