### PR TITLE
Sonar: remove unnecessary type assertions (S4325)

### DIFF
--- a/ui/src/common/components/inputs/ValuePrecisionUnitControl/ValuePrecisionUnitControl.tsx
+++ b/ui/src/common/components/inputs/ValuePrecisionUnitControl/ValuePrecisionUnitControl.tsx
@@ -66,7 +66,7 @@ export function ValuePrecisionUnitControl({
 
   const handleChange = (name: keyof ValuePrecisionUnit, newValue: string | number | null) => {
     const previousValue = uncontrolledValue ?? {};
-    uncontrolledOnChange({ ...previousValue, [name]: newValue } as ValuePrecisionUnit);
+    uncontrolledOnChange({ ...previousValue, [name]: newValue });
   };
 
   const unitOnChange = handleChange.bind(null, 'units');

--- a/ui/src/common/hooks/useAppUncontrolled.ts
+++ b/ui/src/common/hooks/useAppUncontrolled.ts
@@ -84,7 +84,7 @@ export function useAppUncontrolled<T>({
   }, [setUncontrolledValue, defaultValue]);
 
   if (value !== undefined) {
-    return [value as T, onChange, true];
+    return [value, onChange, true];
   }
 
   return [uncontrolledValue as T, handleUncontrolledChange, false];

--- a/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationResult.tsx
+++ b/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationResult.tsx
@@ -46,7 +46,7 @@ export function ReactionValidationResult({ reactionId }: Readonly<ReactionValida
       {hasErrorsWarnings && (
         <ReactionValidationList
           opened={opened}
-          validation={validation!}
+          validation={validation}
           onClose={close}
         />
       )}

--- a/ui/src/features/reactions/ReactionView/Setup/Setup.tsx
+++ b/ui/src/features/reactions/ReactionView/Setup/Setup.tsx
@@ -60,7 +60,7 @@ export function Setup({ reactionId }: ReactionViewSectionProps) {
             { label: 'Details', render: setup => setup.vessel.material.details },
           ]}
         />
-        {Object.values(setup.automationCode as Record<string, AppData>).map(automationCode => (
+        {Object.values(setup.automationCode).map(automationCode => (
           <EntityListItem
             key={automationCode.id}
             historyPathComponents={[[ENTITY_FIELD]]}

--- a/ui/src/store/entities/reactions/reactions.reducer.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.ts
@@ -65,10 +65,7 @@ const reactionsById = createReducer<ItemsById<ReactionOrTemplate>>({}, builder =
     (state, { payload: { reactionId, pathComponents, newValue } }) => {
       const reaction = state[reactionId];
       const updatedReaction: AppReaction = linkReactionEntities(
-        deepMergeWithArrayMerge(
-          reaction.data,
-          generateDeepPartialReactionByPath(pathComponents, newValue) as unknown as AppReaction,
-        ),
+        deepMergeWithArrayMerge(reaction.data, generateDeepPartialReactionByPath(pathComponents, newValue)),
       );
       return {
         ...state,


### PR DESCRIPTION
## Summary

Batch 5 of the SonarCloud cleanup (#671) — addresses `typescript:S4325` ("unnecessary type assertion").

Removes **5 of the 9** flagged assertions that the project's strict `tsc -b` build confirms are genuinely redundant. Type assertions are compile-time only, so each removal is a verified no-op:

| File | Removed |
|------|---------|
| `Setup.tsx` | `as Record<string, AppData>` — `automationCode` is already typed |
| `useAppUncontrolled.ts` | `as T` — `value` is narrowed to `T` after the `!== undefined` guard |
| `ValuePrecisionUnitControl.tsx` | `as ValuePrecisionUnit` — receiver accepts the source type |
| `reactions.reducer.ts` | `as unknown as AppReaction` — `deepMergeWithArrayMerge` accepts the source type |
| `ReactionValidationResult.tsx` | non-null `!` — the prop already accepts the nullable type |

The other **4** S4325 findings are **Sonar false positives**: those assertions are load-bearing under the project's `tsconfig` (which is stricter than Sonar's TS analyzer) and removing them breaks the build. Verified by reverting each after `npm run build` failed:
- `Notes.tsx` — `ValueType` includes `undefined`; the assertion narrows to satisfy the `[string, string]` return type.
- `ImportFromJSON.tsx` — `FormType.file` is `File | null` but `ImportTemplatePayload.file` is `File`.
- `reactionNodeToComponent.ts` — the heterogeneous component map needs the `as ReactionNodeToComponent` coercion.
- `MeasurementValueControl.tsx` — `{ type, value }` widens past the discriminated `ReactionMeasurementValue` union.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean
- [x] `npm run build` (strict `tsc -b` + vite) green
- [ ] SonarCloud PR gate green

Part of #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes 5 redundant TypeScript type assertions flagged by SonarCloud rule S4325. All removals are compile-time no-ops confirmed by a clean `tsc -b` + `npm run build` run.

- **`useAppUncontrolled.ts`** and **`ReactionValidationResult.tsx`**: assertions dropped because TypeScript's control-flow analysis already narrows the types at those sites (post-`!== undefined` guard and aliased-condition narrowing via `hasErrorsWarnings`, respectively).
- **`Setup.tsx`** and **`reactions.reducer.ts`**: casts removed because the declared types of the targets already match the source types.
- **`ValuePrecisionUnitControl.tsx`**: `as ValuePrecisionUnit` on an object spread removed because the receiver accepts the inferred type directly.

<h3>Confidence Score: 5/5</h3>

All changes are compile-time only — removing type assertions has zero runtime effect and the build passes cleanly.

Every assertion removed has been verified as genuinely redundant by a successful strict tsc -b build. The PR author also identified and explicitly retained the 4 load-bearing assertions that Sonar incorrectly flagged, demonstrating careful validation. No logic, data flow, or runtime behavior is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/inputs/ValuePrecisionUnitControl/ValuePrecisionUnitControl.tsx | Removes redundant `as ValuePrecisionUnit` cast on object spread — the inferred type is already compatible with the receiver. |
| ui/src/common/hooks/useAppUncontrolled.ts | Removes `as T` narrowing cast inside the `value !== undefined` guard branch — TypeScript already narrows `value` to `T` at that point. |
| ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationResult.tsx | Drops non-null assertion on `validation` prop — TypeScript 4.4+ aliased-condition narrowing through the `hasErrorsWarnings` const variable makes the `!` redundant. |
| ui/src/features/reactions/ReactionView/Setup/Setup.tsx | Removes `as Record<string, AppData>` on `setup.automationCode` — the field is already typed correctly so the assertion was a no-op. |
| ui/src/store/entities/reactions/reactions.reducer.ts | Removes `as unknown as AppReaction` double cast on the `deepMergeWithArrayMerge` argument — the function accepts the source type directly. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["TypeScript source files"] --> B{Type assertion present?}
    B -- "as T / as X / !" --> C{Is it load-bearing\nunder strict tsc?}
    C -- Yes --> D["Keep assertion\n(4 Sonar false-positives)"]
    C -- No --> E["Remove assertion\n(5 files in this PR)"]
    E --> F["useAppUncontrolled.ts\n(value narrowed by !== undefined)"]
    E --> G["ReactionValidationResult.tsx\n(validation narrowed via hasErrorsWarnings)"]
    E --> H["Setup.tsx\n(automationCode already typed)"]
    E --> I["reactions.reducer.ts\n(deepMerge accepts source type)"]
    E --> J["ValuePrecisionUnitControl.tsx\n(spread result matches receiver)"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/sonar-unn..."](https://github.com/open-reaction-database/ord-app/commit/b185fd6fd8eae9bf339e3d2fd011670739153342) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34755958)</sub>

<!-- /greptile_comment -->