### PR TITLE
test(ui): unit tests for reaction path helpers + clearDependantFields

### DIFF
--- a/ui/src/store/entities/reactions/reactions.utils.test.ts
+++ b/ui/src/store/entities/reactions/reactions.utils.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  convertObjectToNullIfEmpty,
+  generateDeepPartialReactionByPath,
+  getDeepReactionPart,
+  removeDeepReactionPart,
+} from './reactions.utils.ts';
+
+describe('generateDeepPartialReactionByPath', () => {
+  it('returns the value directly for an empty path', () => {
+    expect(generateDeepPartialReactionByPath([], 'value')).toBe('value');
+  });
+
+  it('nests the value under string path components', () => {
+    expect(generateDeepPartialReactionByPath(['a'], 1)).toEqual({ a: 1 });
+    expect(generateDeepPartialReactionByPath(['a', 'b'], 1)).toEqual({ a: { b: 1 } });
+  });
+
+  it('creates arrays for numeric path components', () => {
+    expect(generateDeepPartialReactionByPath(['inputs', 0], 'x')).toEqual({ inputs: ['x'] });
+  });
+});
+
+describe('getDeepReactionPart', () => {
+  it('reads the value at the given path', () => {
+    expect(getDeepReactionPart({ a: { b: 1 } }, ['a', 'b'])).toBe(1);
+    expect(getDeepReactionPart({ items: [10, 20] }, ['items', 1])).toBe(20);
+  });
+
+  it('returns the whole object for an empty path', () => {
+    const reaction = { a: 1 };
+    expect(getDeepReactionPart(reaction, [])).toBe(reaction);
+  });
+
+  it('returns null when the path runs through a missing branch', () => {
+    expect(getDeepReactionPart({}, ['missing', 'deeper'])).toBeNull();
+  });
+});
+
+describe('removeDeepReactionPart', () => {
+  it('removes a top-level string key', () => {
+    expect(removeDeepReactionPart({ a: 1, b: 2 }, ['a'])).toEqual({ b: 2 });
+  });
+
+  it('removes an array element by numeric index', () => {
+    expect(removeDeepReactionPart([10, 20, 30], [1])).toEqual([10, 30]);
+  });
+
+  it('removes a nested key without touching siblings', () => {
+    expect(removeDeepReactionPart({ a: { b: 1, c: 2 } }, ['a', 'b'])).toEqual({ a: { c: 2 } });
+  });
+
+  it('removes a nested array element', () => {
+    expect(removeDeepReactionPart({ items: [10, 20, 30] }, ['items', 1])).toEqual({ items: [10, 30] });
+  });
+});
+
+describe('convertObjectToNullIfEmpty', () => {
+  it('returns null when every value is empty (undefined/null/"")', () => {
+    expect(convertObjectToNullIfEmpty({ a: '', b: null, c: undefined })).toBeNull();
+  });
+
+  it('returns the object when any value is non-empty', () => {
+    const object = { a: 'x', b: '' };
+    expect(convertObjectToNullIfEmpty(object)).toBe(object);
+  });
+
+  it('treats an enum key set to the unspecified value (0) as empty', () => {
+    expect(convertObjectToNullIfEmpty({ type: 0 }, ['type'])).toBeNull();
+  });
+
+  it('keeps a 0-valued key that is not declared as an enum key', () => {
+    const object = { type: 0 };
+    expect(convertObjectToNullIfEmpty(object)).toBe(object);
+  });
+});

--- a/ui/src/store/utils/clearDependantFields.test.ts
+++ b/ui/src/store/utils/clearDependantFields.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { clearDependantFields } from './clearDependantFields.ts';
+
+interface Sample {
+  keep: string;
+  dependant: string | null;
+}
+
+describe('clearDependantFields', () => {
+  it('nulls a field whose predicate is false', () => {
+    const result = clearDependantFields<Sample>({ keep: 'v', dependant: 'x' }, [['dependant', () => false]]);
+    expect(result).toEqual({ keep: 'v', dependant: null });
+  });
+
+  it('leaves a field whose predicate is true', () => {
+    const result = clearDependantFields<Sample>({ keep: 'v', dependant: 'x' }, [['dependant', () => true]]);
+    expect(result).toEqual({ keep: 'v', dependant: 'x' });
+  });
+
+  it('evaluates each predicate against the working copy', () => {
+    const result = clearDependantFields<Sample>({ keep: '', dependant: 'x' }, [
+      ['dependant', object => object.keep !== ''],
+    ]);
+    expect(result.dependant).toBeNull();
+  });
+
+  it('does not mutate the input object', () => {
+    const input: Sample = { keep: 'v', dependant: 'x' };
+    clearDependantFields<Sample>(input, [['dependant', () => false]]);
+    expect(input.dependant).toBe('x');
+  });
+});

