### PR TITLE
Fix flaky character-limitation tests (boundary off-by-one)

### DIFF
--- a/ord_app/tests/test_groups/test_create_groups.py
+++ b/ord_app/tests/test_groups/test_create_groups.py
@@ -26,6 +26,6 @@ async def test_create_group(api_client, mock_authenticated_user):
 
 
 async def test_create_group_with_character_limitations(api_client, mock_authenticated_user):
-    payload = {"name": faker.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2)}
+    payload = {"name": faker.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH + 1, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2)}
     response = api_client.post("/api/v1/groups", json=payload)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/ord_app/tests/test_templates/test_create_templates.py
+++ b/ord_app/tests/test_templates/test_create_templates.py
@@ -40,7 +40,7 @@ async def test_create_template(api_client, mock_authenticated_user, test_db_sess
 async def test_create_template_with_character_limitations(api_client, mock_authenticated_user, test_db_session):
     payload = {
         "binpb": b64encode(Reaction(reaction_id=fake.uuid4()).SerializeToString()).decode(),
-        "name": fake.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2),
+        "name": fake.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH + 1, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2),
         "variables": {"foo": "bar"},
     }
     response = api_client.post("/api/v1/templates", json=payload)

--- a/ord_app/tests/tests_datasets/test_create_dataset.py
+++ b/ord_app/tests/tests_datasets/test_create_dataset.py
@@ -22,7 +22,7 @@ from sqlalchemy import select
 
 from ord_app.service_api.domain.reactions import validate_dataset_reactions
 from ord_app.service_api.models import ReactionModel
-from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH
+from ord_app.service_api.schemas.base import MAX_CRITICAL_FIELD_LENGTH, MAX_FIELD_LENGTH
 from ord_app.tests.conftest import create_test_dataset, read_testdata_bytes, read_testdata_text
 
 faker = Faker()
@@ -153,8 +153,8 @@ async def test_dataset_extend(api_client, mock_authenticated_user, test_db_sessi
 async def test_create_dataset_with_character_limitations(api_client, mock_authenticated_user):
     *_, group = mock_authenticated_user
     payload = {
-        "name": faker.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2),
-        "description": faker.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2),
+        "name": faker.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH + 1, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2),
+        "description": faker.pystr(min_chars=MAX_FIELD_LENGTH + 1, max_chars=MAX_FIELD_LENGTH * 2),
     }
     response = api_client.post(f"/api/v1/groups/{group.id}/datasets", json=payload)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/ord_app/tests/tests_reactions/test_create_reactions.py
+++ b/ord_app/tests/tests_reactions/test_create_reactions.py
@@ -107,7 +107,7 @@ async def test_create_reaction_with_character_limitations(api_client, mock_authe
     payload = {
         "binpb": b64encode(
             Reaction(
-                reaction_id=fake.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2)
+                reaction_id=fake.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH + 1, max_chars=MAX_CRITICAL_FIELD_LENGTH * 2)
             ).SerializeToString()
         ).decode()
     }


### PR DESCRIPTION
## Summary

The `*_with_character_limitations` tests (datasets, reactions, groups, templates) generate values with `fake.pystr(min_chars=MAX_CRITICAL_FIELD_LENGTH, ...)`, which can produce a string of **exactly** `MAX_CRITICAL_FIELD_LENGTH`. The limit checks reject only values **strictly longer** than the max (the domain check is `len > MAX`, and pydantic `max_length=N` accepts `len == N`), so a boundary-length value is accepted — the test then intermittently sees `200` instead of `422`.

This surfaced as a spurious `test_python` failure on an unrelated PR (#687): `assert 200 == 422`.

Fix — make each generated value strictly exceed **its own** field's limit:
- `name` / `reaction_id` (limit `MAX_CRITICAL_FIELD_LENGTH`): `min_chars=... + 1`.
- dataset `description` (limit `MAX_FIELD_LENGTH`, not `MAX_CRITICAL`): generate against `MAX_FIELD_LENGTH + 1` so it actually exceeds its own bound (it previously used `MAX_CRITICAL_FIELD_LENGTH`, well under the 8192 limit, so the description never independently triggered the 422 — the name field did).

## Test plan
- [x] `ruff check` / `ruff format --check` clean; tests collect cleanly
- [ ] CI `test_python` (ubuntu + macos) green — now deterministic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes intermittent `422`-vs-`200` assertion failures in the `*_with_character_limitations` test suite by correcting off-by-one errors in Faker string generation. Since the domain validators reject strings strictly longer than their limit (`len > MAX`), and Faker's `min_chars=MAX` can emit a boundary-length value that is accepted, tests were non-deterministically passing or failing.

- **Groups, templates, reactions**: `min_chars` shifted from `MAX_CRITICAL_FIELD_LENGTH` to `MAX_CRITICAL_FIELD_LENGTH + 1` so every generated name/`reaction_id` always exceeds its 512-character limit.
- **Dataset description**: corrected from using `MAX_CRITICAL_FIELD_LENGTH` (512, well under the actual `MAX_FIELD_LENGTH = 8192` cap) to `MAX_FIELD_LENGTH + 1`, so the description field now independently triggers a 422 rather than relying on the name field to fail first.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are confined to test files and directly address a well-understood flakiness root cause.

Every changed line is a test-only correction to a Faker string generation boundary. The root cause (domain validators use strict len > MAX, Faker could emit exactly MAX) is well-explained and each fix is independently verifiable against the schema constants in base.py. The dataset description fix additionally corrects a latent test-design issue where the description field was never actually being tested against its own limit.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ord_app/tests/tests_datasets/test_create_dataset.py | Imports MAX_FIELD_LENGTH and corrects both fields: name uses MAX_CRITICAL_FIELD_LENGTH+1 (512→513), description uses MAX_FIELD_LENGTH+1 (8192→8193) so each field independently triggers 422. |
| ord_app/tests/test_groups/test_create_groups.py | Single-line fix: min_chars raised from MAX_CRITICAL_FIELD_LENGTH to MAX_CRITICAL_FIELD_LENGTH+1 so the group name always exceeds the 512-char limit. |
| ord_app/tests/test_templates/test_create_templates.py | Single-line fix mirroring the groups change: name min_chars raised to MAX_CRITICAL_FIELD_LENGTH+1. |
| ord_app/tests/tests_reactions/test_create_reactions.py | Single-line fix: reaction_id min_chars raised to MAX_CRITICAL_FIELD_LENGTH+1, ensuring the serialized protobuf always contains an oversized reaction_id. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Faker.pystr(min_chars=LIMIT+1, max_chars=LIMIT*2)"] --> B["Generated string length always > LIMIT"]
    B --> C{"Domain validator\nlen > MAX?"}
    C -- "Yes (always)" --> D["422 Unprocessable Entity ✓"]
    C -- "No (was possible\nwhen len == LIMIT)" --> E["200 OK — test failure ✗"]
    style E fill:#ffcccc
    style D fill:#ccffcc
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix flaky character-limitation tests (bo..."](https://github.com/open-reaction-database/ord-app/commit/d235face0f7b6b33ee3f883c4dba16f24b30dd26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34760747)</sub>

<!-- /greptile_comment -->