### PR TITLE
Add Playwright E2E with a full no-auth stack CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,24 +105,19 @@ jobs:
         working-directory: ui
         run: npm ci
 
-      - name: Build UI (no-auth)
-        working-directory: ui
-        run: npm run build
-        env:
-          VITE_E2E_NO_AUTH: "TRUE"
-          VITE_API_ENDPOINT: "http://127.0.0.1:8000/service_api/api/v1"
-
       - name: Install Playwright browsers
         working-directory: ui
         run: npx playwright install --with-deps chromium
 
-      # Backend + UI preview must run in the same step as Playwright: background processes
+      # The UI is served via the dev server (vite dev), not a production build: the no-auth
+      # bypass is hard-gated off in production builds (import.meta.env.PROD), so e2e must use
+      # dev mode. Backend + UI + Playwright all run in one step because background processes
       # started in earlier steps do not survive into later ones on GitHub runners.
       - name: Start servers and run E2E
         run: |
           set -e
           nohup uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 > /tmp/backend.log 2>&1 &
-          nohup npm --prefix ui run preview -- --host 127.0.0.1 --port 5173 > /tmp/preview.log 2>&1 &
+          nohup npm --prefix ui run dev -- --host 127.0.0.1 --port 5173 > /tmp/ui.log 2>&1 &
           for _ in $(seq 1 60); do
             curl -sf http://127.0.0.1:8000/service_api/docs > /dev/null && break || sleep 2
           done
@@ -130,16 +125,18 @@ jobs:
           for _ in $(seq 1 30); do
             curl -sf http://127.0.0.1:5173 > /dev/null && break || sleep 2
           done
-          curl -sf http://127.0.0.1:5173 > /dev/null || { echo "preview failed"; cat /tmp/preview.log; exit 1; }
+          curl -sf http://127.0.0.1:5173 > /dev/null || { echo "ui failed"; cat /tmp/ui.log; exit 1; }
           npm --prefix ui run test:e2e
         env:
           APP_ENV: localhost
           ORD_APP_E2E: "true"
           CORS_ORIGINS: '["http://127.0.0.1:5173"]'
+          VITE_E2E_NO_AUTH: "TRUE"
+          VITE_API_ENDPOINT: "http://127.0.0.1:8000/service_api/api/v1"
           PG_DSN: "postgresql+asyncpg://ord:password@localhost:5432/test"
           PG_ALEMBIC_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
           PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
 
       - name: Server logs (on failure)
         if: failure()
-        run: cat /tmp/backend.log /tmp/preview.log || true
+        run: cat /tmp/backend.log /tmp/ui.log || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,3 +140,13 @@ jobs:
       - name: Server logs (on failure)
         if: failure()
         run: cat /tmp/backend.log /tmp/ui.log || true
+
+      - name: Upload Playwright report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            ui/playwright-report/
+            ui/test-results/
+          retention-days: 7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Start backend (e2e no-auth mode)
         run: |
-          nohup uv run fastapi run ord_app/service_api/main.py --host 127.0.0.1 --port 8000 > /tmp/backend.log 2>&1 &
+          nohup uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 > /tmp/backend.log 2>&1 &
           for _ in $(seq 1 60); do
             if curl -sf http://127.0.0.1:8000/service_api/docs > /dev/null; then echo "backend up"; exit 0; fi
             sleep 2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,21 +96,6 @@ jobs:
           PG_ALEMBIC_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
           PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
 
-      - name: Start backend (e2e no-auth mode)
-        run: |
-          nohup uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 > /tmp/backend.log 2>&1 &
-          for _ in $(seq 1 60); do
-            if curl -sf http://127.0.0.1:8000/service_api/docs > /dev/null; then echo "backend up"; exit 0; fi
-            sleep 2
-          done
-          echo "backend failed to start"; cat /tmp/backend.log; exit 1
-        env:
-          APP_ENV: localhost
-          ORD_APP_E2E: "true"
-          PG_DSN: "postgresql+asyncpg://ord:password@localhost:5432/test"
-          PG_ALEMBIC_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
-          PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
-
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -127,23 +112,32 @@ jobs:
           VITE_E2E_NO_AUTH: "TRUE"
           VITE_API_ENDPOINT: "http://127.0.0.1:8000/service_api/api/v1"
 
