### PR TITLE
test(ui): unit tests for datasets/groups reducers + groups selectors

### DIFF
--- a/ui/src/store/entities/datasets/datasets.reducer.test.ts
+++ b/ui/src/store/entities/datasets/datasets.reducer.test.ts
@@ -214,9 +214,32 @@ describe('datasetsReducer', () => {
       expect(state.areDatasetGroupsLoading).toBe(true);
     });
 
-    it('is false once the groups list resolves or is cleared', () => {
+    it('is false once the groups list resolves', () => {
       let state = datasetsReducer(initialState(), getDatasetGroupsActions.request(1));
       expect(state.areDatasetGroupsLoading).toBe(true);
+      state = datasetsReducer(state, getDatasetGroupsActions.success([]));
+      expect(state.areDatasetGroupsLoading).toBe(false);
+    });
+
+    it('is false once the groups list is cleared', () => {
+      let state = datasetsReducer(initialState(), getDatasetGroupsActions.request(1));
+      expect(state.areDatasetGroupsLoading).toBe(true);
+      state = datasetsReducer(state, clearDatasetGroupsListAction());
+      expect(state.areDatasetGroupsLoading).toBe(false);
+    });
+
+    // shareDatasetWithGroupActions.success is intentionally NOT a reset trigger: the
+    // shareDatasetWithGroup thunk dispatches success() and then re-fetches via
+    // getDatasetGroups, so the loading flag is cleared by that follow-up
+    // getDatasetGroupsActions.request -> .success cycle, keeping the spinner up across
+    // the refetch. This test pins that cascaded-request design.
+    it('stays true after share success alone (reset by the follow-up refetch)', () => {
+      let state = datasetsReducer(initialState(), shareDatasetWithGroupActions.request(sharePayload));
+      expect(state.areDatasetGroupsLoading).toBe(true);
+      state = datasetsReducer(state, shareDatasetWithGroupActions.success());
+      expect(state.areDatasetGroupsLoading).toBe(true);
+      // the thunk's follow-up getDatasetGroups request/success is what clears it
+      state = datasetsReducer(state, getDatasetGroupsActions.request(sharePayload.datasetId));
       state = datasetsReducer(state, getDatasetGroupsActions.success([]));
       expect(state.areDatasetGroupsLoading).toBe(false);
     });

--- a/ui/src/store/entities/datasets/datasets.reducer.test.ts
+++ b/ui/src/store/entities/datasets/datasets.reducer.test.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { datasetsReducer } from './datasets.reducer.ts';
+import {
+  clearDatasetGroupsListAction,
+  createDatasetFromFileActions,
+  createNewDatasetActions,
+  getDatasetActions,
+  getDatasetGroupsActions,
+  getDatasetPageActions,
+  getGroupsInitialDatasetListActions,
+  setDatasetEditOpenedAction,
+  shareDatasetWithGroupActions,
+  unshareDatasetWithGroupActions,
+  updateDatasetActions,
+} from './datasets.actions.ts';
+import { setActiveGroupIdAction } from '../groups/groups.actions.ts';
+import { emptyPagination } from 'common/constants.ts';
+import type { Dataset, DatasetGroup } from './datasets.types.ts';
+import type { Pages } from 'common/types';
+
+const makeDataset = (id: number, overrides: Partial<Dataset> = {}): Dataset => ({
+  id,
+  name: `dataset-${id}`,
+  description: `description-${id}`,
+  owner: { id: 1, email: 'owner@example.com', name: 'Owner' },
+  created_at: '2026-01-01T00:00:00Z',
+  modified_at: '2026-01-01T00:00:00Z',
+  groups: [],
+  reactions_count: { total: 0, invalid: 0, valid: 0, none: 0 },
+  ...overrides,
+});
+
+const makePage = (items: Array<Dataset>, overrides: Partial<Pages<Dataset>> = {}): Pages<Dataset> => ({
+  items,
+  page: 1,
+  size: 10,
+  total: items.length,
+  pages: 1,
+  ...overrides,
+});
+
+const initialState = () => datasetsReducer(undefined, { type: '@@INIT' });
+
+describe('datasetsReducer', () => {
+  it('returns the initial state', () => {
+    expect(initialState()).toEqual({
+      datasetsById: {},
+      datasetsOrder: [],
+      pagination: emptyPagination,
+      areDatasetsLoading: false,
+      isDatasetCreating: false,
+      isDatasetEditOpened: false,
+      datasetGroups: null,
+      areDatasetGroupsLoading: false,
+    });
+  });
+
+  describe('datasetsById', () => {
+    it('stores a single fetched dataset by id', () => {
+      const dataset = makeDataset(1);
+      const state = datasetsReducer(initialState(), getDatasetActions.success(dataset));
+      expect(state.datasetsById).toEqual({ 1: dataset });
+    });
+
+    it('merges updated fields into an existing dataset on update success', () => {
+      const dataset = makeDataset(1, { name: 'old', description: 'old desc' });
+      let state = datasetsReducer(initialState(), getDatasetActions.success(dataset));
+      state = datasetsReducer(
+        state,
+        updateDatasetActions.success({ ...dataset, name: 'new', description: 'new desc' }),
+      );
+      expect(state.datasetsById[1].name).toBe('new');
+      expect(state.datasetsById[1].description).toBe('new desc');
+      // unrelated fields are preserved by the merge
+      expect(state.datasetsById[1].owner).toEqual(dataset.owner);
+    });
+
+    it('adds newly created datasets (empty and from-file)', () => {
+      const created = makeDataset(2);
+      const fromFile = makeDataset(3);
+      let state = datasetsReducer(initialState(), createNewDatasetActions.success(created));
+      state = datasetsReducer(state, createDatasetFromFileActions.success(fromFile));
+      expect(Object.keys(state.datasetsById)).toEqual(['2', '3']);
+    });
+
+    it('merges list payloads over existing entries without dropping prior datasets', () => {
+      const existing = makeDataset(1, { name: 'existing' });
+      let state = datasetsReducer(initialState(), getDatasetActions.success(existing));
+      // a list page that re-includes id 1 (partial) plus a new id 2
+      const page = makePage([makeDataset(1, { name: 'refreshed' }), makeDataset(2)]);
+      state = datasetsReducer(state, getDatasetPageActions.success(page));
+      expect(state.datasetsById[1].name).toBe('refreshed');
+      expect(state.datasetsById[2]).toBeDefined();
+    });
+  });
+
+  describe('datasetsOrder', () => {
+    it('records the order of ids from a successful list', () => {
+      const page = makePage([makeDataset(5), makeDataset(2), makeDataset(9)]);
+      const state = datasetsReducer(initialState(), getGroupsInitialDatasetListActions.success(page));
+      expect(state.datasetsOrder).toEqual([5, 2, 9]);
+    });
+
+    it('resets the order when the active group changes', () => {
+      const page = makePage([makeDataset(5)]);
+      let state = datasetsReducer(initialState(), getDatasetPageActions.success(page));
+      expect(state.datasetsOrder).toEqual([5]);
+      state = datasetsReducer(state, setActiveGroupIdAction(7));
+      expect(state.datasetsOrder).toEqual([]);
+    });
+
+    it('clears the order while a page request is in flight', () => {
+      const page = makePage([makeDataset(5)]);
+      let state = datasetsReducer(initialState(), getDatasetPageActions.success(page));
+      state = datasetsReducer(state, getDatasetPageActions.request({ page: 2, size: 10 }));
+      expect(state.datasetsOrder).toEqual([]);
+    });
+  });
+
+  describe('areDatasetsLoading', () => {
+    it('is true while listing and on active-group change, false once settled', () => {
+      let state = datasetsReducer(initialState(), setActiveGroupIdAction(1));
+      expect(state.areDatasetsLoading).toBe(true);
+      state = datasetsReducer(state, getDatasetPageActions.success(makePage([])));
+      expect(state.areDatasetsLoading).toBe(false);
+      state = datasetsReducer(state, getGroupsInitialDatasetListActions.request(1));
+      expect(state.areDatasetsLoading).toBe(true);
+      state = datasetsReducer(state, getGroupsInitialDatasetListActions.failure(new Error('x')));
+      expect(state.areDatasetsLoading).toBe(false);
+    });
+  });
+
+  describe('isDatasetCreating', () => {
+    it('toggles around create requests', () => {
+      let state = datasetsReducer(
+        initialState(),
+        createNewDatasetActions.request({ name: 'a', description: 'b', groupId: 1 }),
+      );
+      expect(state.isDatasetCreating).toBe(true);
+      state = datasetsReducer(state, createNewDatasetActions.success(makeDataset(1)));
+      expect(state.isDatasetCreating).toBe(false);
+    });
+  });
+
+  describe('pagination', () => {
+    it('updates page params on request and totals on success', () => {
+      let state = datasetsReducer(initialState(), getDatasetPageActions.request({ page: 3, size: 25 }));
+      expect(state.pagination).toMatchObject({ page: 3, size: 25 });
+      state = datasetsReducer(state, getDatasetPageActions.success(makePage([], { total: 42, pages: 5 })));
+      expect(state.pagination).toMatchObject({ page: 3, size: 25, total: 42, pages: 5 });
+    });
+
+    it('resets to empty pagination on active-group change', () => {
+      let state = datasetsReducer(initialState(), getDatasetPageActions.request({ page: 3, size: 25 }));
+      state = datasetsReducer(state, setActiveGroupIdAction(1));
+      expect(state.pagination).toEqual(emptyPagination);
+    });
+  });
+
+  describe('isDatasetEditOpened', () => {
+    it('reflects the set action and closes on update success', () => {
+      let state = datasetsReducer(initialState(), setDatasetEditOpenedAction(true));
+      expect(state.isDatasetEditOpened).toBe(true);
+      state = datasetsReducer(state, updateDatasetActions.success(makeDataset(1)));
+      expect(state.isDatasetEditOpened).toBe(false);
+    });
+  });
+
+  describe('datasetGroups', () => {
+    const groups: Array<DatasetGroup> = [
+      { id: 1, name: 'g1', is_primary: true },
+      { id: 2, name: 'g2', is_primary: false },
+    ];
+
+    it('stores fetched groups and clears them on the clear action', () => {
+      let state = datasetsReducer(initialState(), getDatasetGroupsActions.success(groups));
+      expect(state.datasetGroups).toEqual(groups);
+      state = datasetsReducer(state, clearDatasetGroupsListAction());
+      expect(state.datasetGroups).toBeNull();
+    });
+
+    it('removes the unshared group from the list', () => {
+      let state = datasetsReducer(initialState(), getDatasetGroupsActions.success(groups));
+      state = datasetsReducer(state, unshareDatasetWithGroupActions.success(1));
+      expect(state.datasetGroups).toEqual([{ id: 2, name: 'g2', is_primary: false }]);
+    });
+
+    it('stays null when unshare success arrives without a loaded list', () => {
+      const state = datasetsReducer(initialState(), unshareDatasetWithGroupActions.success(1));
+      expect(state.datasetGroups).toBeNull();
+    });
+  });
+
+  describe('areDatasetGroupsLoading', () => {
+    const sharePayload = { datasetId: 1, groupId: 2, primaryGroupId: 3 };
+
+    it('is true while share/unshare/get requests are pending', () => {
+      const state = datasetsReducer(initialState(), shareDatasetWithGroupActions.request(sharePayload));
+      expect(state.areDatasetGroupsLoading).toBe(true);
+    });
+
+    it('is false once the groups list resolves or is cleared', () => {
+      let state = datasetsReducer(initialState(), getDatasetGroupsActions.request(1));
+      expect(state.areDatasetGroupsLoading).toBe(true);
+      state = datasetsReducer(state, getDatasetGroupsActions.success([]));
+      expect(state.areDatasetGroupsLoading).toBe(false);
+    });
+  });
+});

--- a/ui/src/store/entities/groups/groups.reducer.test.ts
+++ b/ui/src/store/entities/groups/groups.reducer.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { groupsReducer } from './groups.reducer.ts';
+import {
+  addGroupMemberActions,
+  getGroupListActions,
+  getGroupMembersActions,
+  removeGroupMembersActions,
+  resetAddMemberErrorAction,
+  setAddMemberInputValueAction,
+  setEditingGroupIdAction,
+  setGroupSearchAction,
+  renameGroupActions,
+  updateGroupMembersActions,
+} from './groups.actions.ts';
+import { USER_ROLES } from 'common/types';
+import type { GroupItem, GroupMember } from './groups.types.ts';
+
+const makeGroupItem = (id: number, name: string, role: USER_ROLES = USER_ROLES.ADMIN): GroupItem => ({
+  id,
+  name,
+  role,
+});
+
+const makeMember = (userId: number, role: USER_ROLES = USER_ROLES.VIEWER): GroupMember => ({
+  id: userId * 10,
+  role,
+  user: {
+    id: userId,
+    name: `user-${userId}`,
+    email: `user-${userId}@example.com`,
+    external_id: `ext-${userId}`,
+    avatar_url: '',
+  },
+});
+
+const initialState = () => groupsReducer(undefined, { type: '@@INIT' });
+
+describe('groupsReducer', () => {
+  it('returns the initial state', () => {
+    expect(initialState()).toEqual({
+      groupsById: {},
+      groupNameSearch: '',
+      editingGroupId: null,
+      groupsMembersByGroupId: {},
+      addMemberInputValue: '',
+      addMemberError: null,
+      isGroupUpdating: false,
+    });
+  });
+
+  describe('groupsById', () => {
+    it('indexes the fetched group list by id', () => {
+      const list = [makeGroupItem(1, 'Alpha'), makeGroupItem(2, 'Beta')];
+      const state = groupsReducer(initialState(), getGroupListActions.success(list));
+      expect(state.groupsById).toEqual({ 1: list[0], 2: list[1] });
+    });
+  });
+
+  describe('groupNameSearch / editingGroupId', () => {
+    it('tracks the search string', () => {
+      const state = groupsReducer(initialState(), setGroupSearchAction('foo'));
+      expect(state.groupNameSearch).toBe('foo');
+    });
+
+    it('tracks the editing group id (including reset to null)', () => {
+      let state = groupsReducer(initialState(), setEditingGroupIdAction(5));
+      expect(state.editingGroupId).toBe(5);
+      state = groupsReducer(state, setEditingGroupIdAction(null));
+      expect(state.editingGroupId).toBeNull();
+    });
+  });
+
+  describe('groupsMembersByGroupId', () => {
+    it('stores members for a group', () => {
+      const members = [makeMember(1), makeMember(2)];
+      const state = groupsReducer(initialState(), getGroupMembersActions.success({ groupId: 7, members }));
+      expect(state.groupsMembersByGroupId[7]).toEqual(members);
+    });
+
+    it('replaces a single member on update success', () => {
+      const members = [makeMember(1, USER_ROLES.VIEWER), makeMember(2, USER_ROLES.VIEWER)];
+      let state = groupsReducer(initialState(), getGroupMembersActions.success({ groupId: 7, members }));
+      const promoted = makeMember(2, USER_ROLES.EDITOR);
+      state = groupsReducer(state, updateGroupMembersActions.success({ groupId: 7, member: promoted }));
+      expect(state.groupsMembersByGroupId[7]).toEqual([members[0], promoted]);
+    });
+
+    it('removes members by user id', () => {
+      const members = [makeMember(1), makeMember(2), makeMember(3)];
+      let state = groupsReducer(initialState(), getGroupMembersActions.success({ groupId: 7, members }));
+      state = groupsReducer(state, removeGroupMembersActions.success({ groupId: 7, membersId: [1, 3] }));
+      expect(state.groupsMembersByGroupId[7]).toEqual([members[1]]);
+    });
+
+    it('appends an added member', () => {
+      const members = [makeMember(1)];
+      let state = groupsReducer(initialState(), getGroupMembersActions.success({ groupId: 7, members }));
+      const added = makeMember(2);
+      state = groupsReducer(state, addGroupMemberActions.success({ groupId: 7, member: added }));
+      expect(state.groupsMembersByGroupId[7]).toEqual([members[0], added]);
+    });
+
+    it('keeps other groups untouched when one group changes', () => {
+      let state = groupsReducer(
+        initialState(),
+        getGroupMembersActions.success({ groupId: 1, members: [makeMember(1)] }),
+      );
+      state = groupsReducer(state, getGroupMembersActions.success({ groupId: 2, members: [makeMember(2)] }));
+      state = groupsReducer(state, removeGroupMembersActions.success({ groupId: 1, membersId: [1] }));
+      expect(state.groupsMembersByGroupId[1]).toEqual([]);
+      expect(state.groupsMembersByGroupId[2]).toHaveLength(1);
+    });
+  });
+
+  describe('addMemberInputValue', () => {
+    it('tracks input and clears it when a member is added', () => {
+      // seed members so the shared addGroupMember success handler has a list to append to
+      let state = groupsReducer(initialState(), getGroupMembersActions.success({ groupId: 1, members: [] }));
+      state = groupsReducer(state, setAddMemberInputValueAction('alice@example.com'));
+      expect(state.addMemberInputValue).toBe('alice@example.com');
+      state = groupsReducer(state, addGroupMemberActions.success({ groupId: 1, member: makeMember(1) }));
+      expect(state.addMemberInputValue).toBe('');
+    });
+  });
+
+  describe('addMemberError', () => {
+    it('records the failure payload and clears on success or reset', () => {
+      let state = groupsReducer(initialState(), getGroupMembersActions.success({ groupId: 1, members: [] }));
+      state = groupsReducer(state, addGroupMemberActions.failure('ALREADY_MEMBER'));
+      expect(state.addMemberError).toBe('ALREADY_MEMBER');
+      state = groupsReducer(state, addGroupMemberActions.success({ groupId: 1, member: makeMember(1) }));
+      expect(state.addMemberError).toBeNull();
+
+      state = groupsReducer(state, addGroupMemberActions.failure('NOT_FOUND'));
+      expect(state.addMemberError).toBe('NOT_FOUND');
+      state = groupsReducer(state, resetAddMemberErrorAction());
+      expect(state.addMemberError).toBeNull();
+    });
+  });
+
+  describe('isGroupUpdating', () => {
+    it('toggles around rename and member-mutation requests', () => {
+      let state = groupsReducer(initialState(), renameGroupActions.request({ id: 1, name: 'x' }));
+      expect(state.isGroupUpdating).toBe(true);
+      state = groupsReducer(state, renameGroupActions.success());
+      expect(state.isGroupUpdating).toBe(false);
+
+      state = groupsReducer(state, addGroupMemberActions.request('a@b.com'));
+      expect(state.isGroupUpdating).toBe(true);
+      state = groupsReducer(state, addGroupMemberActions.failure('GENERIC'));
+      expect(state.isGroupUpdating).toBe(false);
+    });
+  });
+});

--- a/ui/src/store/entities/groups/groups.selectors.test.ts
+++ b/ui/src/store/entities/groups/groups.selectors.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  selectAdminGroupsList,
+  selectGroupById,
+  selectGroupsByIdsList,
+  selectHaveAnyGroups,
+  selectMemberRoles,
+  selectOrderedGroupsList,
+} from './groups.selectors.ts';
+import { USER_ROLES } from 'common/types';
+import type { GroupItem, GroupMember } from './groups.types.ts';
+import type { User } from '../users/users.types.ts';
+import type { AppState } from '../../configureAppStore.ts';
+
+const makeGroupItem = (id: number, name: string, role: USER_ROLES): GroupItem => ({ id, name, role });
+
+const makeUser = (id: number): User => ({
+  id,
+  name: `user-${id}`,
+  email: `user-${id}@example.com`,
+  external_id: `ext-${id}`,
+  avatar_url: '',
+});
+
+const makeMember = (userId: number, role: USER_ROLES): GroupMember => ({
+  id: userId * 10,
+  role,
+  user: makeUser(userId),
+});
+
+interface StateParts {
+  groupsById?: Record<number, GroupItem>;
+  groupNameSearch?: string;
+  groupsMembersByGroupId?: Record<number, Array<GroupMember>>;
+  self?: User | null;
+  editingGroupId?: number | null;
+}
+
+const buildState = ({
+  groupsById = {},
+  groupNameSearch = '',
+  groupsMembersByGroupId = {},
+  self = null,
+  editingGroupId = null,
+}: StateParts = {}): AppState =>
+  ({
+    entities: {
+      groups: { groupsById, groupNameSearch, groupsMembersByGroupId },
+      users: { self },
+    },
+    features: {
+      groupsSidebar: { editingGroupId },
+    },
+  }) as unknown as AppState;
+
+describe('selectGroupById', () => {
+  it('returns the matching group or undefined', () => {
+    const state = buildState({ groupsById: { 1: makeGroupItem(1, 'Alpha', USER_ROLES.ADMIN) } });
+    expect(selectGroupById(1)(state)?.name).toBe('Alpha');
+    expect(selectGroupById(99)(state)).toBeUndefined();
+  });
+});
+
+describe('selectHaveAnyGroups', () => {
+  it('is false with no groups and true once present', () => {
+    expect(selectHaveAnyGroups(buildState())).toBe(false);
+    expect(selectHaveAnyGroups(buildState({ groupsById: { 1: makeGroupItem(1, 'A', USER_ROLES.VIEWER) } }))).toBe(true);
+  });
+});
+
+describe('selectGroupsByIdsList', () => {
+  it('maps ids to groups and drops unknown ids', () => {
+    const state = buildState({
+      groupsById: { 1: makeGroupItem(1, 'A', USER_ROLES.ADMIN), 2: makeGroupItem(2, 'B', USER_ROLES.VIEWER) },
+    });
+    const result = selectGroupsByIdsList([2, 99, 1])(state);
+    expect(result.map(g => g.id)).toEqual([2, 1]);
+  });
+});
+
+describe('selectOrderedGroupsList', () => {
+  const groupsById = {
+    1: makeGroupItem(1, 'Charlie', USER_ROLES.ADMIN),
+    2: makeGroupItem(2, 'alpha', USER_ROLES.VIEWER),
+    3: makeGroupItem(3, 'Bravo', USER_ROLES.EDITOR),
+  };
+
+  it('sorts groups case-insensitively by name', () => {
+    const result = selectOrderedGroupsList(buildState({ groupsById }));
+    expect(result.map(g => g.name)).toEqual(['alpha', 'Bravo', 'Charlie']);
+  });
+
+  it('filters by the (case-insensitive) search term before sorting', () => {
+    const result = selectOrderedGroupsList(buildState({ groupsById, groupNameSearch: 'A' }));
+    // 'alpha', 'Bravo', and 'Charlie' all contain an 'a'
+    expect(result.map(g => g.name)).toEqual(['alpha', 'Bravo', 'Charlie']);
+
+    const narrow = selectOrderedGroupsList(buildState({ groupsById, groupNameSearch: 'bra' }));
+    expect(narrow.map(g => g.name)).toEqual(['Bravo']);
+  });
+});
+
+describe('selectAdminGroupsList', () => {
+  it('keeps only groups where the user is admin or editor', () => {
+    const groupsById = {
+      1: makeGroupItem(1, 'AdminGroup', USER_ROLES.ADMIN),
+      2: makeGroupItem(2, 'EditorGroup', USER_ROLES.EDITOR),
+      3: makeGroupItem(3, 'ViewerGroup', USER_ROLES.VIEWER),
+    };
+    const result = selectAdminGroupsList(buildState({ groupsById }));
+    expect(result.map(g => g.name)).toEqual(['AdminGroup', 'EditorGroup']);
+  });
+});
+
+describe('selectMemberRoles', () => {
+  it('reports the current user as admin and detects multiple admins', () => {
+    const state = buildState({
+      editingGroupId: 7,
+      self: makeUser(1),
+      groupsMembersByGroupId: {
+        7: [makeMember(1, USER_ROLES.ADMIN), makeMember(2, USER_ROLES.ADMIN), makeMember(3, USER_ROLES.VIEWER)],
+      },
+    });
+    expect(selectMemberRoles(state)).toEqual({ isAdmin: true, hasTwoAdmins: true });
+  });
+
+  it('reports non-admin and single-admin correctly', () => {
+    const state = buildState({
+      editingGroupId: 7,
+      self: makeUser(3),
+      groupsMembersByGroupId: {
+        7: [makeMember(1, USER_ROLES.ADMIN), makeMember(3, USER_ROLES.VIEWER)],
+      },
+    });
+    expect(selectMemberRoles(state)).toEqual({ isAdmin: false, hasTwoAdmins: false });
+  });
+
+  it('defaults to empty roles when the editing group has no members loaded', () => {
+    const state = buildState({ editingGroupId: 7, self: makeUser(1) });
+    expect(selectMemberRoles(state)).toEqual({ isAdmin: false, hasTwoAdmins: false });
+  });
+});


### PR DESCRIPTION
## Summary

Continues the §9.4 unit-test backfill (epic #662) — the entity-slice **reducers + selectors** layer, the next target called out in the triage plan (#656). No production code changes; tests only.

UI unit suite **77 → 116 tests** (+39).

| File | Tests | Covers |
|------|-------|--------|
| `datasets.reducer.test.ts` | 18 | `datasetsById` merge semantics, order/pagination resets on active-group change, loading/creating flags, `datasetGroups` share/unshare |
| `groups.reducer.test.ts` | 12 | member add/update/remove, add-member input + error lifecycle, `isGroupUpdating` toggles |
| `groups.selectors.test.ts` | 9 | ordered/filtered list sorting (case-insensitive), admin/editor filtering, `selectMemberRoles` (`isAdmin` / `hasTwoAdmins`) |

## Notes

- The `addGroupMember` success reducer assumes the group's members are already loaded (`[...state[groupId], member]` throws otherwise). This holds in the real UI flow (members load before the add control is usable); the tests seed members first to satisfy that implicit precondition. Documented here rather than changed.

## Gates

- `tsc -b`, `eslint`, `prettier --check`, full `vitest` — all green locally (116 passing).

## Remaining concerns

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017w5t7QWrNgEtTVcokjZezm)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 39 new unit tests across three new test files, covering the `datasetsReducer`, `groupsReducer`, and their associated selectors. No production code is changed.

- **`datasets.reducer.test.ts`** (18 tests): covers `datasetsById` merge semantics, pagination/order resets on active-group change, `datasetGroups` share/unshare, and the cascaded-request loading-flag design for `shareDatasetWithGroupActions` (now documented with a pinning test and comment).
- **`groups.reducer.test.ts`** (12 tests): covers member add/update/remove, input and error lifecycle for `addGroupMember`, and `isGroupUpdating` toggle paths.
- **`groups.selectors.test.ts`** (9 tests): covers case-insensitive sort/filter in `selectOrderedGroupsList`, admin/editor filtering in `selectAdminGroupsList`, and all three branches of `selectMemberRoles`.

<h3>Confidence Score: 5/5</h3>

Test-only PR with no production code changes; all new tests correctly reflect the production reducers and selectors.

All three test files exercise state shapes, action payload types, and selector input paths that precisely match the production implementations. The cascaded-request loading flag design is now documented with both a comment and a pinning test. No regressions are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/datasets/datasets.reducer.test.ts | 18 new reducer tests; state shape, action payload types, and all loading/flag transitions correctly reflect the production datasetsReducer. The cascaded-request design for areDatasetGroupsLoading is now pinned with a test and an explanatory comment. |
| ui/src/store/entities/groups/groups.reducer.test.ts | 12 new reducer tests; member mutation helpers (makeMember IDs align with member.user.id as expected by removeGroupMembersActions.success) and all toggle paths for isGroupUpdating are correctly exercised. |
| ui/src/store/entities/groups/groups.selectors.test.ts | 9 new selector tests; buildState correctly places editingGroupId under features.groupsSidebar (matching the selectEditingGroupId selector from the features slice used by selectMemberRoles) and entity groups state under entities.groups. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): cover datasetGroups clear + sh..."](https://github.com/open-reaction-database/ord-app/commit/03a79d5fc3bbaede48acddd208aaaffbbbf0ece5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35026100)</sub>

<!-- /greptile_comment -->