--- a/ui/src/store/utils/clearDependantFields.test.ts
+++ b/ui/src/store/utils/clearDependantFields.test.ts
@@ -17,7 +17,7 @@ import { describe, it, expect } from 'vitest';
 import { clearDependantFields } from './clearDependantFields.ts';
 
 interface Sample {
-  keep: string;
+  keep: string | null;
   dependant: string | null;
 }
 
@@ -32,11 +32,14 @@ describe('clearDependantFields', () => {
     expect(result).toEqual({ keep: 'v', dependant: 'x' });
   });
 
-  it('evaluates each predicate against the working copy', () => {
-    const result = clearDependantFields<Sample>({ keep: '', dependant: 'x' }, [
-      ['dependant', object => object.keep !== ''],
+  it('evaluates each predicate against the working copy, not the original', () => {
+    // The first rule nulls `keep`; the second rule's predicate must observe that
+    // mutation. Were it reading the original object, `dependant` would survive.
+    const result = clearDependantFields<Sample>({ keep: 'set', dependant: 'x' }, [
+      ['keep', () => false],
+      ['dependant', object => object.keep !== null],
     ]);
-    expect(result.dependant).toBeNull();
+    expect(result).toEqual({ keep: null, dependant: null });
   });
 
   it('does not mutate the input object', () => {


### PR DESCRIPTION
## Summary

Extends the #662 coverage backfill with more pure, deterministic functions (no production code touched):

- **`generateDeepPartialReactionByPath`** — empty path, nested string keys, numeric components producing arrays.
- **`getDeepReactionPart`** — reads, empty-path identity, `null` on a missing branch.
- **`removeDeepReactionPart`** — top-level/nested string keys and array indices.
- **`convertObjectToNullIfEmpty`** — all-empty → `null`, non-empty passthrough, enum-key unspecified-value (`0`) handling.
- **`clearDependantFields`** — predicate true/false, evaluation against the working copy, no mutation of the input.

UI unit suite: **21 → 39** tests.

## Test plan
- [x] `vitest run` — 39/39 pass
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean
- [ ] CI green

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 18 new unit tests covering four pure utility functions in `reactions.utils.ts` and the `clearDependantFields` helper — no production code is touched.

- **`reactions.utils.test.ts`**: Tests `generateDeepPartialReactionByPath`, `getDeepReactionPart`, `removeDeepReactionPart`, and `convertObjectToNullIfEmpty`, covering empty-path identity, string/numeric path nesting, null-on-missing-branch, and enum-key zero handling.
- **`clearDependantFields.test.ts`**: Tests null-on-false-predicate, no-op-on-true, working-copy evaluation, and non-mutation of the input — with a local `Sample` interface that models the nullable field contract.

<h3>Confidence Score: 5/5</h3>

Test-only PR with no production code changes — safe to merge.

Both files are purely additive test suites for already-shipped, pure utility functions. The assertions are correct against the implementations, no test can produce a false positive or mask a real regression, and no shared state or side effects are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.utils.test.ts | New test file with 14 cases covering generateDeepPartialReactionByPath, getDeepReactionPart, removeDeepReactionPart, and convertObjectToNullIfEmpty — assertions match implementation behaviour correctly. |
| ui/src/store/utils/clearDependantFields.test.ts | New test file with 4 cases covering the null-on-false, no-op-on-true, predicate-receives-working-copy, and no-input-mutation contracts for clearDependantFields. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[reactions.utils.test.ts] --> B[generateDeepPartialReactionByPath]
    A --> C[getDeepReactionPart]
    A --> D[removeDeepReactionPart]
    A --> E[convertObjectToNullIfEmpty]

    B --> B1["empty path → value passthrough"]
    B --> B2["string keys → nested object"]
    B --> B3["numeric key → array"]

    C --> C1["nested key/index → value"]
    C --> C2["empty path → object identity"]
    C --> C3["missing branch → null"]

    D --> D1["top-level string key"]
    D --> D2["numeric index splice"]
    D --> D3["nested string key"]
    D --> D4["nested array index"]

    E --> E1["all empty → null"]
    E --> E2["any non-empty → object identity"]
    E --> E3["enum key = 0 → null"]
    E --> E4["non-enum key = 0 → object identity"]

    F[clearDependantFields.test.ts] --> G[clearDependantFields]
    G --> G1["predicate false → null field"]
    G --> G2["predicate true → no change"]
    G --> G3["predicate sees working copy"]
    G --> G4["input not mutated"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/tes..."](https://github.com/open-reaction-database/ord-app/commit/0a743b6d5fc14d1c04700773b3575a4769fd24de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34759482)</sub>

<!-- /greptile_comment -->