### PR TITLE
feature/ORD-370 characters payload form limitations

### DIFF
--- a/ord_app/service_api/domain/reactions.py
+++ b/ord_app/service_api/domain/reactions.py
@@ -30,12 +30,14 @@ from ord_app.service_api.domain.datasets import load_message, write_message
 from ord_app.service_api.models import ReactionModel, UserModel
 from ord_app.service_api.repositories.datasets import DatasetsRepository
 from ord_app.service_api.repositories.reactions import ReactionsRepository
+from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH
 from ord_app.service_api.schemas.datasets import DownloadFileFormats
 from ord_app.service_api.schemas.reactions import ReactionCreateSchema, ReactionUpdateSchema
 from ord_app.service_api.services.exceptions import (
     ConflictError,
     EntityNotFoundError,
     ProtobufDecodeError,
+    UnprocessableEntityError,
     psycopg_error_wrapper,
 )
 from ord_app.service_api.services.pb_utils import validate_pb_reaction
@@ -152,9 +154,12 @@ class ReactionsUseCase:
         else:
             pb_reaction = await run_in_threadpool(load_message, db_reaction.binpb, Reaction, "binpb")
             # If the loaded message has a valid reaction_id, use it; otherwise, fallback to reaction.id
-            db_reaction.pb_reaction_id = pb_reaction.reaction_id = str(
-                (pb_reaction.reaction_id or "").strip() or generated_pb_reaction_id
-            )
+            pb_reaction_id = (pb_reaction.reaction_id or "").strip()
+            if len(pb_reaction_id) > MAX_CRITICAL_FIELD_LENGTH:
+                raise UnprocessableEntityError(
+                    f"Reaction ID {pb_reaction_id} exceeds {MAX_CRITICAL_FIELD_LENGTH} characters"
+                )
+            db_reaction.pb_reaction_id = pb_reaction.reaction_id = pb_reaction_id or generated_pb_reaction_id
             db_reaction.binpb = pb_reaction.SerializeToString()
 
         await self.db.commit()
@@ -232,7 +237,12 @@ class ReactionsUseCase:
 
     async def update(self, dataset_id: int, reaction_id: int, payload: ReactionUpdateSchema):
         pb_reaction = await run_in_threadpool(load_message, payload.binpb, Reaction, "binpb")
-        pb_reaction.reaction_id = (pb_reaction.reaction_id or "").strip()
+        pb_reaction_id = (pb_reaction.reaction_id or "").strip()
+        if len(pb_reaction_id) > MAX_CRITICAL_FIELD_LENGTH:
+            raise UnprocessableEntityError(
+                f"Reaction ID {pb_reaction_id} exceeds {MAX_CRITICAL_FIELD_LENGTH} characters"
+            )
+        pb_reaction.reaction_id = pb_reaction_id
 
         db_reaction = await self.reaction_repo.get(id=reaction_id, dataset_id=dataset_id)
         if db_reaction is None:

--- a/ord_app/service_api/schemas/base.py
+++ b/ord_app/service_api/schemas/base.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from pydantic import BaseModel
 
+MAX_CRITICAL_FIELD_LENGTH = 512
+
 
 class BaseSchema(BaseModel):
     pass

--- a/ord_app/service_api/schemas/datasets.py
+++ b/ord_app/service_api/schemas/datasets.py
@@ -15,10 +15,10 @@ from datetime import datetime
 from typing import Any, Literal, Optional
 from uuid import uuid4
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, constr, field_validator, model_validator
 from sqlalchemy import Row
 
-from ord_app.service_api.schemas.base import BaseSchema
+from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH, BaseSchema
 from ord_app.service_api.schemas.users import UserResponseSchema
 
 DownloadFileFormats = Literal["binpb", "json", "txtpb"]
@@ -76,15 +76,14 @@ class DatasetWithReactionCountResponseSchema(DatasetResponseSchema):
 
 
 class DatasetCreateSchema(BaseSchema):
-    name: str | None
-    description: str | None = ""
+    name: constr(max_length=MAX_CRITICAL_FIELD_LENGTH)
+    description: constr(max_length=8192) | None = ""
 
-    @field_validator("name", mode="after")
-    def set_name_default(cls, value: str) -> str:
-        value = value.strip()
-        if not value:
-            return uuid4().hex
-        return value
+    @field_validator("name", mode="before")
+    def set_name_default(cls, value: str | None) -> str:
+        if value := (value or "").strip():
+            return value
+        return uuid4().hex
 
 
 class DatasetShareSchema(BaseSchema):

--- a/ord_app/service_api/schemas/groups.py
+++ b/ord_app/service_api/schemas/groups.py
@@ -14,7 +14,7 @@
 from pydantic import constr
 
 from ord_app.service_api.models import UserRolesList
-from ord_app.service_api.schemas.base import BaseSchema
+from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH, BaseSchema
 from ord_app.service_api.schemas.users import UserResponseSchema
 
 
@@ -30,7 +30,7 @@ class GroupUserResponseSchema(BaseSchema):
 
 
 class GroupCreateSchema(BaseSchema):
-    name: str | None
+    name: constr(max_length=MAX_CRITICAL_FIELD_LENGTH)
 
 
 class GroupAddMemberSchema(BaseSchema):

--- a/ord_app/service_api/schemas/templates.py
+++ b/ord_app/service_api/schemas/templates.py
@@ -16,13 +16,14 @@ from typing import Any
 
 import orjson
 from ord_schema.proto.reaction_pb2 import Reaction
-from pydantic import BaseModel, Field, Json, field_validator, model_validator
+from pydantic import Field, Json, constr, field_validator, model_validator
 
 from ord_app.service_api.domain.datasets import load_message
