### PR TITLE
chore: fold tox.ini into pyproject + add coverage reporter config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
       # merging this upload with the UI lcov via the `python`/`ui` flags.
       - name: Upload coverage to Codecov
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: coverage.xml
           flags: python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,11 +79,13 @@ jobs:
       # merging this upload with the UI lcov via the `python`/`ui` flags.
       - name: Upload coverage to Codecov
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: coverage.xml
           flags: python
           token: ${{ secrets.CODECOV_TOKEN }}
+          # Strict on push + same-repo PRs; tolerate fork/dependabot (tokenless). Mirrors ord-schema.
+          fail_ci_if_error: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot/')) }}
 
       - name: Upload Python coverage report
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,8 @@ jobs:
         with:
           files: coverage.xml
           flags: python
+          # CODECOV_TOKEN is an org-wide token, so the repo slug must be explicit.
+          slug: open-reaction-database/ord-app
           token: ${{ secrets.CODECOV_TOKEN }}
           # Strict on push + same-repo PRs; tolerate fork/dependabot (tokenless). Mirrors ord-schema.
           fail_ci_if_error: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot/')) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-14"]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Check out repository
@@ -72,8 +75,16 @@ jobs:
           {
             echo "### Python test coverage"
             echo ""
-            uv run coverage report --format=markdown
-          } >> "$GITHUB_STEP_SUMMARY"
+            uv run coverage report --format=markdown || echo "_coverage data unavailable_"
+          } > coverage-comment.md
+          cat coverage-comment.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment Python coverage on PR
+        if: ${{ always() && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: python-coverage
+          path: coverage-comment.md
 
       - name: Upload Python coverage report
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-14"]
     runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-      pull-requests: write
 
     steps:
       - name: Check out repository
@@ -76,15 +73,17 @@ jobs:
             echo "### Python test coverage"
             echo ""
             uv run coverage report --format=markdown || echo "_coverage data unavailable_"
-          } > coverage-comment.md
-          cat coverage-comment.md >> "$GITHUB_STEP_SUMMARY"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Comment Python coverage on PR
-        if: ${{ always() && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+      # Codecov posts the PR comment with project (total) + patch (delta) coverage,
+      # merging this upload with the UI lcov via the `python`/`ui` flags.
+      - name: Upload coverage to Codecov
+        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
-          header: python-coverage
-          path: coverage-comment.md
+          files: coverage.xml
+          flags: python
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload Python coverage report
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,11 +60,30 @@ jobs:
           PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
 
       - name: Run tests
-        run: uv run pytest -vv --cov=ord_app --durations=10
+        run: uv run pytest -vv --cov=ord_app --cov-report=term-missing --cov-report=xml --cov-report=html --durations=10
         env:
           PG_DSN: "postgresql+asyncpg://ord:password@localhost:5432/test"
           PG_ALEMBIC_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
           PG_TEST_DSN: "postgresql+psycopg://ord:password@localhost:5432/test"
+
+      - name: Coverage summary
+        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
+        run: |
+          {
+            echo "### Python test coverage"
+            echo ""
+            uv run coverage report --format=markdown
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Python coverage report
+        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: python-coverage
+          path: |
+            coverage.xml
+            htmlcov/
+          retention-days: 7
 
   test_e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/ui_checks.yml
+++ b/.github/workflows/ui_checks.yml
@@ -42,9 +42,6 @@ jobs:
 
   test_ui:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -61,16 +58,18 @@ jobs:
               echo "### UI test coverage"
               echo ""
               jq -r '.total | "| Metric | % | Covered / Total |\n|---|---:|---:|\n| Lines | \(.lines.pct)% | \(.lines.covered) / \(.lines.total) |\n| Statements | \(.statements.pct)% | \(.statements.covered) / \(.statements.total) |\n| Functions | \(.functions.pct)% | \(.functions.covered) / \(.functions.total) |\n| Branches | \(.branches.pct)% | \(.branches.covered) / \(.branches.total) |"' coverage/coverage-summary.json
-            } > coverage-comment.md
-            cat coverage-comment.md >> "$GITHUB_STEP_SUMMARY"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Comment UI coverage on PR
-        if: ${{ always() && github.event_name == 'pull_request' && hashFiles('ui/coverage-comment.md') != '' }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+      # Codecov merges this lcov upload (ui flag) with the Python coverage.xml
+      # (python flag) into one PR comment with project (total) + patch (delta) coverage.
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
-          header: ui-coverage
-          path: ui/coverage-comment.md
+          files: ui/coverage/lcov.info
+          flags: ui
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload UI coverage report
         if: always()

--- a/.github/workflows/ui_checks.yml
+++ b/.github/workflows/ui_checks.yml
@@ -48,4 +48,23 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
-      - run: npm run test
+      - run: npm run test:coverage
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            {
+              echo "### UI test coverage"
+              echo ""
+              jq -r '.total | "| Metric | % | Covered / Total |\n|---|---:|---:|\n| Lines | \(.lines.pct)% | \(.lines.covered) / \(.lines.total) |\n| Statements | \(.statements.pct)% | \(.statements.covered) / \(.statements.total) |\n| Functions | \(.functions.pct)% | \(.functions.covered) / \(.functions.total) |\n| Branches | \(.branches.pct)% | \(.branches.covered) / \(.branches.total) |"' coverage/coverage-summary.json
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload UI coverage report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ui-coverage
+          path: ui/coverage/
+          retention-days: 7

--- a/.github/workflows/ui_checks.yml
+++ b/.github/workflows/ui_checks.yml
@@ -65,11 +65,13 @@ jobs:
       # (python flag) into one PR comment with project (total) + patch (delta) coverage.
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: ui/coverage/lcov.info
           flags: ui
           token: ${{ secrets.CODECOV_TOKEN }}
+          # Strict on push + same-repo PRs; tolerate fork/dependabot (tokenless). Mirrors ord-schema.
+          fail_ci_if_error: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot/')) }}
 
       - name: Upload UI coverage report
         if: always()

--- a/.github/workflows/ui_checks.yml
+++ b/.github/workflows/ui_checks.yml
@@ -42,6 +42,9 @@ jobs:
 
   test_ui:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -58,8 +61,16 @@ jobs:
               echo "### UI test coverage"
               echo ""
               jq -r '.total | "| Metric | % | Covered / Total |\n|---|---:|---:|\n| Lines | \(.lines.pct)% | \(.lines.covered) / \(.lines.total) |\n| Statements | \(.statements.pct)% | \(.statements.covered) / \(.statements.total) |\n| Functions | \(.functions.pct)% | \(.functions.covered) / \(.functions.total) |\n| Branches | \(.branches.pct)% | \(.branches.covered) / \(.branches.total) |"' coverage/coverage-summary.json
-            } >> "$GITHUB_STEP_SUMMARY"
+            } > coverage-comment.md
+            cat coverage-comment.md >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Comment UI coverage on PR
+        if: ${{ always() && github.event_name == 'pull_request' && hashFiles('ui/coverage-comment.md') != '' }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: ui-coverage
+          path: ui/coverage-comment.md
 
       - name: Upload UI coverage report
         if: always()

--- a/.github/workflows/ui_checks.yml
+++ b/.github/workflows/ui_checks.yml
@@ -69,6 +69,8 @@ jobs:
         with:
           files: ui/coverage/lcov.info
           flags: ui
+          # CODECOV_TOKEN is an org-wide token, so the repo slug must be explicit.
+          slug: open-reaction-database/ord-app
           token: ${{ secrets.CODECOV_TOKEN }}
           # Strict on push + same-repo PRs; tolerate fork/dependabot (tokenless). Mirrors ord-schema.
           fail_ci_if_error: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot/')) }}

--- a/.github/workflows/ui_checks.yml
+++ b/.github/workflows/ui_checks.yml
@@ -65,7 +65,7 @@ jobs:
       # (python flag) into one PR comment with project (total) + patch (delta) coverage.
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ui/coverage/lcov.info
           flags: ui

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ COPY migrations/ ./migrations/
 COPY alembic.ini .
 COPY uv.lock .
 COPY pyproject.toml .
-COPY tox.ini .
 COPY ord_app/ ./ord_app
 
 RUN uv sync --frozen

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,44 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Codecov configuration. Coverage is uploaded from two jobs under separate
+# flags (`python` from tests.yml, `ui` from ui_checks.yml) and merged into a
+# single PR comment reporting project (total) + patch (delta) coverage.
+
+coverage:
+  status:
+    # Report-only: surface project/patch coverage without failing the PR.
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+flag_management:
+  default_rules:
+    # A PR that only touches one language still shows the other's coverage
+    # (carried forward from the base commit) instead of dropping to unknown.
+    carryforward: true
+  individual_flags:
+    - name: python
+      paths:
+        - ord_app/
+    - name: ui
+      paths:
+        - ui/
+
+comment:
+  layout: "condensed_header, diff, flags, files"
+  require_changes: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,12 @@ dev = [
 [tool.uv]
 package = false
 
+# Pytest config lives here (single source of truth); the former root tox.ini
+# (which only held a [pytest] section, no tox config) has been folded in.
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+
 # Ruff config lives here (single source of truth); the former root ruff.toml
 # took precedence over [tool.ruff] and has been folded in.
 [tool.ruff]

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,0 @@
-[pytest]
-asyncio_mode=auto
-asyncio_default_fixture_loop_scope=function

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -36,7 +36,9 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      // text/text-summary -> console; html + lcov -> uploaded artifacts; json-summary -> CI step summary.
+      reporter: ['text', 'text-summary', 'html', 'lcov', 'json-summary'],
+      reportsDirectory: './coverage',
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/**/*.test.{ts,tsx}', 'src/**/*.d.ts', 'src/test/**', 'src/**/*.module.scss'],
     },


### PR DESCRIPTION
## Summary

Config cleanups plus full CI coverage reporting (total + delta) via Codecov.

1. **Fold `tox.ini` into `pyproject.toml`** — the root `tox.ini` only held a `[pytest]` section (asyncio settings), no actual tox config. Moved to `[tool.pytest.ini_options]` as the single source of truth, mirroring the earlier `ruff.toml` consolidation (#682). Also dropped the now-obsolete `COPY tox.ini` from the `Dockerfile`.
2. **Coverage reporters** — `vite.config.ts` emits `lcov` (+ `text-summary`/`json-summary`) so the UI suite produces a Codecov-ingestible report.
3. **Coverage in CI** — both test jobs produce coverage and report it three ways:
   - **Codecov PR comment** with project (total) + patch (delta) coverage, merging Python (`coverage.xml`, `python` flag) and UI (`lcov.info`, `ui` flag) into one comment. `codecov.yml` defines the flags (carryforward so a single-language PR still shows the other's coverage) and keeps project/patch statuses informational (no failing gate).
   - **Step summaries** — a markdown coverage table in each job's run summary.
   - **Artifacts** — `coverage.xml` + `htmlcov/` (Python, ubuntu) and `ui/coverage/` (UI), retained 7 days.

Codecov uses the org-wide `CODECOV_TOKEN`; an explicit `slug: open-reaction-database/ord-app` is set so uploads attribute correctly (org tokens, unlike per-repo tokens, don't identify the project). `fail_ci_if_error` mirrors ord-schema: strict on push + same-repo PRs, tolerant of fork/Dependabot.

> **Note:** This PR's Codecov comment is the first-time "Welcome to Codecov" message — `main` has no baseline coverage yet. Once this merges, subsequent PRs get the full project + patch comment.

## Gates

- `pyproject.toml` valid TOML; `pytest --co` loads config from it; `vitest run --coverage` produces `coverage-summary.json` + `lcov.info` locally; `codecov.yml` validates against the Codecov API; both workflow files validate as YAML; CI green; Codecov uploads confirmed landing in `open-reaction-database/ord-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017w5t7QWrNgEtTVcokjZezm)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates pytest configuration from `tox.ini` into `pyproject.toml`, removes the now-redundant `COPY tox.ini` from the `Dockerfile`, and wires up coverage reporting for both the Python and UI test suites (step summaries, Codecov uploads with `python`/`ui` flags, and artifact retention).

- `tox.ini`'s sole `[pytest]` section (`asyncio_mode`, `asyncio_default_fixture_loop_scope`) is faithfully reproduced under `[tool.pytest.ini_options]` in `pyproject.toml`; config values are identical.
- `vite.config.ts` adds `text-summary`, `lcov`, and `json-summary` reporters and an explicit `reportsDirectory`; the CI workflows consume these outputs via `jq` for the step summary and `codecov/codecov-action` for upload.
- `codecov.yml` configures informational-only status checks with carryforward flag management so a PR touching only one language still shows the other's coverage.

<h3>Confidence Score: 5/5</h3>

All changes are config consolidation and CI observability additions with no impact on runtime behavior; safe to merge.

The pytest config migration preserves identical values, the Dockerfile update correctly drops a now-deleted file, and the coverage wiring is additive with no threshold gates that could break CI.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Added [tool.pytest.ini_options] section with asyncio settings migrated from the deleted tox.ini; values are identical. |
| tox.ini | Deleted; its sole [pytest] section has been moved to pyproject.toml. |
| Dockerfile | Dropped COPY tox.ini since pytest config now lives in the already-copied pyproject.toml. |
| ui/vite.config.ts | Expanded coverage reporters to include text-summary, lcov, and json-summary; added explicit reportsDirectory. |
| .github/workflows/tests.yml | Added XML/HTML coverage flags to pytest, coverage markdown summary step, Codecov upload, and artifact upload — all gated to ubuntu-latest only. |
| .github/workflows/ui_checks.yml | Switched from npm run test to test:coverage and added jq-based coverage summary, Codecov upload, and artifact upload steps; missing trailing newline. |
| codecov.yml | New file: configures Codecov with informational-only project/patch status, carryforward flag management for python and ui flags, and comment layout. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant PY as test_python (ubuntu)
    participant UI as test_ui
    participant CC as Codecov
    participant AR as Artifacts

    GH->>PY: trigger on push/PR
    PY->>PY: "uv run pytest --cov=ord_app --cov-report=xml,html,term-missing"
    PY->>GH: coverage report → $GITHUB_STEP_SUMMARY
    PY->>CC: upload coverage.xml (flag: python)
    PY->>AR: upload coverage.xml + htmlcov/ (7 days)

    GH->>UI: "trigger on push/PR (ui/** paths)"
    UI->>UI: npm run test:coverage
    UI->>UI: vitest emits lcov.info + json-summary
    UI->>GH: jq coverage-summary.json → $GITHUB_STEP_SUMMARY
    UI->>CC: upload ui/coverage/lcov.info (flag: ui)
    UI->>AR: upload ui/coverage/ (7 days)

    CC->>GH: PR comment (project + patch coverage, both flags merged)
```
</details>

<sub>Reviews (5): Last reviewed commit: ["ci: set explicit Codecov slug for org-wi..."](https://github.com/open-reaction-database/ord-app/commit/0bcea2f9305fdf20be99a79550ce0bb16823bd87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35032587)</sub>

<!-- /greptile_comment -->
