### PR TITLE
test(ui): unit tests for users/templates/enumeration slices

### DIFF
--- a/ui/src/store/entities/enumeration/enumeration.reducer.test.ts
+++ b/ui/src/store/entities/enumeration/enumeration.reducer.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { enumerationReducer } from './enumeration.reducer.ts';
+import {
+  enumerateBatchActions,
+  finishEnumerationAction,
+  interruptEnumerationAction,
+  startEnumerationActions,
+} from './enumeration.actions.ts';
+import type { StartEnumeration } from './enumeration.types.ts';
+
+const startPayload: StartEnumeration = {
+  dataset: 1,
+  matching: [],
+  templateCSV: { headers: [], content: [] },
+  data: {} as StartEnumeration['data'],
+  variables: [],
+};
+
+const start = () => enumerationReducer(undefined, startEnumerationActions(startPayload));
+
+describe('enumerationReducer', () => {
+  it('starts with no progress', () => {
+    expect(enumerationReducer(undefined, { type: '@@INIT' })).toEqual({ enumerationProgress: null });
+  });
+
+  it('initializes progress on start', () => {
+    const state = start();
+    expect(state.enumerationProgress).toMatchObject({
+      dataset: 1,
+      reactions: [],
+      errors: [],
+      index: 0,
+      finished: false,
+      resultDatasetId: null,
+    });
+  });
+
+  describe('enumerateBatch success', () => {
+    it('appends reactions and errors and advances the index by their combined count', () => {
+      let state = start();
+      state = enumerationReducer(
+        state,
+        enumerateBatchActions.success({ reactions: ['r1', 'r2'], errors: [{ line: 3, message: 'bad' }] }),
+      );
+      expect(state.enumerationProgress).toMatchObject({
+        reactions: ['r1', 'r2'],
+        errors: [{ line: 3, message: 'bad' }],
+        index: 3,
+      });
+
+      state = enumerationReducer(state, enumerateBatchActions.success({ reactions: ['r3'], errors: [] }));
+      expect(state.enumerationProgress?.reactions).toEqual(['r1', 'r2', 'r3']);
+      expect(state.enumerationProgress?.index).toBe(4);
+    });
+
+    it('is a no-op when there is no active progress', () => {
+      const state = enumerationReducer(undefined, enumerateBatchActions.success({ reactions: ['r1'], errors: [] }));
+      expect(state.enumerationProgress).toBeNull();
+    });
+  });
+
+  describe('finishEnumeration', () => {
+    it('marks progress finished and records the result dataset id', () => {
+      let state = start();
+      state = enumerationReducer(state, finishEnumerationAction(42));
+      expect(state.enumerationProgress).toMatchObject({ finished: true, resultDatasetId: 42 });
+    });
+
+    it('is a no-op when there is no active progress', () => {
+      const state = enumerationReducer(undefined, finishEnumerationAction(42));
+      expect(state.enumerationProgress).toBeNull();
+    });
+  });
+
+  it('clears progress on interrupt', () => {
+    let state = start();
+    state = enumerationReducer(state, interruptEnumerationAction());
+    expect(state.enumerationProgress).toBeNull();
+  });
+});

--- a/ui/src/store/entities/enumeration/enumeration.selectors.test.ts
+++ b/ui/src/store/entities/enumeration/enumeration.selectors.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectEnumerationProgress } from './enumeration.selectors.ts';
+import type { EnumerationProgress } from './enumeration.types.ts';
+import type { AppState } from '../../configureAppStore.ts';
+
+const buildState = (enumerationProgress: EnumerationProgress | null): AppState =>
+  ({ entities: { enumeration: { enumerationProgress } } }) as unknown as AppState;
+
+describe('selectEnumerationProgress', () => {
+  it('returns null when no enumeration is running', () => {
+    expect(selectEnumerationProgress(buildState(null))).toBeNull();
+  });
+
+  it('returns the current progress object', () => {
+    const progress = { index: 5, finished: false, resultDatasetId: null } as EnumerationProgress;
+    expect(selectEnumerationProgress(buildState(progress))).toBe(progress);
+  });
+});

--- a/ui/src/store/entities/templates/templates.reducer.test.ts
+++ b/ui/src/store/entities/templates/templates.reducer.test.ts
@@ -60,14 +60,32 @@ describe('templatesReducer', () => {
     });
   });
 