+from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH, BaseSchema
 from ord_app.service_api.schemas.reactions import get_molblocks
 
 
-class TemplateResponseModel(BaseModel):
+class TemplateResponseModel(BaseSchema):
     id: int
     name: str
     binpb: bytes | Any
@@ -47,8 +48,8 @@ class TemplateResponseModel(BaseModel):
         return b64encode(raw)
 
 
-class TemplateCreateModel(BaseModel):
-    name: str
+class TemplateCreateModel(BaseSchema):
+    name: constr(max_length=MAX_CRITICAL_FIELD_LENGTH)
     binpb: bytes | Any
     variables: Json
 
@@ -68,8 +69,8 @@ class TemplateCreateModel(BaseModel):
         return data
 
 
-class TemplateUpdateModel(BaseModel):
-    name: str | None = None
+class TemplateUpdateModel(BaseSchema):
+    name: constr(max_length=MAX_CRITICAL_FIELD_LENGTH) | None = None
     binpb: bytes | None = None
     variables: Json | None = None
 

--- a/ord_app/tests/test_groups/test_create_groups.py
+++ b/ord_app/tests/test_groups/test_create_groups.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from faker import Faker
+from fastapi import status
+
+from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH
 
 faker = Faker()
 
@@ -21,3 +24,9 @@ async def test_create_group(api_client, mock_authenticated_user):
     payload = {"name": faker.company()}
     response_data = api_client.post("/api/v1/groups", json=payload).raise_for_status().json()
     assert payload["name"] == response_data["name"]
+
+
+async def test_create_group_with_character_limitations(api_client, mock_authenticated_user):
+    payload = {"name": faker.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2)}
+    response = api_client.post("/api/v1/groups", json=payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/ord_app/tests/test_templates/test_create_templates.py
+++ b/ord_app/tests/test_templates/test_create_templates.py
@@ -14,17 +14,17 @@
 from base64 import b64encode
 
 from faker import Faker
+from fastapi import status
 from ord_schema.proto.reaction_pb2 import Reaction
 from sqlalchemy import select
 
 from ord_app.service_api.models import TemplateModel
+from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH
 
 fake = Faker()
 
 
 async def test_create_template(api_client, mock_authenticated_user, test_db_session):
-    user, *_, = mock_authenticated_user
-
     payload = {
         "binpb": b64encode(Reaction(reaction_id=fake.uuid4()).SerializeToString()).decode(),
         "name": fake.name(),
@@ -35,3 +35,13 @@ async def test_create_template(api_client, mock_authenticated_user, test_db_sess
     stmt = select(TemplateModel).where(TemplateModel.id == response_data["id"])
     db_template = await test_db_session.scalar(stmt)
     assert db_template.name == payload["name"]
+
+
+async def test_create_template_with_character_limitations(api_client, mock_authenticated_user, test_db_session):
+    payload = {
+        "binpb": b64encode(Reaction(reaction_id=fake.uuid4()).SerializeToString()).decode(),
+        "name": fake.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2),
+        "variables": {"foo": "bar"},
+    }
+    response = api_client.post("/api/v1/templates", json=payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/ord_app/tests/tests_datasets/test_create_dataset.py
+++ b/ord_app/tests/tests_datasets/test_create_dataset.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 
 from ord_app.service_api.domain.reactions import validate_dataset_reactions
 from ord_app.service_api.models import ReactionModel
+from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH
 from ord_app.service_api.settings import RuntimeSettings
 from ord_app.tests.conftest import create_test_dataset
 
@@ -135,3 +136,13 @@ async def test_dataset_extend(api_client, mock_authenticated_user, test_db_sessi
 
     for item in response_data["items"]:
         assert item["pb_reaction_id"] in (reaction_id, enum_reaction_id)
+
+
+async def test_create_dataset_with_character_limitations(api_client, mock_authenticated_user):
+    *_, group = mock_authenticated_user
+    payload = {
+        "name": faker.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2),
+        "description": faker.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2)
+    }
+    response = api_client.post(f"/api/v1/groups/{group.id}/datasets", json=payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/ord_app/tests/tests_reactions/test_create_reactions.py
+++ b/ord_app/tests/tests_reactions/test_create_reactions.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 from base64 import b64decode, b64encode
 
+from faker import Faker
+from fastapi import status
 from ord_schema.proto.dataset_pb2 import Dataset
 from ord_schema.proto.reaction_pb2 import Reaction
 
 from ord_app.service_api.domain.datasets import load_message
+from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH
 from ord_app.service_api.settings import RuntimeSettings
 from ord_app.tests.conftest import create_test_dataset
 
+fake = Faker()
 
 async def test_create_reaction_with_pb(api_client, mock_authenticated_user, test_db_session):
     dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
@@ -85,3 +89,17 @@ async def test_create_duplicate_reaction_without_reaction_id(api_client, mock_au
     response_data2 = api_client.post(f"/api/v1/datasets/{dataset.id}/reactions", json=payload).raise_for_status().json()
     assert response_data1["id"] != response_data2["id"]
     assert response_data1["pb_reaction_id"] != response_data2["pb_reaction_id"]
+
+
+async def test_create_reaction_with_character_limitations(api_client, mock_authenticated_user, test_db_session):
+    dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
+    payload = {
+        "binpb": b64encode(
+            Reaction(
+                reaction_id=fake.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2)
+            ).SerializeToString()
+        ).decode()
+    }
+
+    response = api_client.post(f"/api/v1/datasets/{dataset.id}/reactions", json=payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
Added restrictions on the maximum allowed number of characters for the following fields:
- group name
- dataset name and description
- reaction_id
- template name