-      - name: Start UI preview
-        working-directory: ui
-        run: |
-          nohup npm run preview > /tmp/preview.log 2>&1 &
-          for _ in $(seq 1 30); do
-            if curl -sf http://localhost:5173 > /dev/null; then echo "preview up"; exit 0; fi
-            sleep 2
-          done
-          echo "preview failed to start"; cat /tmp/preview.log; exit 1
-
       - name: Install Playwright browsers
         working-directory: ui
         run: npx playwright install --with-deps chromium
 
-      - name: Run E2E tests
-        working-directory: ui
-        run: npm run test:e2e
+      # Backend + UI preview must run in the same step as Playwright: background processes
+      # started in earlier steps do not survive into later ones on GitHub runners.
+      - name: Start servers and run E2E
+        run: |
+          set -e
+          nohup uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 > /tmp/backend.log 2>&1 &
+          nohup npm --prefix ui run preview > /tmp/preview.log 2>&1 &
+          for _ in $(seq 1 60); do
+            curl -sf http://127.0.0.1:8000/service_api/docs > /dev/null && break || sleep 2
+          done
+          curl -sf http://127.0.0.1:8000/service_api/docs > /dev/null || { echo "backend failed"; cat /tmp/backend.log; exit 1; }
+          for _ in $(seq 1 30); do
+            curl -sf http://localhost:5173 > /dev/null && break || sleep 2
+          done
+          curl -sf http://localhost:5173 > /dev/null || { echo "preview failed"; cat /tmp/preview.log; exit 1; }
+          npm --prefix ui run test:e2e
+        env:
+          APP_ENV: localhost
+          ORD_APP_E2E: "true"
+          PG_DSN: "postgresql+asyncpg://ord:password@localhost:5432/test"
+          PG_ALEMBIC_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
+          PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
 
       - name: Server logs (on failure)
         if: failure()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,19 +122,20 @@ jobs:
         run: |
           set -e
           nohup uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 > /tmp/backend.log 2>&1 &
-          nohup npm --prefix ui run preview > /tmp/preview.log 2>&1 &
+          nohup npm --prefix ui run preview -- --host 127.0.0.1 --port 5173 > /tmp/preview.log 2>&1 &
           for _ in $(seq 1 60); do
             curl -sf http://127.0.0.1:8000/service_api/docs > /dev/null && break || sleep 2
           done
           curl -sf http://127.0.0.1:8000/service_api/docs > /dev/null || { echo "backend failed"; cat /tmp/backend.log; exit 1; }
           for _ in $(seq 1 30); do
-            curl -sf http://localhost:5173 > /dev/null && break || sleep 2
+            curl -sf http://127.0.0.1:5173 > /dev/null && break || sleep 2
           done
-          curl -sf http://localhost:5173 > /dev/null || { echo "preview failed"; cat /tmp/preview.log; exit 1; }
+          curl -sf http://127.0.0.1:5173 > /dev/null || { echo "preview failed"; cat /tmp/preview.log; exit 1; }
           npm --prefix ui run test:e2e
         env:
           APP_ENV: localhost
           ORD_APP_E2E: "true"
+          CORS_ORIGINS: '["http://127.0.0.1:5173"]'
           PG_DSN: "postgresql+asyncpg://ord:password@localhost:5432/test"
           PG_ALEMBIC_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
           PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,3 +65,86 @@ jobs:
           PG_DSN: "postgresql+asyncpg://ord:password@localhost:5432/test"
           PG_ALEMBIC_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
           PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