+  // One case per request/resolve pair so each reset branch of the isAnyOf matcher is
+  // independently covered (create success, create failure, get success, get failure).
   describe('isTemplateCreating', () => {
-    it('is true while a create or get request is pending', () => {
+    it('toggles around the create flow (request -> success)', () => {
       let state = templatesReducer(initialState(), createNewTemplateActions.request({} as never));
       expect(state.isTemplateCreating).toBe(true);
       state = templatesReducer(state, createNewTemplateActions.success(makeTemplate('a')));
       expect(state.isTemplateCreating).toBe(false);
+    });
 
-      state = templatesReducer(state, getTemplateActions.request(1));
+    it('toggles around the create flow (request -> failure)', () => {
+      let state = templatesReducer(initialState(), createNewTemplateActions.request({} as never));
+      expect(state.isTemplateCreating).toBe(true);
+      state = templatesReducer(state, createNewTemplateActions.failure(new Error('x')));
+      expect(state.isTemplateCreating).toBe(false);
+    });
+
+    it('toggles around the get flow (request -> success)', () => {
+      let state = templatesReducer(initialState(), getTemplateActions.request(1));
+      expect(state.isTemplateCreating).toBe(true);
+      state = templatesReducer(state, getTemplateActions.success(makeTemplate('a')));
+      expect(state.isTemplateCreating).toBe(false);
+    });
+
+    it('toggles around the get flow (request -> failure)', () => {
+      let state = templatesReducer(initialState(), getTemplateActions.request(1));
       expect(state.isTemplateCreating).toBe(true);
       state = templatesReducer(state, getTemplateActions.failure(new Error('x')));
       expect(state.isTemplateCreating).toBe(false);

--- a/ui/src/store/entities/templates/templates.reducer.test.ts
+++ b/ui/src/store/entities/templates/templates.reducer.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { templatesReducer } from './templates.reducer.ts';
+import {
+  createNewTemplateActions,
+  getAllTemplatesActions,
+  getTemplateActions,
+  importTemplateFromFileActions,
+  removeTemplateActions,
+} from './templates.actions.ts';
+import type { ReactionTemplate } from 'store/entities/reactions/reactions.types.ts';
+
+// The reducer only reads `template.id`, so a minimal stub keeps the test focused.
+const makeTemplate = (id: string): ReactionTemplate => ({ id, name: `template-${id}` }) as ReactionTemplate;
+
+const initialState = () => templatesReducer(undefined, { type: '@@INIT' });
+
+describe('templatesReducer', () => {
+  it('returns the initial state', () => {
+    expect(initialState()).toEqual({ templatesOrder: [], isTemplateCreating: false });
+  });
+
+  describe('templatesOrder', () => {
+    it('records the order of ids from a full fetch', () => {
+      const state = templatesReducer(
+        initialState(),
+        getAllTemplatesActions.success([makeTemplate('a'), makeTemplate('b'), makeTemplate('c')]),
+      );
+      expect(state.templatesOrder).toEqual(['a', 'b', 'c']);
+    });
+
+    it('removes the deleted template id', () => {
+      let state = templatesReducer(
+        initialState(),
+        getAllTemplatesActions.success([makeTemplate('a'), makeTemplate('b')]),
+      );
+      state = templatesReducer(state, removeTemplateActions.success('a'));
+      expect(state.templatesOrder).toEqual(['b']);
+    });
+
+    it('prepends newly created and imported templates', () => {
+      let state = templatesReducer(initialState(), getAllTemplatesActions.success([makeTemplate('a')]));
+      state = templatesReducer(state, createNewTemplateActions.success(makeTemplate('b')));
+      state = templatesReducer(state, importTemplateFromFileActions.success(makeTemplate('c')));
+      expect(state.templatesOrder).toEqual(['c', 'b', 'a']);
+    });
+  });
+
+  describe('isTemplateCreating', () => {
+    it('is true while a create or get request is pending', () => {
+      let state = templatesReducer(initialState(), createNewTemplateActions.request({} as never));
+      expect(state.isTemplateCreating).toBe(true);
+      state = templatesReducer(state, createNewTemplateActions.success(makeTemplate('a')));
+      expect(state.isTemplateCreating).toBe(false);
+
+      state = templatesReducer(state, getTemplateActions.request(1));
+      expect(state.isTemplateCreating).toBe(true);
+      state = templatesReducer(state, getTemplateActions.failure(new Error('x')));
+      expect(state.isTemplateCreating).toBe(false);
+    });
+  });
+});

--- a/ui/src/store/entities/templates/templates.selectors.test.ts
+++ b/ui/src/store/entities/templates/templates.selectors.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectTemplates, selectTemplatesOrder } from './templates.selectors.ts';
+import type { ReactionTemplate } from 'store/entities/reactions/reactions.types.ts';
+import type { AppState } from '../../configureAppStore.ts';
+
+const makeTemplate = (id: string): ReactionTemplate => ({ id, name: `template-${id}` }) as ReactionTemplate;
+
+const buildState = (templatesOrder: Array<string>, reactionsById: Record<string, ReactionTemplate>): AppState =>
+  ({
+    entities: {
+      templates: { templatesOrder },
+      reactions: { reactionsById },
+    },
+  }) as unknown as AppState;
+
+describe('selectTemplatesOrder', () => {
+  it('returns the stored order', () => {
+    expect(selectTemplatesOrder(buildState(['a', 'b'], {}))).toEqual(['a', 'b']);
+  });
+});
+
+describe('selectTemplates', () => {
+  it('resolves the ordered ids against the reactions store', () => {
+    const a = makeTemplate('a');
+    const b = makeTemplate('b');
+    const state = buildState(['b', 'a'], { a, b });
+    expect(selectTemplates(state)).toEqual([b, a]);
+  });
+
+  it('returns an empty list when there is no order', () => {
+    expect(selectTemplates(buildState([], { a: makeTemplate('a') }))).toEqual([]);
+  });
+});

--- a/ui/src/store/entities/templates/templates.selectors.test.ts
+++ b/ui/src/store/entities/templates/templates.selectors.test.ts
@@ -45,4 +45,13 @@ describe('selectTemplates', () => {
   it('returns an empty list when there is no order', () => {
     expect(selectTemplates(buildState([], { a: makeTemplate('a') }))).toEqual([]);
   });
+
+  // An id can be in templatesOrder before its reaction data has loaded (getAllTemplates
+  // populates the order, individual reaction data arrives separately). The selector does
+  // an unguarded lookup, so it yields undefined for the missing entry — pin that behavior.
+  it('yields undefined for an ordered id that is not yet in the reactions store', () => {
+    const a = makeTemplate('a');
+    const result = selectTemplates(buildState(['a', 'missing'], { a }));
+    expect(result).toEqual([a, undefined]);
+  });
 });

--- a/ui/src/store/entities/users/users.reducer.test.ts
+++ b/ui/src/store/entities/users/users.reducer.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { usersReducer } from './users.reducer.ts';
+import { createUserActions } from './users.actions.ts';
+import type { User } from './users.types.ts';
+
+const user: User = {
+  id: 1,
+  name: 'Ada',
+  email: 'ada@example.com',
+  external_id: 'ext-1',
+  avatar_url: 'https://example.com/a.png',
+};
+
+describe('usersReducer', () => {
+  it('starts with a null self', () => {
+    expect(usersReducer(undefined, { type: '@@INIT' })).toEqual({ self: null });
+  });
+
+  it('stores the authenticated user on create success', () => {
+    const state = usersReducer(undefined, createUserActions.success(user));
+    expect(state.self).toEqual(user);
+  });
+
+  it('ignores unrelated actions', () => {
+    const seeded = usersReducer(undefined, createUserActions.success(user));
+    const next = usersReducer(seeded, { type: 'other/action' });
+    expect(next.self).toBe(seeded.self);
+  });
+});

--- a/ui/src/store/entities/users/users.selectors.test.ts
+++ b/ui/src/store/entities/users/users.selectors.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectSelf } from './users.selectors.ts';
+import type { User } from './users.types.ts';
+import type { AppState } from '../../configureAppStore.ts';
+
+const buildState = (self: User | null): AppState => ({ entities: { users: { self } } }) as unknown as AppState;
+
+describe('selectSelf', () => {
+  it('returns null when no user is authenticated', () => {
+    expect(selectSelf(buildState(null))).toBeNull();
+  });
+
+  it('returns the authenticated user', () => {
+    const user: User = {
+      id: 1,
+      name: 'Ada',
+      email: 'ada@example.com',
+      external_id: 'ext-1',
+      avatar_url: '',
+    };
+    expect(selectSelf(buildState(user))).toBe(user);
+  });
+});


### PR DESCRIPTION
## Summary

Continues the §9.4 unit-test backfill (epic #662), covering the remaining entity-slice reducers and their selectors. Tests only; no production code changes.

| Module | Tests | Covers |
|--------|-------|--------|
| `users.reducer` + `users.selectors` | 3 + 2 | auth-user storage on create success, `selectSelf` |
| `templates.reducer` + `templates.selectors` | 5 + 3 | order on fetch/remove and create/import prepend, `isTemplateCreating` toggles, `selectTemplates` resolving ids against the reactions store |
| `enumeration.reducer` + `enumeration.selectors` | 7 + 2 | start initialization, batch append + index math, finish/interrupt transitions, null-progress no-ops |

## Notes

- `templates.reducer` only reads `template.id`, so the reducer tests use a minimal `ReactionTemplate` stub (`{ id, name } as ReactionTemplate`) rather than a full proto-backed fixture — keeps the test focused on the ordering logic under test.

## Gates

- `tsc -b`, `eslint`, `prettier --check`, full `vitest` — all green locally.

## Remaining concerns

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017w5t7QWrNgEtTVcokjZezm)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds unit tests for the `users`, `templates`, and `enumeration` slice reducers and selectors, with no changes to production code. This is a test backfill under epic #662.

- **Users**: 3 reducer tests (initial state, create-success, unrelated-action passthrough) and 2 selector tests for `selectSelf`.
- **Templates**: 5 reducer tests covering `templatesOrder` ordering/removal/prepend and 4 independent `isTemplateCreating` toggle cases (all branches of the `isAnyOf` matcher now exercised); 3 selector tests for `selectTemplates` including a newly added case for an id present in `templatesOrder` but absent from the reactions store.
- **Enumeration**: 7 reducer tests covering initialization, batch-append index math, finish/interrupt transitions, and null-progress no-ops; 2 selector tests for `selectEnumerationProgress`.

<h3>Confidence Score: 5/5</h3>

Pure test additions with no production code changes; safe to merge.

All six new test files correctly reflect the production reducer and selector logic — action shapes, state paths, index arithmetic, and guard conditions all match. The previous review concerns about uncovered isTemplateCreating branches and the missing-id selector case have both been addressed directly in this PR.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/enumeration/enumeration.reducer.test.ts | Correct index-math assertions and null-guard no-op tests; start/finish/interrupt all properly exercised. |
| ui/src/store/entities/enumeration/enumeration.selectors.test.ts | Simple null and progress-object identity tests; state shape matches the selector's access path. |
| ui/src/store/entities/templates/templates.reducer.test.ts | All four isTemplateCreating branches now covered in separate it-blocks; templatesOrder ordering/removal/prepend fully exercised. |
| ui/src/store/entities/templates/templates.selectors.test.ts | Resolves-by-order, empty-order, and missing-id (undefined pin) cases all covered; state shape aligns with selectReactions access path. |
| ui/src/store/entities/users/users.reducer.test.ts | Clean tests for initial state, create-success storage, and unrelated-action passthrough; no issues. |
| ui/src/store/entities/users/users.selectors.test.ts | Null and authenticated-user identity cases covered; state shape correct for selectSelf. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([null]) -->|startEnumerationActions| B[EnumerationProgress: reactions empty, index=0, finished=false]
    B -->|enumerateBatchActions.success| C[EnumerationProgress: reactions appended, index advanced]
    C -->|enumerateBatchActions.success| C
    C -->|finishEnumerationAction| D[EnumerationProgress: finished=true, resultDatasetId set]
    B -->|interruptEnumerationAction| A
    C -->|interruptEnumerationAction| A
    D -->|interruptEnumerationAction| A
    A -->|enumerateBatchActions.success no-op| A
    A -->|finishEnumerationAction no-op| A
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/test-bac..."](https://github.com/open-reaction-database/ord-app/commit/215df5c6525e3e42c02a1fb44a1cd43d34de16ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35026539)</sub>

<!-- /greptile_comment -->