### PR TITLE
Sonar: globalThis over window in gtag snippet (S7764)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -22,7 +22,7 @@ limitations under the License.
       src="https://www.googletagmanager.com/gtag/js?id=G-R9MFY2X2C7"
     ></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
+      globalThis.dataLayer = globalThis.dataLayer || [];
       function gtag() {
         dataLayer.push(arguments);
       }


### PR DESCRIPTION
## Summary

Closes out `javascript:S7764` — the remaining 2 findings, both in `ui/index.html`'s Google Analytics bootstrap (`window.dataLayer = window.dataLayer || []`). `globalThis === window` in the browser, so the analytics dataLayer initialization is unchanged.

(Companion to #676, which handled the `typescript:S7764` `.ts` occurrences.)

## Test plan
- [ ] CI green
- [ ] SonarCloud PR gate green

Part of #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the two `window` references in the Google Analytics `dataLayer` initialization with `globalThis` to close SonarCloud finding S7764. In a browser, `globalThis === window`, so analytics behavior is unchanged.

- The `gtag` function body (`dataLayer.push(arguments)`) keeps the bare unqualified identifier, which still resolves correctly because properties set on `globalThis` are accessible as global variables in browser scripts.
- No functional change; purely a linter-compliance update matching the companion `.ts` fix in #676.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a one-line mechanical substitution in a Google Analytics snippet with no functional impact in the browser.

The only changed line swaps window.dataLayer for globalThis.dataLayer; both resolve to the same object in every browser environment where gtag.js runs. The rest of the snippet is untouched, and the unqualified dataLayer reference inside gtag() continues to work as before.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/index.html | Replaces `window.dataLayer` with `globalThis.dataLayer` in the Google Analytics bootstrap snippet to satisfy SonarCloud rule S7764; functionally equivalent in browser contexts. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant gtag_script as gtag inline script
    participant globalThis as globalThis (≡ window)
    participant GTM as googletagmanager.com

    Browser->>GTM: async load gtag.js
    Browser->>gtag_script: execute inline script
    gtag_script->>globalThis: "globalThis.dataLayer = globalThis.dataLayer || []"
    gtag_script->>globalThis: define gtag() → dataLayer.push(arguments)
    gtag_script->>globalThis: gtag('js', new Date())
    gtag_script->>globalThis: gtag('config', 'G-R9MFY2X2C7')
    GTM-->>Browser: gtag.js loaded (reads window.dataLayer ≡ globalThis.dataLayer)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Sonar: prefer globalThis over window in ..."](https://github.com/open-reaction-database/ord-app/commit/326235109a07debc591e6a3f478ea63c1a616083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34756530)</sub>

<!-- /greptile_comment -->