### PR TITLE
test(ui): unit tests for float conversion + required-text-field schema

### DIFF
--- a/ui/src/common/utils/requiredTextField.schema.test.ts
+++ b/ui/src/common/utils/requiredTextField.schema.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { emptyFieldMessage, requiredTextField } from './requiredTextField.schema.ts';
+
+describe('emptyFieldMessage', () => {
+  it('builds a label-specific message', () => {
+    expect(emptyFieldMessage('Name')).toBe('Name should not be empty');
+  });
+});
+
+describe('requiredTextField', () => {
+  it('accepts a non-empty value', async () => {
+    await expect(requiredTextField('Name').validate('ethanol')).resolves.toBe('ethanol');
+  });
+
+  it('rejects an empty string with the empty-field message', async () => {
+    await expect(requiredTextField('Name').validate('')).rejects.toThrow('Name should not be empty');
+  });
+
+  it('rejects a whitespace-only value', async () => {
+    await expect(requiredTextField('Name').isValid('   ')).resolves.toBe(false);
+  });
+});

--- a/ui/src/common/utils/requiredTextField.schema.test.ts
+++ b/ui/src/common/utils/requiredTextField.schema.test.ts
@@ -31,7 +31,7 @@ describe('requiredTextField', () => {
     await expect(requiredTextField('Name').validate('')).rejects.toThrow('Name should not be empty');
   });
 
-  it('rejects a whitespace-only value', async () => {
-    await expect(requiredTextField('Name').isValid('   ')).resolves.toBe(false);
+  it('rejects a whitespace-only value with the empty-field message', async () => {
+    await expect(requiredTextField('Name').validate('   ')).rejects.toThrow('Name should not be empty');
   });
 });

--- a/ui/src/store/entities/reactions/reactions.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactions.converters.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { convertReactionFloatsToDoubles } from './reactions.converters.ts';
+
+describe('convertReactionFloatsToDoubles', () => {
+  it('rounds floats to 7 significant figures in place', () => {
+    const part = { value: 1.123456789 };
+    convertReactionFloatsToDoubles(part);
+    expect(part.value).toBe(1.123457);
+  });
+
+  it('leaves integers unchanged', () => {
+    const part = { count: 42 };
+    convertReactionFloatsToDoubles(part);
+    expect(part.count).toBe(42);
+  });
+
+  it('recurses into nested objects and objects within arrays', () => {
+    const part = { outer: { inner: 2.000000123 }, list: [{ x: 3.000000456 }] };
+    convertReactionFloatsToDoubles(part);
+    expect(part.outer.inner).toBe(2);
+    expect(part.list[0].x).toBe(3);
+  });
+
+  it('leaves bare numeric array elements untouched (only object properties are rounded)', () => {
+    const part = { values: [1.123456789] };
+    convertReactionFloatsToDoubles(part);
+    expect(part.values[0]).toBe(1.123456789);
+  });
+
+  it('leaves non-numeric values untouched', () => {
+    const part = { name: 'ethanol', flag: true };
+    convertReactionFloatsToDoubles(part);
+    expect(part).toEqual({ name: 'ethanol', flag: true });
+  });
+
+  it('is a no-op for null or non-object input', () => {
+    expect(() => convertReactionFloatsToDoubles(null)).not.toThrow();
+    expect(() => convertReactionFloatsToDoubles(5)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

More #662 coverage of pure functions (no production code changed):

- **`convertReactionFloatsToDoubles`** — 7-sig-fig rounding in place, integer passthrough, recursion into nested objects and objects-within-arrays, no-op on `null`/non-object. Also pins the documented quirk that **bare numeric array elements are left untouched** (they hit the `typeof !== 'object'` early return — only object *properties* are rounded).
- **`emptyFieldMessage` / `requiredTextField`** — message formatting; accepts non-empty; rejects empty and whitespace-only input.

## Test plan
- [x] `vitest run` for the new files — 10/10 pass
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean
- [ ] CI green

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds test-only coverage for two pure utility functions with no production code changes. Both test files address existing behavior without modifying any implementation.

- **`reactions.converters.test.ts`**: 6 cases for `convertReactionFloatsToDoubles` — rounding, integer passthrough, recursive descent into nested objects and array-held objects, the documented bare-numeric-array quirk, non-numeric value passthrough, and null/non-object no-op.
- **`requiredTextField.schema.test.ts`**: 4 cases for `emptyFieldMessage` and `requiredTextField` — message format, acceptance of a valid value, and rejection of both empty and whitespace-only input with message-text assertions (addressing the feedback from a previous review round).

<h3>Confidence Score: 5/5</h3>

Test-only additions with no production code changes; safe to merge.

Both files are pure test additions. The expected values in the converter tests align correctly with the implementation logic (toPrecision(7) + parseFloat), the integer passthrough and bare-array quirk are accurately documented, and the requiredTextField assertions now pin message text for all three branches — including the whitespace-only case flagged in the previous review round.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/common/utils/requiredTextField.schema.test.ts | New test file covering emptyFieldMessage format and requiredTextField validation (accept, reject empty, reject whitespace-only); all assertions pin message text after addressing previous review feedback. |
| ui/src/store/entities/reactions/reactions.converters.test.ts | New test file covering convertReactionFloatsToDoubles: 7-sig-fig rounding, integer passthrough, recursive descent into nested objects and object-within-arrays, documented bare-numeric-array quirk, non-numeric passthrough, and null/non-object no-op; all expected values verified against the implementation logic. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[convertReactionFloatsToDoubles] --> B{typeof input !== object OR null?}
    B -- yes --> C[return early / no-op]
    B -- no --> D{Array.isArray?}
    D -- yes --> E[forEach item → recurse]
    D -- no --> F[iterate Object.keys]
    F --> G{typeof value}
    G -- object --> H[recurse into value]
    G -- number --> I{Number.isInteger?}
    G -- other --> J[leave unchanged]
    I -- yes --> K[parseInt passthrough]
    I -- no --> L[toPrecision 7 → parseFloat]

    subgraph "Tests cover"
        C:::tested
        E:::tested
        H:::tested
        K:::tested
        L:::tested
        J:::tested
    end

    classDef tested fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into test/unit-conve..."](https://github.com/open-reaction-database/ord-app/commit/1f20a6967b7fcb3e98fc69c6a2e2d1820fd43db9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34759630)</sub>

<!-- /greptile_comment -->