### PR TITLE
Add SSM bastion for local RDS access

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,90 @@
+# infrastructure
+
+Pulumi stacks that provision the AWS infrastructure for ord-app.
+
+## Layout
+
+| Project | Purpose |
+| --- | --- |
+| [domain/](domain/) | Route 53 hosted zone and ACM certificates |
+| [backend/](backend/) | VPC, RDS Aurora, Redis, bastion ([README](backend/README.md)) |
+| [app/](app/) | ECS service, ALB, task definitions for ord-app |
+| [interface/](interface/) | CloudFront / public-facing edge config |
+
+Each project has its own stack (`ord/prod`) and is deployed independently.
+
+## Prerequisites
+
+- [Pulumi CLI](https://www.pulumi.com/docs/install/) (currently using 3.220+)
+- AWS CLI configured for SSO
+- Python 3.12+
+
+## One-time setup
+
+### Authenticate
+
+```sh
+aws sso login
+pulumi login
+```
+
+SSO credentials expire periodically — re-run `aws sso login` when Pulumi reports
+`Failed to refresh cached SSO credentials`.
+
+### Python environment
+
+Each Pulumi project has its own `requirements.txt`. The cleanest way to keep
+Pulumi's deps from colliding with the workspace `.venv` (which would pin a
+different `protobuf` than `ord-schema` requires) is a per-project virtualenv:
+
+```sh
+cd infrastructure/<project>
+python3 -m venv venv
+./venv/bin/pip install -r requirements.txt
+```
+
+Then add this to that project's `Pulumi.yaml` so Pulumi auto-uses it:
+
+```yaml
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+```
+
+> **Heads up:** if you instead `pip install -r requirements.txt` into the root
+> workspace `.venv`, it will upgrade `protobuf` to v6 and break `ord-schema`
+> (which pins `<5`). Use a per-project venv.
+
+## Deploying
+
+From any project directory:
+
+```sh
+pulumi preview --stack ord/prod   # show planned changes
+pulumi up      --stack ord/prod   # apply
+```
+
+Always run `preview` first and review the diff. The `prod` stack is the only
+stack that exists today — there is no separate dev/staging.
+
+## Inspecting state
+
+```sh
+pulumi stack ls                   # list stacks
+pulumi stack output --stack ord/prod          # all stack outputs
+pulumi stack output --stack ord/prod --show-secrets <name>   # include secrets
+```
+
+The Pulumi Cloud console is at <https://app.pulumi.com/ord>.
+
+## Recommended deploy order
+
+When bringing the stacks up from scratch:
+
+1. `domain` — DNS + certs
+2. `backend` — VPC, database, cache (other stacks depend on its outputs via stack references)
+3. `app`
+4. `interface`
+
+For routine changes, deploy only the project you modified.

--- a/infrastructure/backend/README.md
+++ b/infrastructure/backend/README.md
@@ -1,0 +1,55 @@
+# backend
+
+Pulumi stack for the backend AWS infrastructure: VPC, RDS Aurora cluster, Redis, and a bastion for local DB access.
+
+## Connecting to RDS from a local client (DataGrip, psql, etc.)
+
+The RDS cluster has no public endpoint. A `t4g.nano` bastion in a private subnet forwards traffic to it via AWS Systems Manager — no SSH, no public IP, no inbound ports. Access is gated by IAM.
+
+### One-time setup
+
+Install the SSM Session Manager plugin:
+
+```sh
+brew install --cask session-manager-plugin
+```
+
+Make sure your AWS CLI credentials are configured for the account this stack is deployed to.
+
+### Start the tunnel
+
+```sh
+BASTION=$(pulumi -C infrastructure/backend stack output bastion_instance_id)
+RDS=$(pulumi -C infrastructure/backend stack output rds_endpoint)
+aws ssm start-session \
+  --target "$BASTION" \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters "{\"host\":[\"$RDS\"],\"portNumber\":[\"5432\"],\"localPortNumber\":[\"15432\"]}"
+```
+
+Leave that running. Local port `15432` is now forwarded to the RDS endpoint on `5432`.
+
+### Connect
+
+In DataGrip (or any PostgreSQL client):
+
+- Host: `localhost`
+- Port: `15432`
+- Database: `ord`
+- User: `ord`
+- Password: pulled from the `rds_password` secret in AWS Secrets Manager. To fetch it:
+
+  ```sh
+  aws secretsmanager get-secret-value \
+    --secret-id "$(pulumi -C infrastructure/backend stack output rds_password_secret_arn)" \
+    --query SecretString --output text
+  ```
+
+### Cost note
+
+The bastion runs 24/7 at roughly $3/mo. To pause it when you're not using it:
+
+```sh
+aws ec2 stop-instances --instance-ids "$BASTION"
+aws ec2 start-instances --instance-ids "$BASTION"
+```