+
+  test_e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - uses: ikalnytskyi/action-setup-postgres@v7
+        with:
+          username: ord
+          password: password
+          database: test
+          port: 5432
+          postgres-version: "17"
+          ssl: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: uv sync --frozen
+
+      - name: Run alembic migrations
+        run: uv run alembic upgrade head
+        env:
+          PG_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
+          PG_ALEMBIC_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
+          PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
+
+      - name: Start backend (e2e no-auth mode)
+        run: |
+          nohup uv run fastapi run ord_app/service_api/main.py --host 127.0.0.1 --port 8000 > /tmp/backend.log 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8000/service_api/docs > /dev/null; then echo "backend up"; exit 0; fi
+            sleep 2
+          done
+          echo "backend failed to start"; cat /tmp/backend.log; exit 1
+        env:
+          APP_ENV: localhost
+          ORD_APP_E2E: "true"
+          PG_DSN: "postgresql+asyncpg://ord:password@localhost:5432/test"
+          PG_ALEMBIC_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
+          PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install UI dependencies
+        working-directory: ui
+        run: npm ci
+
+      - name: Build UI (no-auth)
+        working-directory: ui
+        run: npm run build
+        env:
+          VITE_E2E_NO_AUTH: "TRUE"
+          VITE_API_ENDPOINT: "http://127.0.0.1:8000/service_api/api/v1"
+
+      - name: Start UI preview
+        working-directory: ui
+        run: |
+          nohup npm run preview > /tmp/preview.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if curl -sf http://localhost:5173 > /dev/null; then echo "preview up"; exit 0; fi
+            sleep 2
+          done
+          echo "preview failed to start"; cat /tmp/preview.log; exit 1
+
+      - name: Install Playwright browsers
+        working-directory: ui
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        working-directory: ui
+        run: npm run test:e2e
+
+      - name: Server logs (on failure)
+        if: failure()
+        run: cat /tmp/backend.log /tmp/preview.log || true

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 coverage/
+# Playwright E2E artifacts
+playwright-report/
+test-results/
+blob-report/
 .tox/
 .nox/
 .coverage

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Run the full stack locally with the dev/test Auth0 bypass enabled, for manual testing or to
+# run the Playwright E2E suite against. Requires a Postgres reachable via the PG_*_DSN env vars
+# (e.g. `docker compose up -d` to start the bundled database). Reproducible: no machine-specific
+# setup beyond uv and a provisioned Postgres — identical to the test_e2e CI job.
+#
+# Usage:
+#   PG_DSN=... PG_ALEMBIC_DSN=... PG_TEST_DSN=... ./scripts/dev-e2e.sh
+#   # then, in another shell: cd ui && npm run test:e2e
+set -euo pipefail
+
+export APP_ENV="${APP_ENV:-localhost}"
+export ORD_APP_E2E="${ORD_APP_E2E:-true}"
+
+echo "Applying database migrations..."
+uv run alembic upgrade head
+
+echo "Starting backend (no-auth e2e mode) on http://127.0.0.1:8000 ..."
+uv run fastapi dev ord_app/service_api/main.py --host 127.0.0.1 --port 8000 &
+backend_pid=$!
+trap 'kill "${backend_pid}" 2>/dev/null || true' EXIT
+
+echo "Starting UI (no-auth) on http://localhost:5173 ..."
+( cd ui && VITE_E2E_NO_AUTH=TRUE npm run dev )

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -26,6 +26,8 @@ set -euo pipefail
 
 export APP_ENV="${APP_ENV:-localhost}"
 export ORD_APP_E2E="${ORD_APP_E2E:-true}"
+# Match the UI origin (127.0.0.1:5173) below; the backend default only allows localhost:5173.
+export CORS_ORIGINS="${CORS_ORIGINS:-[\"http://127.0.0.1:5173\"]}"
 
 echo "Applying database migrations..."
 uv run alembic upgrade head
@@ -35,5 +37,5 @@ uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 &
 backend_pid=$!
 trap 'kill "${backend_pid}" 2>/dev/null || true' EXIT
 
-echo "Starting UI (no-auth) on http://localhost:5173 ..."
-( cd ui && VITE_E2E_NO_AUTH=TRUE npm run dev )
+echo "Starting UI (no-auth) on http://127.0.0.1:5173 ..."
+( cd ui && VITE_E2E_NO_AUTH=TRUE npm run dev -- --host 127.0.0.1 --port 5173 )

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -31,7 +31,7 @@ echo "Applying database migrations..."
 uv run alembic upgrade head
 
 echo "Starting backend (no-auth e2e mode) on http://127.0.0.1:8000 ..."
-uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 --reload &
+uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 &
 backend_pid=$!
 trap 'kill "${backend_pid}" 2>/dev/null || true' EXIT
 

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -31,7 +31,7 @@ echo "Applying database migrations..."
 uv run alembic upgrade head
 
 echo "Starting backend (no-auth e2e mode) on http://127.0.0.1:8000 ..."
-uv run fastapi dev ord_app/service_api/main.py --host 127.0.0.1 --port 8000 &
+uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 --reload &
 backend_pid=$!
 trap 'kill "${backend_pid}" 2>/dev/null || true' EXIT
 

--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -19,7 +19,20 @@ import { test, expect } from '@playwright/test';
 // backend e2e mode enabled, the app must load without redirecting to Auth0 and render the
 // authenticated shell. Reaching the Datasets page proves the dev user was provisioned.
 test('loads the authenticated app without Auth0 and shows the Datasets page', async ({ page }) => {
-  await page.goto('/');
+  const diagnostics: Array<string> = [];
+  page.on('console', message => {
+    if (message.type() === 'error') diagnostics.push(`console.error: ${message.text()}`);
+  });
+  page.on('pageerror', error => diagnostics.push(`pageerror: ${error.message}`));
+  page.on('requestfailed', request =>
+    diagnostics.push(`requestfailed: ${request.url()} -> ${request.failure()?.errorText}`),
+  );
+
+  const response = await page.goto('/', { waitUntil: 'domcontentloaded' }).catch(error => {
+    diagnostics.push(`goto threw: ${error.message}`);
+    return null;
+  });
+  console.log(`E2E DIAG: gotoStatus=${response?.status()} url=${page.url()} :: ${diagnostics.join(' | ')}`);
 
   // "/" redirects to "/datasets" — and crucially we stay on the app, not the Auth0 domain.
   await expect(page).toHaveURL(/\/datasets/);

--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -24,14 +24,18 @@ test('loads the authenticated app without Auth0 and shows the Datasets page', as
     if (message.type() === 'error') diagnostics.push(`console.error: ${message.text()}`);
   });
   page.on('pageerror', error => diagnostics.push(`pageerror: ${error.message}`));
-  page.on('requestfailed', request =>
-    diagnostics.push(`requestfailed: ${request.url()} -> ${request.failure()?.errorText}`),
-  );
+  page.on('crash', () => diagnostics.push('PAGE CRASHED'));
+  page.on('requestfailed', request => {
+    if (!request.url().includes('google-analytics')) {
+      diagnostics.push(`requestfailed: ${request.url()} -> ${request.failure()?.errorText}`);
+    }
+  });
 
   const response = await page.goto('/', { waitUntil: 'domcontentloaded' }).catch(error => {
     diagnostics.push(`goto threw: ${error.message}`);
     return null;
   });
+  await page.waitForTimeout(15_000);
   console.log(`E2E DIAG: gotoStatus=${response?.status()} url=${page.url()} :: ${diagnostics.join(' | ')}`);
 
   // "/" redirects to "/datasets" (client-side, after the dev user is provisioned) — and

--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -19,27 +19,11 @@ import { test, expect } from '@playwright/test';
 // backend e2e mode enabled, the app must load without redirecting to Auth0 and render the
 // authenticated shell. Reaching the Datasets page proves the dev user was provisioned.
 test('loads the authenticated app without Auth0 and shows the Datasets page', async ({ page }) => {
-  const diagnostics: Array<string> = [];
-  page.on('console', message => {
-    if (message.type() === 'error') diagnostics.push(`console.error: ${message.text()}`);
-  });
-  page.on('pageerror', error => diagnostics.push(`pageerror: ${error.message}`));
-  page.on('crash', () => diagnostics.push('PAGE CRASHED'));
-  page.on('requestfailed', request => {
-    if (!request.url().includes('google-analytics')) {
-      diagnostics.push(`requestfailed: ${request.url()} -> ${request.failure()?.errorText}`);
-    }
-  });
-
-  const response = await page.goto('/', { waitUntil: 'domcontentloaded' }).catch(error => {
-    diagnostics.push(`goto threw: ${error.message}`);
-    return null;
-  });
-  await page.waitForTimeout(15_000);
-  console.log(`E2E DIAG: gotoStatus=${response?.status()} url=${page.url()} :: ${diagnostics.join(' | ')}`);
+  // 'load' may not fire reliably for this WASM-heavy app; domcontentloaded is enough to start it.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
 
   // "/" redirects to "/datasets" (client-side, after the dev user is provisioned) — and
-  // crucially we stay on the app, not the Auth0 domain.
+  // crucially we stay on the app, never the Auth0 domain.
   await expect(page).toHaveURL(/\/datasets/, { timeout: 30_000 });
 
   // The Datasets list heading only renders once the dev user has been provisioned.

--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -34,8 +34,9 @@ test('loads the authenticated app without Auth0 and shows the Datasets page', as
   });
   console.log(`E2E DIAG: gotoStatus=${response?.status()} url=${page.url()} :: ${diagnostics.join(' | ')}`);
 
-  // "/" redirects to "/datasets" — and crucially we stay on the app, not the Auth0 domain.
-  await expect(page).toHaveURL(/\/datasets/);
+  // "/" redirects to "/datasets" (client-side, after the dev user is provisioned) — and
+  // crucially we stay on the app, not the Auth0 domain.
+  await expect(page).toHaveURL(/\/datasets/, { timeout: 30_000 });
 
   // The Datasets list heading only renders once the dev user has been provisioned.
   await expect(page.getByRole('heading', { name: 'Datasets', level: 1 })).toBeVisible({ timeout: 30_000 });

--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { test, expect } from '@playwright/test';
+
+// Smoke test for the no-auth dev/E2E bypass: with VITE_E2E_NO_AUTH set (frontend) and the
+// backend e2e mode enabled, the app must load without redirecting to Auth0 and render the
+// authenticated shell. Reaching the Datasets page proves the dev user was provisioned.
+test('loads the authenticated app without Auth0 and shows the Datasets page', async ({ page }) => {
+  await page.goto('/');
+
+  // "/" redirects to "/datasets" — and crucially we stay on the app, not the Auth0 domain.
+  await expect(page).toHaveURL(/\/datasets/);
+
+  // The Datasets list heading only renders once the dev user has been provisioned.
+  await expect(page.getByRole('heading', { name: 'Datasets', level: 1 })).toBeVisible({ timeout: 30_000 });
+});

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -38,6 +38,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2423,6 +2424,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -10350,6 +10367,53 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,8 @@
     "prepare": "cd .. && husky ./ui/.husky",
     "add-license": "license-check-and-add add",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "lint-staged": {
     "(*.ts|*.tsx|*.cjs|*.mjs)": [
@@ -61,6 +62,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
   use: {
     baseURL: BASE_URL,
     trace: 'on-first-retry',
+    // --disable-dev-shm-usage avoids renderer crashes on heavy WASM pages (Ketcher/Indigo) in
+    // CI containers where /dev/shm is small; --no-sandbox is required on CI runners.
+    launchOptions: { args: ['--no-sandbox', '--disable-dev-shm-usage'] },
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 });

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -17,7 +17,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 // The UI preview server (see vite.config.ts `preview.port`). The backend + UI are started by
 // the caller (the test_e2e CI job or scripts/dev-e2e.sh) with the no-auth bypass enabled.
-const BASE_URL = 'http://localhost:5173';
+const BASE_URL = 'http://127.0.0.1:5173';
 
 export default defineConfig({
   testDir: './e2e',

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+// The UI preview server (see vite.config.ts `preview.port`). The backend + UI are started by
+// the caller (the test_e2e CI job or scripts/dev-e2e.sh) with the no-auth bypass enabled.
+const BASE_URL = 'http://localhost:5173';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: true,
+  retries: 1,
+  reporter: 'list',
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./src/test/setup.ts'],
+    // Unit tests live under src/; e2e/ is Playwright (run via `npm run test:e2e`), not vitest.
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary

Capstone of the testing-infrastructure epic (#662): an end-to-end verification of the no-auth path (frontend flag #667 + backend mode #668).

- **Playwright** config + a **smoke test** that loads the app through the no-auth bypass and asserts it reaches the **Datasets** page with no Auth0 redirect — which proves the dev user was provisioned through the backend e2e mode (i.e. the whole FE↔BE no-auth path works).
- A **`test_e2e` CI job** that boots the full stack reproducibly: Postgres via `action-setup-postgres` (mirroring `test_python`), the backend in e2e mode (`ORD_APP_E2E`, `APP_ENV=localhost`), and the UI built + previewed with `VITE_E2E_NO_AUTH`. No machine-specific setup.
- **`scripts/dev-e2e.sh`** to run the same stack locally against any provisioned Postgres.

This is the piece that lets an agent/CI actually verify UI behavior going forward — future "needs a visual pass" issues can become E2E/visual tests.

## Test plan
- [x] `tsc`/`eslint`/`prettier`/`build` clean; `playwright test --list` discovers the test
- [ ] **`test_e2e` CI job green** — the real end-to-end check (Postgres + backend e2e + UI no-auth + Playwright). Iterating here as needed.

Part of #662. Closes #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds end-to-end testing infrastructure using Playwright, wiring together the no-auth frontend bypass and backend e2e mode into a single verifiable CI job (`test_e2e`).

- **`test_e2e` CI job**: Boots a full stack (Postgres, uvicorn backend in e2e mode, Vite dev server with no-auth flag) and runs a Playwright smoke test that asserts the app reaches the Datasets page without an Auth0 redirect; failure artifacts (Playwright report, traces) are uploaded on job failure.
- **`scripts/dev-e2e.sh`**: Local companion script that mirrors the CI stack for running E2E tests or manual testing against a provisioned Postgres, with CORS and no-auth env vars pre-configured.
- **`ui/vite.config.ts`**: Adds a `vitest.include` filter to keep Playwright's `e2e/` directory out of the vitest unit-test run.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are test infrastructure with no impact on production code paths.

The PR adds only CI configuration, a local dev script, Playwright config, and a smoke test. No production application code is modified. The CI job correctly provisions Postgres, runs migrations, and waits for both servers before running tests. Failure diagnostics (server logs and Playwright artifacts) are captured on job failure.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/tests.yml | Adds test_e2e CI job with Postgres, backend (uvicorn), Vite dev server, and Playwright; includes failure artifact upload. No npm or Playwright browser caching configured. |
| ui/playwright.config.ts | New Playwright config; comment incorrectly references "preview server" and vite.config.ts preview.port, but both CI and dev-e2e.sh actually start the vite dev server. |
| ui/e2e/smoke.spec.ts | Single smoke test asserting no-auth redirect to /datasets and heading visibility; reasonable timeouts for a WASM-heavy app. |
| scripts/dev-e2e.sh | Local E2E helper script; starts backend in background with no readiness poll before the UI, meaning tests run from a second shell may hit an unready backend. |
| ui/vite.config.ts | Adds vitest include filter to exclude e2e/ from unit test runs; clean separation of Playwright and vitest scopes. |
| ui/package.json | Adds @playwright/test devDependency and test:e2e script; straightforward. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI as GitHub Actions (test_e2e)
    participant PG as Postgres :5432
    participant BE as uvicorn backend :8000
    participant UI as Vite dev server :5173
    participant PW as Playwright (Chromium)

    CI->>PG: action-setup-postgres (start)
    CI->>BE: uv run alembic upgrade head
    CI->>BE: "nohup uvicorn (ORD_APP_E2E=true)"
    CI->>CI: poll /service_api/docs (up to 120s)
    CI->>UI: "nohup npm run dev (VITE_E2E_NO_AUTH=TRUE)"
    CI->>CI: poll http://127.0.0.1:5173 (up to 60s)
    CI->>PW: npm run test:e2e
    PW->>UI: GET /
    UI->>BE: provision dev user (e2e mode)
    BE-->>UI: 200 OK
    UI-->>PW: redirect to /datasets
    PW->>UI: assert URL matches /datasets
    PW->>UI: assert h1 Datasets visible
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Match dev-e2e.sh origin/CORS to CI"](https://github.com/open-reaction-database/ord-app/commit/0d17786e04f253c9db6071208d527f48c05ff741) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34741639)</sub>

<!-- /greptile_comment -->