### PR TITLE
Sonar: prefer globalThis over window (S7764)

### DIFF
--- a/ui/src/common/configuration.constants.ts
+++ b/ui/src/common/configuration.constants.ts
@@ -19,5 +19,5 @@ export const auth0ClientId = import.meta.env.VITE_AUTH0_CLIENT_ID as string;
 export const auth0Audience = import.meta.env.VITE_AUTH0_AUDIENCE as string;
 export const auth0Issuer = import.meta.env.VITE_AUTH0_ISSUER as string;
 export const auth0Scope = import.meta.env.VITE_AUTH0_SCOPE as string;
-export const domain = window.location.origin;
+export const domain = globalThis.location.origin;
 export const showReactionPreviewDetails = import.meta.env.VITE_SHOW_REACTION_PREVIEW_DETAILS === 'TRUE';

--- a/ui/src/common/hooks/useAuth.ts
+++ b/ui/src/common/hooks/useAuth.ts
@@ -39,7 +39,7 @@ export function useAuth() {
     if (!isLoading && !isAuthenticated) {
       loginWithRedirect({
         appState: {
-          returnTo: window.location.href,
+          returnTo: globalThis.location.href,
         },
       });
     }
@@ -78,7 +78,7 @@ export function useAuth() {
       } catch (_: unknown) {
         loginWithRedirect({
           appState: {
-            returnTo: window.location.href,
+            returnTo: globalThis.location.href,
           },
         });
       }

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsKetcherEditor/ComponentsKetcherEditor.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsKetcherEditor/ComponentsKetcherEditor.tsx
@@ -34,7 +34,7 @@ interface ComponentsKetcherEditorProps {
   identifier: IdentifierData | null;
 }
 
-const appWindow = window as unknown as { ketcher: Ketcher | null };
+const appWindow = globalThis as unknown as { ketcher: Ketcher | null };
 
 const structServiceProvider = new StandaloneStructServiceProvider();
 

--- a/ui/src/features/reactions/ReactionList/DatasetReactionCard/DatasetReactionCard.tsx
+++ b/ui/src/features/reactions/ReactionList/DatasetReactionCard/DatasetReactionCard.tsx
@@ -38,7 +38,7 @@ function ReactionTitle({ index, id }: Readonly<ReactionTitleProps>) {
   const copyToClipboardOptions: Array<CopyButtonOptions> = [
     {
       label: 'Copy Reaction Link',
-      value: `${window.location.href}/reactions/${id}`,
+      value: `${globalThis.location.href}/reactions/${id}`,
     },
     { label: 'Copy Reaction ID', value: reaction.pb_reaction_id },
   ];

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -20,7 +20,7 @@ import { Buffer } from 'buffer';
 
 // Because ketcher depends on draft-js which requires setImmediate package
 // https://github.com/yuzujs/setImmediate
-window.global ||= window;
-window.Buffer = Buffer;
+globalThis.global ||= globalThis;
+globalThis.Buffer = Buffer;
 
 createRoot(document.getElementById('root')!).render(<AppRoot />);


### PR DESCRIPTION
## Summary

Batch 6 of the SonarCloud cleanup (#671) — resolves all **8** `typescript:S7764` ("Prefer `globalThis` over `window`") findings.

In a browser, `globalThis` and `window` reference the same object, so every substitution is a runtime no-op:
- `window.location.{origin,href}` accesses (configuration.constants.ts, useAuth.ts ×2, DatasetReactionCard.tsx)
- the ketcher `window as unknown as { ketcher }` cast (ComponentsKetcherEditor.tsx)
- the draft-js `global`/`Buffer` shims in main.tsx

Verified safe by the strict `tsc -b` build (the global-property augmentations on `main.tsx` resolve identically on `globalThis`).

## Test plan
- [x] `eslint`, `prettier --check` clean
- [x] `npm run build` (strict `tsc -b` + vite) green
- [ ] SonarCloud PR gate green

Part of #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces all `window` references with `globalThis` across five files, addressing SonarCloud rule S7764. Since `globalThis === window` in every supported browser, every substitution is a runtime no-op.

- `window.location.{origin,href}` accesses in `configuration.constants.ts`, `useAuth.ts`, and `DatasetReactionCard.tsx` are direct property-access swaps with identical runtime behaviour.
- The Ketcher `window as unknown as { ketcher }` cast and the draft-js `global`/`Buffer` shims in `main.tsx` are updated correspondingly, remaining semantically equivalent in a browser context.

<h3>Confidence Score: 5/5</h3>

All five substitutions are runtime no-ops in a browser — globalThis and window are the same object — and the strict TypeScript build confirms type safety.

Every change is a mechanical window → globalThis swap. In a browser context the two references are identical, so there is no altered behaviour anywhere in the changed files. The strict tsc -b build passing further confirms no type regressions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/main.tsx | Replaces `window.global ||= window` and `window.Buffer = Buffer` shims with `globalThis` equivalents; semantically identical in browser. |
| ui/src/common/configuration.constants.ts | Swaps `window.location.origin` for `globalThis.location.origin`; no behavioural change in a browser context. |
| ui/src/common/hooks/useAuth.ts | Two `window.location.href` usages replaced with `globalThis.location.href`; runtime behaviour unchanged. |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsKetcherEditor/ComponentsKetcherEditor.tsx | Ketcher global cast updated from `window as unknown as { ketcher }` to `globalThis as unknown as { ketcher }`; functionally equivalent. |
| ui/src/features/reactions/ReactionList/DatasetReactionCard/DatasetReactionCard.tsx | Clipboard link construction updated to use `globalThis.location.href`; no behavioural change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Browser environment<br/>(globalThis === window)"] --> B["configuration.constants.ts<br/>globalThis.location.origin"]
    A --> C["useAuth.ts ×2<br/>globalThis.location.href"]
    A --> D["DatasetReactionCard.tsx<br/>globalThis.location.href"]
    A --> E["ComponentsKetcherEditor.tsx<br/>globalThis as unknown as {ketcher}"]
    A --> F["main.tsx<br/>globalThis.global ||= globalThis<br/>globalThis.Buffer = Buffer"]
    B & C & D & E & F --> G["Identical runtime behaviour ✓"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/sonar-glo..."](https://github.com/open-reaction-database/ord-app/commit/cbeb35b8f49075f5e231b83609d7c114d261e1b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34756077)</sub>

<!-- /greptile_comment -->