### PR TITLE
test(ui): unit tests for reactionEntity + reactionData converters

### DIFF
--- a/ui/src/store/entities/reactions/reactionData/reactionData.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionData/reactionData.converters.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { Buffer } from 'buffer';
+import {
+  ordDataMapToReactionDataMap,
+  ordDataToReaction,
+  reactionDataMapToOrdDataMap,
+  reactionDataToOrd,
+} from './reactionData.converters.ts';
+import { AppDataType } from './reactionData.types.ts';
+
+describe('ordDataToReaction', () => {
+  it('maps a URL value', () => {
+    const result = ordDataToReaction({ url: 'http://example.com' }, 'link');
+    expect(result.name).toBe('link');
+    expect(result.data.type).toBe(AppDataType.Url);
+    expect(result.data.value).toBe('http://example.com');
+  });
+
+  it('maps a string value', () => {
+    expect(ordDataToReaction({ stringValue: 'hello' }, 'n').data).toMatchObject({
+      type: AppDataType.Text,
+      value: 'hello',
+    });
+  });
+
+  it('maps a numeric value, preferring float over integer', () => {
+    expect(ordDataToReaction({ floatValue: 1.5 }, 'n').data).toMatchObject({ type: AppDataType.Number, value: 1.5 });
+    expect(ordDataToReaction({ integerValue: 3 }, 'n').data).toMatchObject({ type: AppDataType.Number, value: 3 });
+    expect(ordDataToReaction({}, 'n').data).toMatchObject({ type: AppDataType.Number, value: null });
+  });
+
+  it('passes a string bytesValue through and base64-encodes a Uint8Array', () => {
+    expect(ordDataToReaction({ bytesValue: 'YWJj' }, 'n').data).toMatchObject({
+      type: AppDataType.Upload,
+      value: 'YWJj',
+    });
+    expect(ordDataToReaction({ bytesValue: new Uint8Array([97, 98, 99]) }, 'n').data.value).toBe('YWJj');
+  });
+
+  it('carries description and format', () => {
+    const result = ordDataToReaction({ stringValue: 's', description: 'desc', format: 'fmt' }, 'n');
+    expect(result.description).toBe('desc');
+    expect(result.data.format).toBe('fmt');
+  });
+});
+
+describe('reactionDataToOrd', () => {
+  const base = { id: 'i', name: 'n', description: 'd' };
+
+  it('round-trips a URL', () => {
+    expect(reactionDataToOrd({ ...base, data: { type: AppDataType.Url, value: 'http://x' } }).url).toBe('http://x');
+  });
+
+  it('round-trips a string', () => {
+    expect(reactionDataToOrd({ ...base, data: { type: AppDataType.Text, value: 'hi' } }).stringValue).toBe('hi');
+  });
+
+  it('splits numbers into integerValue and floatValue', () => {
+    expect(reactionDataToOrd({ ...base, data: { type: AppDataType.Number, value: 3 } }).integerValue).toBe(3);
+    expect(reactionDataToOrd({ ...base, data: { type: AppDataType.Number, value: 1.5 } }).floatValue).toBe(1.5);
+  });
+
+  it('decodes an Upload base64 string to bytes', () => {
+    const ordData = reactionDataToOrd({ ...base, data: { type: AppDataType.Upload, value: 'YWJj' } });
+    expect(Buffer.from(ordData.bytesValue as Uint8Array).toString()).toBe('abc');
+  });
+
+  it('adds no value field when value is null', () => {
+    const ordData = reactionDataToOrd({ ...base, data: { type: AppDataType.Number, value: null } });
+    expect(ordData.integerValue).toBeUndefined();
+    expect(ordData.floatValue).toBeUndefined();
+  });
+});
+
+describe('ordDataMapToReactionDataMap / reactionDataMapToOrdDataMap', () => {
+  it('keys converted entries by their generated id', () => {
+    const result = ordDataMapToReactionDataMap({ first: { stringValue: 'a' } });
+    const entries = Object.values(result);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('first');
+    expect(entries[0].data.value).toBe('a');
+  });
+
+  it('returns null for an empty reaction data map', () => {
+    expect(reactionDataMapToOrdDataMap({})).toBeNull();
+  });
+
+  it('keys ord entries by the app data name', () => {
+    const result = reactionDataMapToOrdDataMap({
+      someId: { id: 'someId', name: 'myField', description: undefined, data: { type: AppDataType.Text, value: 'x' } },
+    });
+    expect(result?.myField.stringValue).toBe('x');
+  });
+});

