### PR TITLE
test(ui): unit tests for async-action factories

### DIFF
--- a/ui/src/store/utils/actions.test.ts
+++ b/ui/src/store/utils/actions.test.ts
@@ -28,22 +28,25 @@ describe('createAsyncAction', () => {
     const actions = createAsyncAction<number, string>('x');
     expect(actions.request(7)).toEqual({ type: 'x/request', payload: 7 });
     expect(actions.success('ok')).toEqual({ type: 'x/success', payload: 'ok' });
+    const error = new Error('boom');
+    expect(actions.failure(error)).toEqual({ type: 'x/failure', payload: error });
   });
 });
 
 describe('createActionFactory', () => {
-  it('prefixes plain action types', () => {
+  it('prefixes plain action types and round-trips the payload', () => {
     const factory = createActionFactory('templates');
-    const action = factory.createAction('rename');
+    const action = factory.createAction<string>('rename');
     expect(action.type).toBe('templates/rename');
     expect(action('value')).toEqual({ type: 'templates/rename', payload: 'value' });
   });
 
-  it('prefixes async action types', () => {
+  it('prefixes async action types and round-trips the request payload', () => {
     const factory = createActionFactory('templates');
-    const actions = factory.createAsyncAction('save');
+    const actions = factory.createAsyncAction<number>('save');
     expect(actions.request.type).toBe('templates/save/request');
     expect(actions.success.type).toBe('templates/save/success');
     expect(actions.failure.type).toBe('templates/save/failure');
+    expect(actions.request(3)).toEqual({ type: 'templates/save/request', payload: 3 });
   });
 });

--- a/ui/src/store/utils/actions.test.ts
+++ b/ui/src/store/utils/actions.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { createActionFactory, createAsyncAction } from './actions.ts';
+
+describe('createAsyncAction', () => {
+  it('derives request/success/failure action types from the base type', () => {
+    const actions = createAsyncAction('reactions/load');
+    expect(actions.request.type).toBe('reactions/load/request');
+    expect(actions.success.type).toBe('reactions/load/success');
+    expect(actions.failure.type).toBe('reactions/load/failure');
+  });
+
+  it('produces action creators that attach the payload', () => {
+    const actions = createAsyncAction<number, string>('x');
+    expect(actions.request(7)).toEqual({ type: 'x/request', payload: 7 });
+    expect(actions.success('ok')).toEqual({ type: 'x/success', payload: 'ok' });
+  });
+});
+
+describe('createActionFactory', () => {
+  it('prefixes plain action types', () => {
+    const factory = createActionFactory('templates');
+    const action = factory.createAction('rename');
+    expect(action.type).toBe('templates/rename');
+    expect(action('value')).toEqual({ type: 'templates/rename', payload: 'value' });
+  });
+
+  it('prefixes async action types', () => {
+    const factory = createActionFactory('templates');
+    const actions = factory.createAsyncAction('save');
+    expect(actions.request.type).toBe('templates/save/request');
+    expect(actions.success.type).toBe('templates/save/success');
+    expect(actions.failure.type).toBe('templates/save/failure');
+  });
+});


### PR DESCRIPTION
## Summary

Covers `store/utils/actions.ts` (#662) — the action-creator infrastructure used across the store:
- `createAsyncAction` — derives `request`/`success`/`failure` types from the base type and attaches payloads.
- `createActionFactory` — prefixes both plain and async action types.

UI unit suite: **73 → 77** tests.

## Test plan
- [x] `vitest run` — 77/77 pass
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean
- [ ] CI green

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new unit test file covering `store/utils/actions.ts` — specifically `createAsyncAction` and `createActionFactory`, the two action-creator utilities used across the store.

- `createAsyncAction` is tested for type derivation (`request`/`success`/`failure` suffixes) and payload round-trips for all three creators, including the `failure` branch with an `Error` instance.
- `createActionFactory` is tested for plain-action prefixing with a payload round-trip, and for async-action prefixing with a `request` payload round-trip that exercises the full `prefix/type/subtype` path.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no changes to production code; safe to merge.

The PR adds four focused unit tests against a small, already-shipped utility. All three async-action creators (request, success, failure) are exercised with payload round-trips in the direct createAsyncAction tests, and the factory tests confirm the prefixing logic end-to-end. No production code is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/store/utils/actions.test.ts | New test file — 4 focused tests covering type derivation, payload attachment, and factory prefixing for both sync and async action creators; no issues found. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createAsyncAction&lt;Req, Succ, Fail&gt;] --> B["request creator\n(type/request)"]
    A --> C["success creator\n(type/success)"]
    A --> D["failure creator\n(type/failure)"]

    E[createActionFactory&lt;prefix&gt;] --> F["createAction(type)\n→ prefix/type"]
    E --> G["createAsyncAction(type)\n→ prefix/type/request\n→ prefix/type/success\n→ prefix/type/failure"]

    subgraph Tests
        T1["derives request/success/failure types"] --> A
        T2["payload round-trip: request·success·failure"] --> A
        T3["prefixes plain action + payload round-trip"] --> E
        T4["prefixes async action types + request payload round-trip"] --> E
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix build + close coverage gaps in actio..."](https://github.com/open-reaction-database/ord-app/commit/0c537a00b77d4158cb2521fd10a1a1c294ec156d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761798)</sub>

<!-- /greptile_comment -->