### PR TITLE
Sonar: prefer Number.parseInt/parseFloat

### DIFF
--- a/ui/src/common/components/interactions/Pagination/Pagination.tsx
+++ b/ui/src/common/components/interactions/Pagination/Pagination.tsx
@@ -74,7 +74,7 @@ export function Pagination({
       <Select
         classNames={{ root: classes.select, input: classes.selectInput }}
         value={String(rowsPerPage)}
-        onChange={value => onRowsPerPageChange(parseInt(value as string))}
+        onChange={value => onRowsPerPageChange(Number.parseInt(value as string))}
         allowDeselect={false}
         data={ROW_PER_PAGE_OPTIONS}
         rightSectionWidth={30}

--- a/ui/src/features/datasets/CreateDatasetFromFile/CreateDatasetFromFile.tsx
+++ b/ui/src/features/datasets/CreateDatasetFromFile/CreateDatasetFromFile.tsx
@@ -45,7 +45,7 @@ export function CreateDatasetFromFile({ onClose }: Readonly<CreateDatasetFromFil
       file: '',
     },
     transformValues: values => ({
-      groupId: parseInt(values.groupId),
+      groupId: Number.parseInt(values.groupId),
       file: values.file as File,
     }),
     validate: yupResolver(createDatasetFromFileSchema),

--- a/ui/src/features/datasets/CreateNewDataset/CreateNewDataset.tsx
+++ b/ui/src/features/datasets/CreateNewDataset/CreateNewDataset.tsx
@@ -45,7 +45,7 @@ export function CreateNewDataset({ onClose }: Readonly<CreateNewDatasetProps>) {
     validateInputOnChange: true,
     validate: yupResolver(createNewDatasetSchema),
     transformValues: (values: CreateNewDatasetFormValues): CreateNewDatasetPayload => ({
-      groupId: parseInt(values.groupId),
+      groupId: Number.parseInt(values.groupId),
       name: values.name,
       description: values.description,
     }),

--- a/ui/src/features/enumeration/EnumerationSetup/EnumerationSetup.tsx
+++ b/ui/src/features/enumeration/EnumerationSetup/EnumerationSetup.tsx
@@ -81,7 +81,7 @@ export function EnumerationSetup({
             ? dataset
             : {
                 ...dataset,
-                groupId: parseInt(dataset.groupId ?? ''),
+                groupId: Number.parseInt(dataset.groupId ?? ''),
               },
       }) as SetupEnumeration,
     validate: yupResolver(schema),

--- a/ui/src/features/enumeration/EnumerationSetup/TemplateFileSelector/TemplateFileSelector.tsx
+++ b/ui/src/features/enumeration/EnumerationSetup/TemplateFileSelector/TemplateFileSelector.tsx
@@ -47,7 +47,7 @@ function cast(value: string, context: CastingContext): string | number | boolean
     return lowerCaseValue === 'true';
   }
   if (NUMBER_REGEX.test(value)) {
-    const parsedValue = parseFloat(value);
+    const parsedValue = Number.parseFloat(value);
     if (!Number.isNaN(parsedValue)) {
       return parsedValue;
     }

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementMasses.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementMasses.tsx
@@ -37,7 +37,7 @@ export function MeasurementMasses({ name, formMethods }: Readonly<ReactionFormCu
 
   const handleChange = (value: Array<string | number>) => {
     const numericValues = value
-      .map(item => (typeof item === 'string' ? parseFloat(item) : item))
+      .map(item => (typeof item === 'string' ? Number.parseFloat(item) : item))
       .filter(item => !isNaN(item));
     onChange(numericValues);
   };

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.tsx
@@ -137,7 +137,7 @@ function optionalStringNumberToNumber(value: Optional<number | string>): Optiona
   if (typeof value === 'number') {
     return value;
   }
-  const parsedValue = parseFloat(value);
+  const parsedValue = Number.parseFloat(value);
   return Number.isNaN(parsedValue) ? null : parsedValue;
 }
 

--- a/ui/src/features/reactions/ReactionHeader/ReactionHeaderActions/ReactionHeaderActions.tsx
+++ b/ui/src/features/reactions/ReactionHeader/ReactionHeaderActions/ReactionHeaderActions.tsx
@@ -35,7 +35,7 @@ interface ReactionHeaderActionsProps {
 
 export function ReactionHeaderActions({ reactionId, previewRef }: Readonly<ReactionHeaderActionsProps>) {
   const { datasetId: rawDatasetId } = useParams<{ datasetId: string }>();
-  const datasetId = parseInt(rawDatasetId);
+  const datasetId = Number.parseInt(rawDatasetId);
   const reaction = useSelector(selectReactionById(reactionId));
   const onPreviewSave = useCallback(() => {
     copyPreviewAsImage(previewRef.current);

--- a/ui/src/features/reactions/ReactionList/DatasetReactionCard/DatasetReactionCard.tsx
+++ b/ui/src/features/reactions/ReactionList/DatasetReactionCard/DatasetReactionCard.tsx
@@ -33,7 +33,7 @@ interface ReactionTitleProps {
 
 function ReactionTitle({ index, id }: Readonly<ReactionTitleProps>) {
   const { datasetId: rawDatasetId } = useParams<{ datasetId: string }>();
-  const datasetId = parseInt(rawDatasetId);
+  const datasetId = Number.parseInt(rawDatasetId);
   const reaction = useSelector(selectReactionById(id));
   const copyToClipboardOptions: Array<CopyButtonOptions> = [
     {

--- a/ui/src/store/entities/reactions/reactions.converters.ts
+++ b/ui/src/store/entities/reactions/reactions.converters.ts
@@ -113,9 +113,9 @@ export function convertReactionFloatsToDoubles(reactionPart: unknown): void {
         convertReactionFloatsToDoubles(value);
       } else if (typeof value === 'number') {
         if (Number.isInteger(value)) {
-          dynamicReactionPart[key] = parseInt(value.toString(), 10);
+          dynamicReactionPart[key] = Number.parseInt(value.toString(), 10);
         } else {
-          dynamicReactionPart[key] = parseFloat(value.toPrecision(PRECISION));
+          dynamicReactionPart[key] = Number.parseFloat(value.toPrecision(PRECISION));
         }
       }
     });

--- a/ui/src/store/entities/reactions/reactions.utils.ts
+++ b/ui/src/store/entities/reactions/reactions.utils.ts
@@ -197,7 +197,7 @@ function parseErrorWarning(text: string, reaction: AppReaction): ErrorWarningMes
   const [error, ...rest] = text.split(':');
   const path = error.replace(/\[(")*/g, '.').replace(/(")*]/g, '');
   const reactionComponentPath = path.split('.').map(item => {
-    const parsedNumber = parseInt(item);
+    const parsedNumber = Number.parseInt(item);
     if (Number.isNaN(parsedNumber)) {
       return item;
     }

--- a/ui/src/store/entities/templates/templates.thunks.ts
+++ b/ui/src/store/entities/templates/templates.thunks.ts
@@ -43,7 +43,7 @@ import type { ThunkCustomWrapper } from 'common/types/store/thunk.ts';
 import { downloadAsJson, downloadFile } from '../../utils/downloadFile.thunks.ts';
 import { getReactionPreviews } from '../reactions/reactions.utils.ts';
 
-const getTemplateIdNumber = (templateId: string): number => parseInt(templateId.split('_')[1]);
+const getTemplateIdNumber = (templateId: string): number => Number.parseInt(templateId.split('_')[1]);
 const getTemplateIdString = (templateId: number): string => `template_${templateId}`;
 
 const parseTemplate = ({

--- a/ui/src/store/features/enumerationWorker/worker.ts
+++ b/ui/src/store/features/enumerationWorker/worker.ts
@@ -68,7 +68,7 @@ function getNumberArrayOrError(value: ValueType, variable: Variable): Array<numb
   if (typeof value !== 'string') {
     throw produceValueTypeError('number array', variable);
   }
-  const values = value.split(',').map(item => parseFloat(item));
+  const values = value.split(',').map(item => Number.parseFloat(item));
   if (values.some(item => Number.isNaN(item))) {
     throw produceValueTypeError('number array', variable);
   }


### PR DESCRIPTION
## Summary

Batch 3 of the SonarCloud cleanup (#671) — resolves `typescript:S7773` ("Prefer `Number.parseInt`/`Number.parseFloat`") across the UI (14 call sites). Purely mechanical via a lookbehind-guarded replacement; no behavior change.

## Test plan
- [x] `tsc`, `eslint`, `prettier`, `npm run build` clean
- [ ] SonarCloud PR gate green (S7773 resolved, no new issues)

Part of #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR mechanically replaces all 14 global `parseInt`/`parseFloat` call sites in the UI with `Number.parseInt`/`Number.parseFloat` to satisfy SonarCloud rule S7773. Since `Number.parseInt === parseInt` and `Number.parseFloat === parseFloat` are guaranteed by the ECMAScript specification, there is zero runtime behavior change.

- **13 files touched**, all changes are single-line symbol renames with no logic modifications.
- The `reactions.converters.ts` change already included an explicit radix-10 argument on the integer branch; the float branch correctly uses `Number.parseFloat` which does not accept a radix.

<h3>Confidence Score: 5/5</h3>

All 14 changes are single-symbol renames with no logic impact; safe to merge.

Every change is a guaranteed no-op substitution — the global and Number-namespaced parse functions are the same object in the JS runtime. No conditional branches, data flows, or interfaces are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.converters.ts | Mechanical: parseInt/parseFloat → Number.parseInt/Number.parseFloat in convertReactionFloatsToDoubles; includes explicit radix 10 for the integer branch. |
| ui/src/store/features/enumerationWorker/worker.ts | Mechanical: parseFloat → Number.parseFloat in getNumberArrayOrError; no behavior change. |
| ui/src/features/enumeration/EnumerationSetup/TemplateFileSelector/TemplateFileSelector.tsx | Mechanical: parseFloat → Number.parseFloat in cast helper; no behavior change. |
| ui/src/store/entities/reactions/reactions.utils.ts | Mechanical: parseInt → Number.parseInt in parseErrorWarning path parser; no behavior change. |
| ui/src/store/entities/templates/templates.thunks.ts | Mechanical: parseInt → Number.parseInt in getTemplateIdNumber; no behavior change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Use Number.parseInt/parseFloat over the ..."](https://github.com/open-reaction-database/ord-app/commit/fde0e856a497639b5a9d55b9b1f366050633e2d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34755073)</sub>

<!-- /greptile_comment -->