--- a/ui/src/store/entities/reactions/reactionData/reactionData.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionData/reactionData.converters.test.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,10 +24,10 @@ import { AppDataType } from './reactionData.types.ts';
 
 describe('ordDataToReaction', () => {
   it('maps a URL value', () => {
-    const result = ordDataToReaction({ url: 'http://example.com' }, 'link');
+    const result = ordDataToReaction({ url: 'https://example.com' }, 'link');
     expect(result.name).toBe('link');
     expect(result.data.type).toBe(AppDataType.Url);
-    expect(result.data.value).toBe('http://example.com');
+    expect(result.data.value).toBe('https://example.com');
   });
 
   it('maps a string value', () => {
@@ -67,7 +67,7 @@ describe('reactionDataToOrd', () => {
   const base = { id: 'i', name: 'n', description: 'd' };
 
   it('round-trips a URL', () => {
-    expect(reactionDataToOrd({ ...base, data: { type: AppDataType.Url, value: 'http://x' } }).url).toBe('http://x');
+    expect(reactionDataToOrd({ ...base, data: { type: AppDataType.Url, value: 'https://x' } }).url).toBe('https://x');
   });
 
   it('round-trips a string', () => {

--- a/ui/src/store/entities/reactions/reactionData/reactionData.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionData/reactionData.converters.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { describe, it, expect } from 'vitest';
-import { Buffer } from 'buffer';
 import {
   ordDataMapToReactionDataMap,
   ordDataToReaction,
@@ -38,14 +37,19 @@ describe('ordDataToReaction', () => {
     });
   });
 
-  it('maps a numeric value, preferring float over integer', () => {
+  it('maps a numeric value, preferring float over integer when both are present', () => {
     expect(ordDataToReaction({ floatValue: 1.5 }, 'n').data).toMatchObject({ type: AppDataType.Number, value: 1.5 });
     expect(ordDataToReaction({ integerValue: 3 }, 'n').data).toMatchObject({ type: AppDataType.Number, value: 3 });
+    expect(ordDataToReaction({ floatValue: 1.5, integerValue: 9 }, 'n').data).toMatchObject({
+      type: AppDataType.Number,
+      value: 1.5,
+    });
     expect(ordDataToReaction({}, 'n').data).toMatchObject({ type: AppDataType.Number, value: null });
   });
 
   it('passes a string bytesValue through and base64-encodes a Uint8Array', () => {
-    expect(ordDataToReaction({ bytesValue: 'YWJj' }, 'n').data).toMatchObject({
+    // The string branch is the copy/paste-via-JSON workaround; the field type is Uint8Array.
+    expect(ordDataToReaction({ bytesValue: 'YWJj' as unknown as Uint8Array }, 'n').data).toMatchObject({
       type: AppDataType.Upload,
       value: 'YWJj',
     });
@@ -76,8 +80,9 @@ describe('reactionDataToOrd', () => {
   });
 
   it('decodes an Upload base64 string to bytes', () => {
+    // 'YWJj' is base64 for 'abc' (bytes 97, 98, 99).
     const ordData = reactionDataToOrd({ ...base, data: { type: AppDataType.Upload, value: 'YWJj' } });
-    expect(Buffer.from(ordData.bytesValue as Uint8Array).toString()).toBe('abc');
+    expect(ordData.bytesValue).toEqual(Uint8Array.from([97, 98, 99]));
   });
 
   it('adds no value field when value is null', () => {
@@ -94,6 +99,8 @@ describe('ordDataMapToReactionDataMap / reactionDataMapToOrdDataMap', () => {
     expect(entries).toHaveLength(1);
     expect(entries[0].name).toBe('first');
     expect(entries[0].data.value).toBe('a');
+    // The map is keyed by the generated id, not by the ord name.
+    expect(Object.keys(result)).toEqual([entries[0].id]);
   });
 
   it('returns null for an empty reaction data map', () => {

--- a/ui/src/store/entities/reactions/reactionEntity/reactionEntity.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionEntity/reactionEntity.converters.test.ts
@@ -54,7 +54,7 @@ describe('withIdName / withoutIdName', () => {
 
 describe('ordBooleanToReaction', () => {
   it('maps null/undefined to Unspecified', () => {
-    expect(ordBooleanToReaction(undefined)).toBe(ReactionBoolean.Unspecified);
+    expect(ordBooleanToReaction()).toBe(ReactionBoolean.Unspecified);
     expect(ordBooleanToReaction(null)).toBe(ReactionBoolean.Unspecified);
   });
 

--- a/ui/src/store/entities/reactions/reactionEntity/reactionEntity.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionEntity/reactionEntity.converters.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ordBooleanToReaction,
+  ordValuePrecisionToReaction,
+  reactionBooleanToOrd,
+  reactionValuePrecisionToOrd,
+  withId,
+  withIdName,
+  withoutId,
+  withoutIdName,
+} from './reactionEntity.converters.ts';
+import { ReactionBoolean } from './reactionEntity.types.ts';
+
+describe('withId / withoutId', () => {
+  it('adds a string id, preserving other fields', () => {
+    const result = withId({ value: 1 });
+    expect(result.value).toBe(1);
+    expect(typeof result.id).toBe('string');
+    expect(result.id.length).toBeGreaterThan(0);
+  });
+
+  it('strips the id', () => {
+    expect(withoutId({ id: 'abc', value: 1 })).toEqual({ value: 1 });
+  });
+});
+
+describe('withIdName / withoutIdName', () => {
+  it('adds a string id and the given name', () => {
+    const result = withIdName({ value: 1 }, 'label');
+    expect(result.value).toBe(1);
+    expect(result.name).toBe('label');
+    expect(typeof result.id).toBe('string');
+  });
+
+  it('strips id and name', () => {
+    expect(withoutIdName({ id: 'abc', name: 'label', value: 1 })).toEqual({ value: 1 });
+  });
+});
+
+describe('ordBooleanToReaction', () => {
+  it('maps null/undefined to Unspecified', () => {
+    expect(ordBooleanToReaction(undefined)).toBe(ReactionBoolean.Unspecified);
+    expect(ordBooleanToReaction(null)).toBe(ReactionBoolean.Unspecified);
+  });
+
+  it('maps booleans to True/False', () => {
+    expect(ordBooleanToReaction(true)).toBe(ReactionBoolean.True);
+    expect(ordBooleanToReaction(false)).toBe(ReactionBoolean.False);
+  });
+});
+
+describe('reactionBooleanToOrd', () => {
+  it('is the inverse of ordBooleanToReaction', () => {
+    expect(reactionBooleanToOrd(ReactionBoolean.Unspecified)).toBeNull();
+    expect(reactionBooleanToOrd(ReactionBoolean.True)).toBe(true);
+    expect(reactionBooleanToOrd(ReactionBoolean.False)).toBe(false);
+  });
+});
+
+describe('ordValuePrecisionToReaction', () => {
+  it('passes through value and precision', () => {
+    expect(ordValuePrecisionToReaction({ value: 1, precision: 2 })).toEqual({ value: 1, precision: 2 });
+  });
+
+  it('defaults missing fields to null', () => {
+    expect(ordValuePrecisionToReaction(undefined)).toEqual({ value: null, precision: null });
+    expect(ordValuePrecisionToReaction({ value: 5 })).toEqual({ value: 5, precision: null });
+  });
+});
+
+describe('reactionValuePrecisionToOrd', () => {
+  it('returns null when both value and precision are null', () => {
+    expect(reactionValuePrecisionToOrd({ value: null, precision: null })).toBeNull();
+  });
+
+  it('returns the value/precision pair otherwise', () => {
+    expect(reactionValuePrecisionToOrd({ value: 1, precision: null })).toEqual({ value: 1, precision: null });
+  });
+});


### PR DESCRIPTION
## Summary

Larger #662 batch covering the pure proto↔app converters (no production code changed). UI unit suite: **49 → 73** tests.

**`reactionEntity.converters`**
- `withId`/`withoutId`, `withIdName`/`withoutIdName` — id/name add + strip
- `ordBooleanToReaction` / `reactionBooleanToOrd` — `Unspecified`/`True`/`False` ↔ `null`/`bool`
- `ordValuePrecisionToReaction` / `reactionValuePrecisionToOrd` — null defaults; both-null → `null`

**`reactionData.converters`**
- `ordDataToReaction` — url / string / numeric (float-over-integer, empty → `null`) / bytes (string passthrough vs `Uint8Array` base64); description + format carry-through
- `reactionDataToOrd` — url/string round-trips, integer-vs-float split, base64 → bytes, null value adds no field
- `ordDataMapToReactionDataMap` / `reactionDataMapToOrdDataMap` — id/name keying, empty → `null`

`id` fields come from `crypto.randomUUID()`, so the tests assert on `name`/`data`/type rather than the id.

## Test plan
- [x] `vitest run` — 73/73 pass
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean
- [ ] CI green

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 24 new unit tests covering the `reactionEntity.converters` and `reactionData.converters` modules, bringing the UI unit suite from 49 to 73 tests. No production code is modified.

- **`reactionEntity.converters.test.ts`** covers `withId`/`withoutId`, `withIdName`/`withoutIdName`, `ordBooleanToReaction`/`reactionBooleanToOrd`, and `ordValuePrecisionToReaction`/`reactionValuePrecisionToOrd`.
- **`reactionData.converters.test.ts`** covers `ordDataToReaction` (all five data type branches including the Uint8Array→base64 path), `reactionDataToOrd` (round-trips, integer/float split, base64 decode, null value), and the two map helpers including the id-keying assertion added in response to prior review feedback.

<h3>Confidence Score: 5/5</h3>

Test-only PR with no production code changes; all new tests verify existing converter behaviour and are correctly aligned with the implementation.

Both new test files accurately reflect the production implementations read during this review. Assertions cover all five data-type branches, both map helpers, the base64 encode/decode path, and the id-keying behaviour. No production logic was changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactionData/reactionData.converters.test.ts | New test file covering all five data type branches plus the two map helpers; prior review feedback (float preference, key assertion) has been addressed. |
| ui/src/store/entities/reactions/reactionEntity/reactionEntity.converters.test.ts | New test file covering id/name helpers, boolean converters, and value/precision round-trips; all assertions match the production implementations. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ord.IData (proto)"] -->|ordDataToReaction| B["AppData (app)"]
    B -->|reactionDataToOrd| A

    subgraph ordDataToReaction
        D1{url?} -->|yes| E1[AppDataType.Url]
        D1 -->|no| D2{stringValue?}
        D2 -->|yes| E2[AppDataType.Text]
        D2 -->|no| D3{bytesValue?}
        D3 -->|yes| E3[AppDataType.Upload / base64]
        D3 -->|no| E4["AppDataType.Number (floatValue ?? integerValue ?? null)"]
    end

    subgraph reactionDataToOrd
        F1{value null?} -->|yes| G1[no field set]
        F1 -->|no| F2{Url?}
        F2 -->|yes| G2[url]
        F2 -->|no| F3{Text?}
        F3 -->|yes| G3[stringValue]
        F3 -->|no| F4{Upload?}
        F4 -->|yes| G4[bytesValue bytes]
        F4 -->|no| F5{isInteger?}
        F5 -->|yes| G5[integerValue]
        F5 -->|no| G6[floatValue]
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Use https in converter test URLs (Sonar ..."](https://github.com/open-reaction-database/ord-app/commit/feb9c5771c8d3116f597829dddef2936e31a7bbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761093)</sub>

<!-- /greptile_comment -->