--- a/infrastructure/backend/__main__.py
+++ b/infrastructure/backend/__main__.py
@@ -14,6 +14,8 @@
 
 """An AWS Python Pulumi program."""
 
+import json
+
 import pulumi
 import pulumi_aws as aws
 import pulumi_awsx as awsx
@@ -145,6 +147,57 @@ dev_security_group = aws.ec2.SecurityGroup(
     vpc_id=vpc.vpc_id,
 )
 
+# Bastion for local DB access via SSM port forwarding (no public IP, no inbound ports).
+bastion_role = aws.iam.Role(
+    "bastion_role",
+    assume_role_policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ec2.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    ),
+)
+aws.iam.RolePolicyAttachment(
+    "bastion_ssm_policy",
+    role=bastion_role.name,
+    policy_arn="arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+)
+bastion_instance_profile = aws.iam.InstanceProfile("bastion_instance_profile", role=bastion_role.name)
+
+bastion_security_group = aws.ec2.SecurityGroup(
+    "bastion_security_group",
+    egress=[
+        aws.ec2.SecurityGroupEgressArgs(
+            from_port=0,
+            to_port=0,
+            protocol="-1",
+            cidr_blocks=["0.0.0.0/0"],
+            ipv6_cidr_blocks=["::/0"],
+        )
+    ],
+    vpc_id=vpc.vpc_id,
+)
+
+bastion_ami_id = aws.ssm.get_parameter_output(
+    name="/aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id",
+).value
+
+bastion = aws.ec2.Instance(
+    "bastion",
+    ami=bastion_ami_id,
+    instance_type="t4g.nano",
+    iam_instance_profile=bastion_instance_profile.name,
+    subnet_id=vpc.private_subnet_ids.apply(lambda ids: ids[0]),
+    vpc_security_group_ids=[bastion_security_group.id],
+    tags={"Name": "bastion"},
+)
+
 pulumi.export("vpc_id", vpc.vpc_id)
 pulumi.export("public_subnet_ids", vpc.public_subnet_ids)
 pulumi.export("private_subnet_ids", vpc.private_subnet_ids)
@@ -152,3 +205,4 @@ pulumi.export("rds_endpoint", cluster.endpoint)
 pulumi.export("rds_password_secret_arn", rds_password_secret.arn)
 pulumi.export("rds_dsn_secret_arn", rds_dsn_secret.arn)
 pulumi.export("redis_endpoint", redis.endpoints.apply(lambda endpoints: endpoints[0]["address"]))
+pulumi.export("bastion_instance_id", bastion.id)


### PR DESCRIPTION
## Summary

- Provisions a `t4g.nano` Ubuntu bastion in a private subnet with an instance profile granting `AmazonSSMManagedInstanceCore`. Local clients reach the RDS cluster via `aws ssm start-session` port forwarding — no public IP, no inbound ports, IAM-gated.
- Adds `infrastructure/backend/README.md` with tunnel / DataGrip connection steps.
- Adds `infrastructure/README.md` with auth, per-project venv setup, and the standard `preview` → `up` workflow.

## Test plan

- [x] `pulumi preview --stack ord/prod` shows expected diff (5 created, 1 unrelated provider-driven update)
- [x] `pulumi up --stack ord/prod` succeeds
- [x] `aws ssm start-session ... AWS-StartPortForwardingSessionToRemoteHost` from a laptop reaches the RDS endpoint via the bastion
- [x] DataGrip connects through the forwarded local port

🤖 Generated with [Claude Code](https://claude.com/claude-code)