### PR TITLE
Use Annotated[str, StringConstraints] over constr() in schemas (ty)

### DIFF
--- a/ord_app/service_api/schemas/datasets.py
+++ b/ord_app/service_api/schemas/datasets.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 from base64 import b64decode
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from uuid import uuid4
 
-from pydantic import Field, constr, field_validator, model_validator
+from pydantic import Field, StringConstraints, field_validator, model_validator
 from sqlalchemy import Row
 
 from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH, MAX_FIELD_LENGTH, BaseSchema
@@ -71,8 +71,8 @@ class DatasetWithReactionCountResponseSchema(DatasetResponseSchema):
 
 
 class DatasetCreateSchema(BaseSchema):
-    name: constr(max_length=MAX_CRITICAL_FIELD_LENGTH)
-    description: constr(max_length=MAX_FIELD_LENGTH) | None = ""
+    name: Annotated[str, StringConstraints(max_length=MAX_CRITICAL_FIELD_LENGTH)]
+    description: Annotated[str, StringConstraints(max_length=MAX_FIELD_LENGTH)] | None = ""
 
     @field_validator("name", mode="before")
     def set_name_default(cls, value: str | None) -> str:
@@ -82,8 +82,8 @@ class DatasetCreateSchema(BaseSchema):
 
 
 class DatasetEnumerateCreateSchema(BaseSchema):
-    name: constr(max_length=MAX_CRITICAL_FIELD_LENGTH)
-    description: constr(max_length=MAX_FIELD_LENGTH) | None = ""
+    name: Annotated[str, StringConstraints(max_length=MAX_CRITICAL_FIELD_LENGTH)]
+    description: Annotated[str, StringConstraints(max_length=MAX_FIELD_LENGTH)] | None = ""
     reactions: list[bytes]
 
     @field_validator("reactions", mode="before")

--- a/ord_app/service_api/schemas/groups.py
+++ b/ord_app/service_api/schemas/groups.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pydantic import constr
+from typing import Annotated
+
+from pydantic import StringConstraints
 
 from ord_app.service_api.models import UserRolesList
 from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH, BaseSchema
@@ -34,11 +36,11 @@ class GroupUserResponseSchema(BaseSchema):
 
 
 class GroupCreateSchema(BaseSchema):
-    name: constr(max_length=MAX_CRITICAL_FIELD_LENGTH)
+    name: Annotated[str, StringConstraints(max_length=MAX_CRITICAL_FIELD_LENGTH)]
 
 
 class GroupAddMemberSchema(BaseSchema):
-    identity: constr(min_length=5)
+    identity: Annotated[str, StringConstraints(min_length=5)]
     role: UserRolesList
 
 

--- a/ord_app/service_api/schemas/templates.py
+++ b/ord_app/service_api/schemas/templates.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from base64 import b64decode, b64encode
-from typing import Any
+from typing import Annotated, Any
 
 import orjson
 from ord_schema.proto.reaction_pb2 import Reaction
-from pydantic import Field, Json, constr, field_validator, model_validator
+from pydantic import Field, Json, StringConstraints, field_validator, model_validator
 
 from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH, BaseSchema
 from ord_app.service_api.schemas.reactions import get_molblocks
@@ -49,7 +49,7 @@ class TemplateResponseModel(BaseSchema):
 
 
 class TemplateCreateModel(BaseSchema):
-    name: constr(max_length=MAX_CRITICAL_FIELD_LENGTH)
+    name: Annotated[str, StringConstraints(max_length=MAX_CRITICAL_FIELD_LENGTH)]
     binpb: bytes | Any
     variables: Json
 
@@ -70,7 +70,7 @@ class TemplateCreateModel(BaseSchema):
 
 
 class TemplateUpdateModel(BaseSchema):
-    name: constr(max_length=MAX_CRITICAL_FIELD_LENGTH) | None = None
+    name: Annotated[str, StringConstraints(max_length=MAX_CRITICAL_FIELD_LENGTH)] | None = None
     binpb: bytes | None = None
     variables: Json | None = None
 


### PR DESCRIPTION
## Summary

Continues #681. Bare `constr(...)` annotations are function calls in type position, which `ty` (and pydantic's own v2 guidance) reject as `invalid-type-form`. Switches the 8 occurrences across the dataset/group/template schemas to the pydantic-v2 idiom:

```python
name: Annotated[str, StringConstraints(max_length=MAX_CRITICAL_FIELD_LENGTH)]
```

Behavior-identical — `constr(max_length=N)` produces exactly this `Annotated`/`StringConstraints` form under the hood in pydantic v2. Verified the constraints still reject out-of-range input at runtime, and the existing `*_with_character_limitations` tests cover the 422 path.

**Clears 8 `ty` diagnostics (35 → 27).**

## Test plan
- [x] `uvx ty check ord_app/` → 35 → 27
- [x] `ruff check` / `ruff format --check` clean; constraint enforcement verified at runtime
- [ ] CI green (`test_python` covers the character-limitation 422 cases)

Part of #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)