### PR TITLE
feature/ORD-456 reactions order

### DIFF
--- a/ord_app/service_api/domain/datasets.py
+++ b/ord_app/service_api/domain/datasets.py
@@ -122,7 +122,7 @@ class DatasetUseCases:
             {
                 "pb_reaction_id": reaction.reaction_id,
                 "binpb": reaction.SerializeToString(),
-                "dataset": dataset,
+                "dataset_id": dataset.id,
                 "owner_id": self.current_user.id,
             }
             for reaction in reactions

--- a/ord_app/service_api/models.py
+++ b/ord_app/service_api/models.py
@@ -106,7 +106,11 @@ class DatasetModel(BaseModel):
     owner_id: Mapped[int] = mapped_column(ForeignKey("user.id", ondelete="SET NULL"))
     owner: Mapped[UserModel] = relationship(UserModel, backref="datasets")
 
-    reactions: Mapped[list["ReactionModel"]] = relationship("ReactionModel", back_populates="dataset")
+    reactions: Mapped[list["ReactionModel"]] = relationship(
+        "ReactionModel",
+        back_populates="dataset",
+        order_by="ReactionModel.id"
+    )
 
     groups: Mapped[list[GroupModel]] = relationship(
         secondary="dataset_group_association",

--- a/ord_app/service_api/repositories/datasets.py
+++ b/ord_app/service_api/repositories/datasets.py
@@ -17,7 +17,7 @@ from fastapi_pagination.ext.sqlalchemy import paginate
 from loguru import logger
 from sqlalchemy import and_, delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import contains_eager, joinedload, with_loader_criteria
+from sqlalchemy.orm import joinedload, selectinload, with_loader_criteria
 
 from ord_app.service_api.models import (
     DatasetGroupAssociationModel,
@@ -131,12 +131,7 @@ class DatasetsRepository:
         stmt = (
             select(DatasetModel)
             .where(DatasetModel.id == dataset_id)
-            .outerjoin(DatasetModel.reactions)
-            .options(contains_eager(DatasetModel.reactions))
-            .order_by(
-                DatasetModel.modified_at.desc(),
-                ReactionModel.id.desc(),
-            )
+            .options(selectinload(DatasetModel.reactions))
         )
         return await self.db.scalar(stmt)
 

--- a/ord_app/service_api/repositories/reactions.py
+++ b/ord_app/service_api/repositories/reactions.py
@@ -14,7 +14,7 @@
 from itertools import batched
 
 from loguru import logger
-from sqlalchemy import select, update
+from sqlalchemy import insert, select, update
 
 from ord_app.service_api.models import ReactionModel
 from ord_app.service_api.repositories.base import BaseRepository
@@ -72,18 +72,16 @@ class ReactionsRepository(BaseRepository[ReactionModel]):
         stmt = (
             select(ReactionModel)
             .where(ReactionModel.dataset_id == dataset_id)
-            .order_by(ReactionModel.modified_at.desc())
+            .order_by(ReactionModel.id)
         )
         return stmt
 
-    async def bulk_create(self, payload: list[dict], autocommit: bool = True) -> list[ReactionModel]:
-        reactions = [ReactionModel(**reaction) for reaction in payload]
+    async def bulk_create(self, payload: list[dict], autocommit: bool = True):
+        stmt = insert(ReactionModel).values(payload)
         if autocommit:
-            self.db.add_all(reactions)
+            await self.db.execute(stmt)
             await self.db.commit()
             logger.debug("Bulk reaction created with payload")
-
-        return reactions
 
     async def find_duplicated_by_pb_reaction_id(
         self,

--- a/ord_app/service_api/resources/v1/datasets.py
+++ b/ord_app/service_api/resources/v1/datasets.py
@@ -83,6 +83,20 @@ async def upload_dataset(
     background_tasks.add_task(validate_dataset_reactions, db, dataset.id)
     return dataset
 
+@router.get(
+    "/datasets/{dataset_id}/download",
+    dependencies=[Depends(dataset_authorization(("admin", "editor", "viewer")))],
+)
+async def download_dataset(
+    dataset_id: int,
+    file_format: DownloadFileFormats,
+    use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
+):
+    dataset, data = await use_case.download(dataset_id, file_format)
+    return Response(
+        data,
+        headers={"Content-Disposition": f'attachment; filename="{dataset.name}.{file_format}"'}
+    )
 
 @router.get("/datasets", response_model=Page[DatasetWithReactionCountResponseSchema])
 async def get_user_datasets(
@@ -126,25 +140,6 @@ async def get_dataset(
     if dataset := await use_case.get(dataset_id):
         return dataset
     raise EntityNotFoundError("Dataset not found")
-
-
-@router.get(
-    "/datasets/{dataset_id}/download",
-    dependencies=[Depends(dataset_authorization(("admin", "editor", "viewer")))],
-)
-async def download_dataset(
-    dataset_id: int,
-    file_format: DownloadFileFormats,
-    use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
-    # NOTE(skearnes): See https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files for comments on
-    # preferred file extensions.
-    dataset, data = await use_case.download(dataset_id, file_format)
-
-    return Response(
-        data,
-        headers={"Content-Disposition": f'attachment; filename="{dataset.name}.{file_format}"'}
-    )
 
 
 @router.post(


### PR DESCRIPTION
Sets the ordering of reactions according to the order of their creation and how these reactions are arranged in the protobuf file. This is achieved by specifying an explicit ordering by reaction IDs.