### PR TITLE
Sonar: use Set.has over Array.includes (S7776)

### DIFF
--- a/ui/src/features/enumeration/EnumerationSetup/TemplateFileSelector/templateFileSelector.utils.ts
+++ b/ui/src/features/enumeration/EnumerationSetup/TemplateFileSelector/templateFileSelector.utils.ts
@@ -15,14 +15,14 @@
  */
 const allowedSymbols = /[A-Za-z0-9]/;
 const defaultDelimiter = ';';
-const lineBreaks: Array<string> = ['\n', '\r'];
+const lineBreaks = new Set(['\n', '\r']);
 
 export function guessDelimiter(fileContent: string): string {
   let firstLineDelimiters = '';
   let index = 0;
   while (index < fileContent.length) {
     const char = fileContent.charAt(index);
-    if (lineBreaks.includes(char)) {
+    if (lineBreaks.has(char)) {
       break;
     }
     if (!allowedSymbols.test(char)) {

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/reactionEntityForm.utils.ts
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/reactionEntityForm.utils.ts
@@ -60,14 +60,14 @@ export async function copyReactionPart(entityName: ReactionNodeEntity, reactionP
   }
 }
 
-const inputAliases = [ReactionNodeEntity.Inputs, ReactionNodeEntity.Input];
+const inputAliases = new Set([ReactionNodeEntity.Inputs, ReactionNodeEntity.Input]);
 
 function checkEntityNames(previousName: ReactionNodeEntity, currentName: ReactionNodeEntity): boolean {
   if (previousName === currentName) {
     return true;
   }
   // Input has two sidebars - with and without a name.
-  return inputAliases.includes(previousName) && inputAliases.includes(currentName);
+  return inputAliases.has(previousName) && inputAliases.has(currentName);
 }
 
 export async function pasteReactionPart(entityField: ReactionNodeEntity): Promise<[object | null, string]> {

--- a/ui/src/store/entities/reactions/reactionWorkups/reactionWorkups.constants.ts
+++ b/ui/src/store/entities/reactions/reactionWorkups/reactionWorkups.constants.ts
@@ -17,10 +17,10 @@ import type { WorkupType } from '../reactionEntityTypes/reactionEntityTypes.type
 import { workupTypeOptions } from '../reactionEntityTypes/reactionEntityTypes.models.ts';
 
 export namespace WorkupConstants {
-  const durationUnCompatibleTypes: Array<WorkupType> = ['UNSPECIFIED', 'ALIQUOT'];
+  const durationUnCompatibleTypes = new Set<WorkupType>(['UNSPECIFIED', 'ALIQUOT']);
 
   export const durationCompatibleTypes = workupTypeOptions.filter(
-    item => !durationUnCompatibleTypes.includes(item as WorkupType),
+    item => !durationUnCompatibleTypes.has(item as WorkupType),
   ) as Array<WorkupType>;
 
   export const aliquotCompatibleTypes: Array<WorkupType> = ['ALIQUOT', 'CUSTOM'];
@@ -47,15 +47,15 @@ export namespace WorkupConstants {
     'CUSTOM',
   ];
 
-  const stirringUnCompatibleTypes: Array<WorkupType> = [
+  const stirringUnCompatibleTypes = new Set<WorkupType>([
     'UNSPECIFIED',
     'FLASH_CHROMATOGRAPHY',
     'OTHER_CHROMATOGRAPHY',
     'WAIT',
     'ALIQUOT',
-  ];
+  ]);
 
   export const stirringCompatibleTypes = workupTypeOptions.filter(
-    item => !stirringUnCompatibleTypes.includes(item as WorkupType),
+    item => !stirringUnCompatibleTypes.has(item as WorkupType),
   ) as Array<WorkupType>;
 }

--- a/ui/src/store/entities/reactions/reactions.utils.ts
+++ b/ui/src/store/entities/reactions/reactions.utils.ts
@@ -111,13 +111,20 @@ export function getDeepReactionPart(reaction: any, pathComponents: ReactionPathC
   }
 }
 
-const nodeEntitiesNamesWithoutCollection = ['authenticStandard', 'notes', 'conditions', 'provenance', 'input', 'setup'];
+const nodeEntitiesNamesWithoutCollection = new Set([
+  'authenticStandard',
+  'notes',
+  'conditions',
+  'provenance',
+  'input',
+  'setup',
+]);
 
 export function reactionFlatPathToSidebars(pathComponents: ReactionPathComponents): Array<ReactionPathComponents> {
   const result: Array<ReactionPathComponents> = [];
   for (let i = 0; i < pathComponents.length; i++) {
     const pathComponent = pathComponents[i];
-    if (nodeEntitiesNamesWithoutCollection.includes(pathComponent as string)) {
+    if (nodeEntitiesNamesWithoutCollection.has(pathComponent as string)) {
       result.push(pathComponents.slice(0, i + 1));
       continue;
     }

--- a/ui/src/store/utils/replaceNameIdInReactionComponentPath.ts
+++ b/ui/src/store/utils/replaceNameIdInReactionComponentPath.ts
@@ -18,9 +18,9 @@ import type { ReactionPathComponents } from '../../common/types/reaction/reactio
 import type { WithIdName } from '../entities/reactions/reactionEntity/reactionEntity.types.ts';
 import { getDeepReactionPart } from '../entities/reactions/reactions.utils.ts';
 
-const mapKeys = ['inputs', 'analyses', 'features', 'analysisData', 'automationCode'];
+const mapKeys = new Set(['inputs', 'analyses', 'features', 'analysisData', 'automationCode']);
 
-const conditionsWithMeasurements = ['temperature', 'electrochemistry', 'pressure'];
+const conditionsWithMeasurements = new Set(['temperature', 'electrochemistry', 'pressure']);
 
 type NamedEntity = WithIdName<unknown>;
 type NamedEntityMap = Record<string, NamedEntity>;
@@ -40,7 +40,7 @@ export function replaceNameIdInReactionComponentPath(
   for (let index = 0; index < path.length; index++) {
     const pathComponent = path[index];
     updatedPath = updatedPath.concat([pathComponent]);
-    if (mapKeys.includes(pathComponent as string)) {
+    if (mapKeys.has(pathComponent as string)) {
       const nameId = path[index + 1] as string;
       let reactionPart: Record<string, WithIdName<unknown>>;
       if (replaceWith === 'id') {
@@ -61,7 +61,7 @@ export function replaceNameIdInReactionComponentPath(
     const currentValue = updatedPath[index];
     if (
       index > 0 &&
-      conditionsWithMeasurements.includes(updatedPath[index - 1] as string) &&
+      conditionsWithMeasurements.has(updatedPath[index - 1] as string) &&
       typeof currentValue === 'string'
     ) {
       if (currentValue === 'measurements') {


### PR DESCRIPTION
## Summary

Batch 7 of the SonarCloud cleanup (#671) — resolves all **7** `typescript:S7776` findings ("`X` should be a `Set`, use `X.has()`").

Each affected `const` is a fixed lookup list used **only** for membership tests (verified by grepping every reference — no iteration, indexing, or spread), so converting the array literal to a `Set` and `.includes()` → `.has()` is behavior-preserving and clearer:

| File | Const |
|------|-------|
| templateFileSelector.utils.ts | `lineBreaks` |
| reactionEntityForm.utils.ts | `inputAliases` |
| reactionWorkups.constants.ts | `durationUnCompatibleTypes`, `stirringUnCompatibleTypes` |
| reactions.utils.ts | `nodeEntitiesNamesWithoutCollection` |
| replaceNameIdInReactionComponentPath.ts | `mapKeys`, `conditionsWithMeasurements` |

## Test plan
- [x] `eslint`, `prettier --check` clean
- [x] `npm run build` (strict `tsc -b` + vite) green
- [x] `vitest run` green
- [ ] SonarCloud PR gate green

Part of #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Converts seven fixed lookup arrays to `Set` and replaces every `.includes()` call with `.has()`, resolving all SonarCloud `typescript:S7776` findings. All affected constants are used exclusively for membership tests with no iteration, indexing, or spread, so the transformation is strictly behavior-preserving.

- Five files are touched across two feature areas and the store layer; each change is a one-for-one mechanical substitution with no logic alterations.
- Type annotations are dropped where TypeScript can infer the element type from the `Set` constructor, and explicit `Set<WorkupType>` generics are preserved where needed for narrowing inside `reactionWorkups.constants.ts`.

<h3>Confidence Score: 5/5</h3>

All changes are isolated, mechanical Array → Set conversions on constants used only for membership checks — no functional paths are altered.

Every converted constant is touched in exactly the same way: the array literal becomes a Set, and each .includes() becomes .has(). Set.has and Array.includes have identical semantics for the string/enum values used here (strict equality, no NaN/undefined edge cases in scope), so no behavioral difference is possible. No new branches, no changed exports, no schema or API impact.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/features/enumeration/EnumerationSetup/TemplateFileSelector/templateFileSelector.utils.ts | Converts lineBreaks from Array<string> to Set; replaces .includes() with .has(). Pure membership-check usage confirmed. |
| ui/src/features/reactions/ReactionEntities/ReactionEntityForm/reactionEntityForm.utils.ts | Converts inputAliases from array to Set; both .has() call sites are pure membership tests. Behavior unchanged. |
| ui/src/store/entities/reactions/reactionWorkups/reactionWorkups.constants.ts | Converts durationUnCompatibleTypes and stirringUnCompatibleTypes to Set<WorkupType>; used only in .filter() membership checks. Explicit type parameter retained. |
| ui/src/store/entities/reactions/reactions.utils.ts | Converts nodeEntitiesNamesWithoutCollection to a Set of string literals; sole usage is .has() membership test inside reactionFlatPathToSidebars. |
| ui/src/store/utils/replaceNameIdInReactionComponentPath.ts | Converts both mapKeys and conditionsWithMeasurements to Set; each is used only for .has() membership tests within the same function. No iteration or spread usage. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Array literal\n['a', 'b', ...]"] -->|"new Set([...])"| B["Set\nnew Set(['a', 'b', ...])"]
    C[".includes(x)"] -->|".has(x)"| D[".has(x)"]

    subgraph Files["Converted Constants"]
        F1["lineBreaks\ntemplateFileSelector.utils.ts"]
        F2["inputAliases\nreactionEntityForm.utils.ts"]
        F3["durationUnCompatibleTypes / stirringUnCompatibleTypes\nreactionWorkups.constants.ts"]
        F4["nodeEntitiesNamesWithoutCollection\nreactions.utils.ts"]
        F5["mapKeys / conditionsWithMeasurements\nreplaceNameIdInReactionComponentPath.ts"]
    end

    B --> Files
    D --> Files

    style Files fill:#f0f8ff,stroke:#4a90d9
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Sonar: use Set.has over Array.includes f..."](https://github.com/open-reaction-database/ord-app/commit/113a9e64c6ea3cc98985bfa4f7db3709284a6f87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34756420)</sub>

<!-- /greptile_comment -->