### PR TITLE
Pin GitHub Actions to commit SHAs (SonarCloud hotspot)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,8 +26,8 @@ jobs:
   check_license_headers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '>=1.16'
       - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -58,7 +58,7 @@ jobs:
   check_javascript:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: clang-format
         run: |
           sudo apt update && sudo apt install clang-format --yes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,9 +32,9 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ikalnytskyi/action-setup-postgres@v7
+      - uses: ikalnytskyi/action-setup-postgres@10ab8a56cc77b4823c2bfa57b1d4dd5605ef0481 # v7
         id: postgres
         with:
           username: ord
@@ -70,9 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ikalnytskyi/action-setup-postgres@v7
+      - uses: ikalnytskyi/action-setup-postgres@10ab8a56cc77b4823c2bfa57b1d4dd5605ef0481 # v7
         with:
           username: ord
           password: password
@@ -97,7 +97,7 @@ jobs:
           PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload Playwright report (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: |

--- a/.github/workflows/ui_checks.yml
+++ b/.github/workflows/ui_checks.yml
@@ -32,8 +32,8 @@ jobs:
   lint_and_build_ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
       - run: npm ci
@@ -43,8 +43,8 @@ jobs:
   test_ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
       - run: npm ci


### PR DESCRIPTION
## Summary

Fixes the SonarCloud security hotspot **"Use full commit SHA hash for this dependency"** that was failing the quality gate — including the one introduced by the `test_e2e` job (`tests.yml:75`, `ikalnytskyi/action-setup-postgres@v7`).

Pins **all** GitHub Actions across `tests.yml`, `ui_checks.yml`, and `checks.yml` to full commit SHAs (with `# vN` comments), matching the existing `astral-sh/setup-uv` pin. No version changes — each SHA is the tip of the same tag.

## Context / accountability
This hotspot is what made SonarCloud red on the recently-merged PRs. I had been excluding SonarCloud from my "CI green" checks, which was wrong — SonarCloud is part of CI and must pass. Going forward it's included in the gate.

## Test plan
- [x] All actions resolve to the same versions (SHAs are tag tips)
- [ ] SonarCloud quality gate passes on this PR (the point of the change)
- [ ] Other CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins all previously tag-referenced GitHub Actions across three workflow files to full commit SHAs, addressing a SonarCloud supply-chain security hotspot. No workflow logic or versions change — only the reference format is updated, with `# vN` comments retained for readability.

- **`checks.yml`**: `actions/checkout@v4` and `actions/setup-go@v5` pinned to their respective commit SHAs.
- **`tests.yml`**: `actions/checkout@v4`, `ikalnytskyi/action-setup-postgres@v7`, `actions/setup-node@v4`, and `actions/upload-artifact@v4` all pinned; `astral-sh/setup-uv` was already pinned pre-PR.
- **`ui_checks.yml`**: `actions/checkout@v4` and `actions/setup-node@v4` pinned; the same SHA is used consistently for each action across all files.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely mechanical pin of action references to commit SHAs with no behavioral changes.

All three workflow files are fully covered, each action uses a consistent SHA across files, version comments are present for maintainability, and the astral-sh/setup-uv pin that was already in place served as a correct template. The actions/upload-artifact SHA was independently confirmed as a known legitimate reference. No logic, environment variables, or job dependencies were touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/checks.yml | Pinned actions/checkout and actions/setup-go from tag references to full commit SHAs with version comments; no functional change. |
| .github/workflows/tests.yml | Pinned actions/checkout, ikalnytskyi/action-setup-postgres, actions/setup-node, and actions/upload-artifact to full commit SHAs; no functional change. |
| .github/workflows/ui_checks.yml | Pinned actions/checkout and actions/setup-node from tag references to full commit SHAs with version comments; no functional change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Pin GitHub Actions to commit SHAs"](https://github.com/open-reaction-database/ord-app/commit/e497fa2682c0f6c21c38e72fe5f51926d404d2a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34753791)</sub>

<!-- /greptile_comment -->