### PR TITLE
Sonar: remove unused unpacked locals (S1481)

### DIFF
--- a/ord_app/service_api/domain/reactions.py
+++ b/ord_app/service_api/domain/reactions.py
@@ -163,7 +163,7 @@ class ReactionsUseCase:
 
     async def get(self, dataset_id: int, reaction_id: int):
         if reaction := await self.reaction_repo.get(id=reaction_id, dataset_id=dataset_id):
-            is_valid, errors, warning = await async_validate_pb_reaction(reaction.pb)
+            _, errors, warning = await async_validate_pb_reaction(reaction.pb)
             reaction.validation = {"errors": errors, "warnings": warning}
             return reaction
         raise EntityNotFoundError(f"Reaction with id={reaction_id} not found")

--- a/ord_app/service_api/schemas/datasets.py
+++ b/ord_app/service_api/schemas/datasets.py
@@ -57,7 +57,7 @@ class DatasetWithReactionCountResponseSchema(DatasetResponseSchema):
     @classmethod
     def reaction_count(cls, data: Any):  # noqa: F811
         if isinstance(data, (Row, tuple)):
-            dataset, rct_total, rct_invalid, rct_valid, rct_none = data
+            _, rct_total, rct_invalid, rct_valid, rct_none = data
             # first element of the data is Dataset ORM object
             # second is reactions count
             data[0].reactions_count = _DatasetReactionCountingSchema(

--- a/ord_app/tests/conftest.py
+++ b/ord_app/tests/conftest.py
@@ -181,7 +181,7 @@ async def create_test_reaction(
     is_valid=None
 ) -> ReactionModel:
     pb_reaction = pb_reaction or Reaction(reaction_id=fake.uuid4())
-    user, _, group = mock_authenticated_user
+    user, *_ = mock_authenticated_user
     reaction = ReactionModel(
         pb_reaction_id=pb_reaction.reaction_id,
         dataset=dataset,

--- a/ord_app/tests/test_groups/test_add_group_members.py
+++ b/ord_app/tests/test_groups/test_add_group_members.py
@@ -17,7 +17,7 @@ from ord_app.tests.conftest import create_test_user_with_group
 
 
 async def test_add_group_member(api_client, mock_authenticated_user, test_db_session):
-    user, _, group = mock_authenticated_user
+    *_, group = mock_authenticated_user
     extra_user, _ = await create_test_user_with_group(test_db_session)
 
     payload = {"identity": extra_user.email, "role": "admin"}

--- a/ord_app/tests/test_groups/test_create_groups.py
+++ b/ord_app/tests/test_groups/test_create_groups.py
@@ -20,7 +20,6 @@ faker = Faker()
 
 
 async def test_create_group(api_client, mock_authenticated_user):
-    user, _, group = mock_authenticated_user
     payload = {"name": faker.company()}
     response_data = api_client.post("/api/v1/groups", json=payload).raise_for_status().json()
     assert payload["name"] == response_data["name"]

--- a/ord_app/tests/test_groups/test_get_group_members.py
+++ b/ord_app/tests/test_groups/test_get_group_members.py
@@ -14,7 +14,7 @@
 
 
 async def test_list_current_user_groups(api_client, mock_authenticated_user):
-    user, _, group = mock_authenticated_user
+    *_, group = mock_authenticated_user
 
     response_data = api_client.get("/api/v1/groups").raise_for_status().json()[0]
 
@@ -24,7 +24,7 @@ async def test_list_current_user_groups(api_client, mock_authenticated_user):
 
 
 async def test_get_group(api_client, mock_authenticated_user):
-    user, _, group = mock_authenticated_user
+    *_, group = mock_authenticated_user
 
     response_data = api_client.get(f"/api/v1/groups/{group.id}").raise_for_status().json()
 

--- a/ord_app/tests/test_groups/test_update_group.py
+++ b/ord_app/tests/test_groups/test_update_group.py
@@ -17,7 +17,7 @@ faker = Faker()
 
 
 async def test_update_group(api_client, mock_authenticated_user):
-    user, _, group = mock_authenticated_user
+    *_, group = mock_authenticated_user
     payload = {"name": faker.company()}
     response_data = api_client.patch(f"/api/v1/groups/{group.id}", json=payload).raise_for_status().json()
     assert payload["name"] == response_data["name"]

--- a/ord_app/tests/test_templates/test_delete_templates.py
+++ b/ord_app/tests/test_templates/test_delete_templates.py
@@ -48,6 +48,5 @@ async def test_delete_foreign_template(api_client, mock_authenticated_user, test
 
 
 async def test_delete_non_existent_template(api_client, mock_authenticated_user):
-    user, *_, = mock_authenticated_user
     response = api_client.delete("/api/v1/templates/100500")
     assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/ord_app/tests/test_templates/test_update_templates.py
+++ b/ord_app/tests/test_templates/test_update_templates.py
@@ -51,7 +51,6 @@ async def test_update_foreign_template(api_client, mock_authenticated_user, test
 
 
 async def test_get_non_existent_template(api_client, mock_authenticated_user, test_db_session):
-    user, *_, = mock_authenticated_user
     payload = {
         "binpb": b64encode(Reaction(reaction_id=fake.name()).SerializeToString()).decode(),
         "name": fake.name(),

--- a/ord_app/tests/tests_datasets/test_common_datasets.py
+++ b/ord_app/tests/tests_datasets/test_common_datasets.py
@@ -24,7 +24,7 @@ def parse_dt(dt):
 
 
 async def test_dataset_modified_at(api_client, mock_authenticated_user):
-    user, _, group = mock_authenticated_user
+    *_, group = mock_authenticated_user
 
     payload = {"name": fake.company(), "description": fake.text(5)}
     resp1 = api_client.post(f"/api/v1/groups/{group.id}/datasets", json=payload).raise_for_status().json()

--- a/ord_app/tests/tests_datasets/test_create_dataset.py
+++ b/ord_app/tests/tests_datasets/test_create_dataset.py
@@ -98,7 +98,7 @@ async def test_upload_dataset_with_reaction_validation(api_client, mock_authenti
     assert {True,} == set((await test_db_session.scalars(stmt)).all())
 
 async def test_upload_wrong_file_extension(api_client, mock_authenticated_user):
-    user, _, group = mock_authenticated_user
+    *_, group = mock_authenticated_user
 
     response_data = api_client.post(
         f"/api/v1/groups/{group.id}/datasets/upload", files={"file": ("wrong.pdf", BytesIO(b"pdf"))}
@@ -107,7 +107,7 @@ async def test_upload_wrong_file_extension(api_client, mock_authenticated_user):
 
 
 async def test_upload_wrong_file(api_client, mock_authenticated_user):
-    user, _, group = mock_authenticated_user
+    *_, group = mock_authenticated_user
 
     response_data = api_client.post(
         f"/api/v1/groups/{group.id}/datasets/upload", files={"file": ("wrongfile.pb", BytesIO(b"pdf"))}
@@ -116,7 +116,7 @@ async def test_upload_wrong_file(api_client, mock_authenticated_user):
 
 
 async def test_dataset_extend(api_client, mock_authenticated_user, test_db_session):
-    user, _, group = mock_authenticated_user
+    user, *_ = mock_authenticated_user
     dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
     reaction_id = faker.uuid4()
     reaction = ReactionModel(

--- a/ord_app/tests/tests_datasets/test_enumerate.py
+++ b/ord_app/tests/tests_datasets/test_enumerate.py
@@ -19,7 +19,7 @@ from ord_schema.proto.reaction_pb2 import Reaction
 faker = Faker()
 
 async def test_create_enumerate_dataset(api_client, mock_authenticated_user, test_db_session):
-    user, _, group = mock_authenticated_user
+    *_, group = mock_authenticated_user
     payload = {
         "name": faker.name(),
         "description": faker.text(),

--- a/ord_app/tests/tests_datasets/test_get_dataset_group.py
+++ b/ord_app/tests/tests_datasets/test_get_dataset_group.py
@@ -19,11 +19,11 @@ faker = Faker()
 
 
 async def test_get_dataset_groups(api_client, mock_authenticated_user, test_db_session):
-    primary_user, set_user_auth, primary_group = mock_authenticated_user
+    *_, primary_group = mock_authenticated_user
     primary_dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
 
     # share primary dataset by primary user to the secondary user
-    secondary_user, secondary_group = await create_test_user_with_group(test_db_session)
+    _, secondary_group = await create_test_user_with_group(test_db_session)
     share_response_data = api_client.post(
         f"/api/v1/groups/{primary_group.id}/datasets/{primary_dataset.id}/share",
         json={"secondary_group_id": secondary_group.id}

--- a/ord_app/tests/tests_datasets/test_share_dataset.py
+++ b/ord_app/tests/tests_datasets/test_share_dataset.py
@@ -54,7 +54,7 @@ async def test_share_and_unshare_dataset(api_client, mock_authenticated_user, te
     assert secondary_group_datasets["items"][0]["id"] == primary_dataset.id
 
     # And secondary user cannot share that dataset
-    foreign_user, foreign_group = await create_test_user_with_group(test_db_session)
+    _, foreign_group = await create_test_user_with_group(test_db_session)
     secondary_user_dataset = api_client.get(f"/api/v1/datasets/{primary_dataset.id}").raise_for_status().json()
     assert primary_dataset.id == secondary_user_dataset["id"]
     assert False is secondary_user_dataset["is_sharable"]

--- a/ord_app/tests/tests_reactions/test_get_reactions.py
+++ b/ord_app/tests/tests_reactions/test_get_reactions.py
@@ -17,7 +17,6 @@ from ord_app.tests.conftest import create_test_dataset, create_test_reaction
 
 
 async def test_paginate_reactions(api_client, mock_authenticated_user, test_db_session):
-    user, _, group = mock_authenticated_user
     dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
     await create_test_reaction(test_db_session, mock_authenticated_user, dataset)
 
@@ -25,7 +24,6 @@ async def test_paginate_reactions(api_client, mock_authenticated_user, test_db_s
     assert response_data["total"] == 1
 
 async def test_paginate_query_reactions(api_client, mock_authenticated_user, test_db_session):
-    user, _, group = mock_authenticated_user
     dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
     reaction_is_valid_none = await create_test_reaction(test_db_session, mock_authenticated_user, dataset)
     reaction_is_valid_true = await create_test_reaction(
@@ -64,7 +62,6 @@ async def test_paginate_query_reactions(api_client, mock_authenticated_user, tes
 
 
 async def test_get_reaction(api_client, mock_authenticated_user, test_db_session):
-    user, _, group = mock_authenticated_user
     dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
     reaction = await create_test_reaction(test_db_session, mock_authenticated_user, dataset)
 
@@ -73,7 +70,6 @@ async def test_get_reaction(api_client, mock_authenticated_user, test_db_session
 
 
 async def test_search_reaction(api_client, mock_authenticated_user, test_db_session):
-    user, _, group = mock_authenticated_user
     dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
     reaction = await create_test_reaction(test_db_session, mock_authenticated_user, dataset)
 
@@ -84,7 +80,6 @@ async def test_search_reaction(api_client, mock_authenticated_user, test_db_sess
 
 
 async def test_download_reaction(api_client, mock_authenticated_user, test_db_session):
-    user, _, group = mock_authenticated_user
     dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
     reaction = await create_test_reaction(test_db_session, mock_authenticated_user, dataset)
 


### PR DESCRIPTION
## Summary

Batch 4 of the SonarCloud cleanup (#671) — resolves all **30** `python:S1481` findings ("unused local variable").

These are all tuple-unpacking assignments that bound names never read in the function body:
- Partial unpacks collapse to `*_` / `_` (keeping only the used binding), e.g. `user, _, group = mock_authenticated_user` → `*_, group = mock_authenticated_user`.
- Fully-unused lines (neither `user` nor `group` referenced) are dropped entirely.

The `mock_authenticated_user` fixture stays in each test signature — its side effect provisions the authenticated user via dependency override, so it must be requested even when its return value is unused.

Two non-test sites: `reactions.py` (`is_valid` → `_`) and `datasets.py` (`dataset` → `_`, the value is read via `data[0]`). No behavior change anywhere.

## Test plan
- [x] `ruff check` clean
- [x] `py_compile` clean on all touched files
- [ ] CI `test_python` (ubuntu + macos) green
- [ ] SonarCloud PR gate green (S1481 resolved, no new issues)

Part of #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes 30 unused local variables flagged by SonarCloud rule S1481, all arising from tuple-unpacking assignments where some bound names were never read. No logic is changed anywhere.

- Test files collapse partial unpacks to `*_`/`_` or drop the entire assignment when no element is used (the `mock_authenticated_user` fixture is still requested for its side-effect dependency override).
- Two production sites are cleaned up: `reactions.py` discards the unused `is_valid` return value with `_`, and `datasets.py` renames the unused `dataset` unpack element to `_` while continuing to access the dataset via `data[0]`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — every change is a mechanical removal of bound-but-never-read names with no effect on runtime behavior.

All edits are dead-name elimination: production code still reads the same tuple indices (data[0], errors, warning), and every test fixture that must run for its side effect is still declared in the function signature. No logic paths, return values, or assertions are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ord_app/service_api/domain/reactions.py | Renames unused `is_valid` tuple element to `_`; the value was never referenced in the function body. |
| ord_app/service_api/schemas/datasets.py | Renames unused `dataset` unpack element to `_`; `data[0]` is still used directly, preserving behavior. |
| ord_app/tests/conftest.py | Collapses `create_test_reaction` unpacking to `user, *_` since only `user` is needed; `create_test_dataset` is unchanged and still uses explicit 3-element unpack. |
| ord_app/tests/tests_datasets/test_get_dataset_group.py | Drops `primary_user` and `set_user_auth` bindings (neither used in body); `create_test_user_with_group` correctly unpacks to `_, secondary_group`. |
| ord_app/tests/tests_reactions/test_get_reactions.py | Drops five fully-unused `user, _, group = mock_authenticated_user` lines across four test functions; fixture is still requested for side effects. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[mock_authenticated_user fixture] -->|yields user, set_mock_user, group| B{Binding needed?}
    B -->|only group| C["*_, group = mock_authenticated_user"]
    B -->|only user| D["user, *_ = mock_authenticated_user"]
    B -->|nothing| E[Drop assignment entirely\nfixture still requested for side effect]
    B -->|user + group| F["user, _, group = mock_authenticated_user\n(unchanged where both used)"]
    G[create_test_user_with_group] -->|returns user, group| H{User needed?}
    H -->|only group| I["_, group = create_test_user_with_group(...)"]
    H -->|both| J["user, group = create_test_user_with_group(...)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Sonar: remove/rename unused unpacked loc..."](https://github.com/open-reaction-database/ord-app/commit/497e86f7cf815cc46b9a30c5205dedf50b167781) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34755752)</sub>

<!-- /greptile_comment -->