### PR TITLE
test(ui): unit tests for reaction sub-entity converters + form/date utils

### DIFF
--- a/ui/src/common/utils/date.test.ts
+++ b/ui/src/common/utils/date.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { convertUtcDateToUserTZ, convertUserTZDateToUtc, formatUtcDateToDisplay, formatDateToDisplay } from './date.ts';
+import { DATE_TIME_FORMAT } from '../constants.ts';
+
+// DATE_TIME_HUMAN_FORMAT renders as e.g. "01.06.2024 02:00 pm" (DD.MM.YYYY hh:mm a).
+const humanFormat = /^\d{2}\.\d{2}\.\d{4} \d{2}:\d{2} (am|pm)$/;
+
+describe('timezone conversions', () => {
+  it('changes the displayed zone without moving the instant', () => {
+    const iso = '2024-06-01T12:00:00Z';
+    expect(convertUtcDateToUserTZ(iso).valueOf()).toBe(Date.parse(iso));
+  });
+
+  it('round-trips a UTC instant through the user timezone and back', () => {
+    const iso = '2024-06-01T12:00:00Z';
+    const userLocal = convertUtcDateToUserTZ(iso).format(DATE_TIME_FORMAT);
+    expect(convertUserTZDateToUtc(userLocal).valueOf()).toBe(Date.parse(iso));
+  });
+});
+
+describe('display formatting', () => {
+  it('formats a UTC date with the human-readable format', () => {
+    expect(formatUtcDateToDisplay('2024-06-01T12:00:00Z')).toMatch(humanFormat);
+  });
+
+  it('formats a local date/Date with the human-readable format', () => {
+    expect(formatDateToDisplay('2024-06-01T12:00:00')).toMatch(humanFormat);
+    expect(formatDateToDisplay(new Date('2024-06-01T12:00:00'))).toMatch(humanFormat);
+  });
+});

--- a/ui/src/common/utils/date.test.ts
+++ b/ui/src/common/utils/date.test.ts
@@ -15,21 +15,23 @@
  */
 import { describe, it, expect } from 'vitest';
 import { convertUtcDateToUserTZ, convertUserTZDateToUtc, formatUtcDateToDisplay, formatDateToDisplay } from './date.ts';
-import { DATE_TIME_FORMAT } from '../constants.ts';
 
 // DATE_TIME_HUMAN_FORMAT renders as e.g. "01.06.2024 02:00 pm" (DD.MM.YYYY hh:mm a).
 const humanFormat = /^\d{2}\.\d{2}\.\d{4} \d{2}:\d{2} (am|pm)$/;
 
+// These assert timezone-independent invariants (instant + UTC offset) so they stay meaningful on a
+// UTC CI runner, where a wall-clock round trip through the guessed zone would pass vacuously.
 describe('timezone conversions', () => {
-  it('changes the displayed zone without moving the instant', () => {
+  it('parses a UTC string without moving the instant', () => {
     const iso = '2024-06-01T12:00:00Z';
     expect(convertUtcDateToUserTZ(iso).valueOf()).toBe(Date.parse(iso));
   });
 
-  it('round-trips a UTC instant through the user timezone and back', () => {
-    const iso = '2024-06-01T12:00:00Z';
-    const userLocal = convertUtcDateToUserTZ(iso).format(DATE_TIME_FORMAT);
-    expect(convertUserTZDateToUtc(userLocal).valueOf()).toBe(Date.parse(iso));
+  it('converts an absolute Date to a UTC-mode value at the same instant', () => {
+    const date = new Date('2024-06-01T12:00:00Z');
+    const utc = convertUserTZDateToUtc(date);
+    expect(utc.valueOf()).toBe(date.getTime());
+    expect(utc.utcOffset()).toBe(0);
   });
 });
 

--- a/ui/src/common/utils/reactionForm/createBooleanInput.test.ts
+++ b/ui/src/common/utils/reactionForm/createBooleanInput.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { createBooleanInput } from './createBooleanInput.ts';
+import {
+  ReactionFormNodeType,
+  type ReactionFormSelect,
+} from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+import { booleanOptions } from 'features/reactions/ReactionEntities/entityFormConfiguration/booleanOptions.ts';
+
+describe('createBooleanInput', () => {
+  it('builds a segmented select node from the shared boolean options', () => {
+    const wrapperConfig = { label: 'Exothermic?' } as ReactionFormSelect['wrapperConfig'];
+    expect(createBooleanInput('isExothermic', wrapperConfig)).toEqual({
+      type: ReactionFormNodeType.select,
+      name: 'isExothermic',
+      selectType: 'segmented',
+      options: booleanOptions,
+      wrapperConfig,
+    });
+  });
+});

--- a/ui/src/common/utils/reactionForm/ordMapToKeyValueObject.test.ts
+++ b/ui/src/common/utils/reactionForm/ordMapToKeyValueObject.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { ordMapToKeyValueObject } from './ordMapToKeyValueObject.ts';
+
+describe('ordMapToKeyValueObject', () => {
+  it('turns a record into label/value pairs, stringifying the key as the label', () => {
+    expect(ordMapToKeyValueObject({ GRAM: 1, MILLIGRAM: 2 })).toEqual([
+      { label: 'GRAM', value: 1 },
+      { label: 'MILLIGRAM', value: 2 },
+    ]);
+  });
+
+  it('preserves string values', () => {
+    expect(ordMapToKeyValueObject({ X: 'x' })).toEqual([{ label: 'X', value: 'x' }]);
+  });
+
+  it('returns an empty array for an empty record', () => {
+    expect(ordMapToKeyValueObject({})).toEqual([]);
+  });
+});

--- a/ui/src/common/utils/reactionForm/wrapInputsWithGrid.test.ts
+++ b/ui/src/common/utils/reactionForm/wrapInputsWithGrid.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { wrapInputsWithGrid } from './wrapInputsWithGrid.ts';
+import {
+  ReactionFormNodeType,
+  type ReactionFormNode,
+} from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const node = (name: string): ReactionFormNode => ({ type: ReactionFormNodeType.value, name }) as ReactionFormNode;
+
+describe('wrapInputsWithGrid', () => {
+  it('wraps inputs in a grid whose column count is the number of fields', () => {
+    const a = node('a');
+    const b = node('b');
+    expect(wrapInputsWithGrid(a, b)).toEqual({
+      type: ReactionFormNodeType.wrapper,
+      grid: 2,
+      fields: [a, b],
+    });
+  });
+
+  it('handles a single input', () => {
+    const a = node('a');
+    expect(wrapInputsWithGrid(a)).toMatchObject({ grid: 1, fields: [a] });
+  });
+
+  it('handles no inputs', () => {
+    expect(wrapInputsWithGrid()).toMatchObject({ grid: 0, fields: [] });
+  });
+});

--- a/ui/src/store/entities/reactions/reactionAmount/reactionAmount.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionAmount/reactionAmount.converters.test.ts
@@ -15,12 +15,19 @@
  */
 import { describe, it, expect } from 'vitest';
 import { ordAmountToReaction, reactionAmountToOrd } from './reactionAmount.converters.ts';
-import { appAmountUnspecified, massUnitNames, volumeUnitNames, unitValueByName } from './reactionAmount.models.ts';
-import type { AppMassUnit, AppVolumeUnit } from './reactionAmount.types.ts';
+import {
+  appAmountUnspecified,
+  massUnitNames,
+  molesUnitNames,
+  volumeUnitNames,
+  unitValueByName,
+} from './reactionAmount.models.ts';
+import type { AppMassUnit, AppMolesUnit, AppVolumeUnit } from './reactionAmount.types.ts';
 import { ReactionBoolean } from '../reactionEntity/reactionEntity.types.ts';
 
 // Object.keys() widens these to string[]; narrow back to the unit unions for the converters.
 const massUnit = massUnitNames[0] as AppMassUnit;
+const molesUnit = molesUnitNames[0] as AppMolesUnit;
 const volumeUnit = volumeUnitNames[0] as AppVolumeUnit;
 
 describe('reactionAmountToOrd', () => {
@@ -43,9 +50,21 @@ describe('reactionAmountToOrd', () => {
       volumeIncludesSolutes: ReactionBoolean.Unspecified,
     });
     expect(result?.mass).toEqual({ value: 5, precision: 0.1, units: unitValueByName[massUnit] });
-    // A mass amount is not a volume, so volumeIncludesSolutes is dropped.
+    // A mass amount is not a volume, so volumeIncludesSolutes is set to null (present, not omitted).
     expect(result?.volumeIncludesSolutes).toBeNull();
     expect(result?.moles).toBeUndefined();
+  });
+
+  it('nests a moles amount under the moles key', () => {
+    const result = reactionAmountToOrd({
+      value: 3,
+      precision: null,
+      units: molesUnit,
+      volumeIncludesSolutes: ReactionBoolean.Unspecified,
+    });
+    expect(result?.moles).toEqual({ value: 3, precision: null, units: unitValueByName[molesUnit] });
+    expect(result?.mass).toBeUndefined();
+    expect(result?.volume).toBeUndefined();
   });
 
   it('keeps volumeIncludesSolutes only for volume units', () => {
@@ -92,11 +111,15 @@ describe('ordAmountToReaction', () => {
 });
 
 describe('round trip', () => {
-  it('preserves a mass amount through ord and back', () => {
+  it.each([
+    ['mass', massUnit],
+    ['moles', molesUnit],
+    ['volume', volumeUnit],
+  ])('preserves a %s amount through ord and back', (_dimension, units) => {
     const amount = {
       value: 12,
       precision: 0.5,
-      units: massUnit,
+      units,
       volumeIncludesSolutes: ReactionBoolean.Unspecified,
     };
     expect(ordAmountToReaction(reactionAmountToOrd(amount))).toMatchObject(amount);

--- a/ui/src/store/entities/reactions/reactionAmount/reactionAmount.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionAmount/reactionAmount.converters.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { ordAmountToReaction, reactionAmountToOrd } from './reactionAmount.converters.ts';
+import { appAmountUnspecified, massUnitNames, volumeUnitNames, unitValueByName } from './reactionAmount.models.ts';
+import type { AppMassUnit, AppVolumeUnit } from './reactionAmount.types.ts';
+import { ReactionBoolean } from '../reactionEntity/reactionEntity.types.ts';
+
+// Object.keys() widens these to string[]; narrow back to the unit unions for the converters.
+const massUnit = massUnitNames[0] as AppMassUnit;
+const volumeUnit = volumeUnitNames[0] as AppVolumeUnit;
+
+describe('reactionAmountToOrd', () => {
+  it('returns null when the unit is unspecified', () => {
+    expect(
+      reactionAmountToOrd({
+        value: 1,
+        precision: null,
+        units: appAmountUnspecified,
+        volumeIncludesSolutes: ReactionBoolean.Unspecified,
+      }),
+    ).toBeNull();
+  });
+
+  it('nests value/precision under the matching dimension key and resolves the unit value', () => {
+    const result = reactionAmountToOrd({
+      value: 5,
+      precision: 0.1,
+      units: massUnit,
+      volumeIncludesSolutes: ReactionBoolean.Unspecified,
+    });
+    expect(result?.mass).toEqual({ value: 5, precision: 0.1, units: unitValueByName[massUnit] });
+    // A mass amount is not a volume, so volumeIncludesSolutes is dropped.
+    expect(result?.volumeIncludesSolutes).toBeNull();
+    expect(result?.moles).toBeUndefined();
+  });
+
+  it('keeps volumeIncludesSolutes only for volume units', () => {
+    const result = reactionAmountToOrd({
+      value: 2,
+      precision: null,
+      units: volumeUnit,
+      volumeIncludesSolutes: ReactionBoolean.True,
+    });
+    expect(result?.volume).toEqual({ value: 2, precision: null, units: unitValueByName[volumeUnit] });
+    expect(result?.volumeIncludesSolutes).toBe(true);
+  });
+});
+
+describe('ordAmountToReaction', () => {
+  it('returns the unspecified default for null/empty input', () => {
+    const expected = {
+      value: null,
+      precision: null,
+      units: appAmountUnspecified,
+      volumeIncludesSolutes: ReactionBoolean.Unspecified,
+    };
+    expect(ordAmountToReaction(null)).toEqual(expected);
+    expect(ordAmountToReaction({})).toEqual(expected);
+  });
+
+  it('maps the dimension value back to its unit name', () => {
+    const result = ordAmountToReaction({ mass: { value: 5, precision: 0.1, units: unitValueByName[massUnit] } });
+    expect(result).toMatchObject({
+      value: 5,
+      precision: 0.1,
+      units: massUnit,
+      volumeIncludesSolutes: ReactionBoolean.Unspecified,
+    });
+  });
+
+  it('reads volumeIncludesSolutes for volume amounts', () => {
+    const result = ordAmountToReaction({
+      volume: { value: 2, precision: null, units: unitValueByName[volumeUnit] },
+      volumeIncludesSolutes: true,
+    });
+    expect(result).toMatchObject({ value: 2, units: volumeUnit, volumeIncludesSolutes: ReactionBoolean.True });
+  });
+});
+
+describe('round trip', () => {
+  it('preserves a mass amount through ord and back', () => {
+    const amount = {
+      value: 12,
+      precision: 0.5,
+      units: massUnit,
+      volumeIncludesSolutes: ReactionBoolean.Unspecified,
+    };
+    expect(ordAmountToReaction(reactionAmountToOrd(amount))).toMatchObject(amount);
+  });
+});

--- a/ui/src/store/entities/reactions/reactionEntityTypes/reactionEntityTypes.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionEntityTypes/reactionEntityTypes.converters.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { ord } from 'ord-schema-protobufjs';
+import {
+  ordReactionRoleToReaction,
+  reactionReactionRoleToOrd,
+  ordTimeTypeToReaction,
+  reactionTimeTypeToOrd,
+} from './reactionEntityTypes.converters.ts';
+
+// The first enum member with a non-zero numeric value (i.e. not UNSPECIFIED).
+const firstNonZeroValue = (enumObject: Record<string, unknown>): number =>
+  Object.values(enumObject).find((value): value is number => typeof value === 'number' && value !== 0)!;
+
+describe('generated entity-type converters', () => {
+  it('round-trips a known ord value through its name (reaction role)', () => {
+    const value = firstNonZeroValue(ord.ReactionRole.ReactionRoleType);
+    const name = ordReactionRoleToReaction(value);
+    expect(typeof name).toBe('string');
+    expect(reactionReactionRoleToOrd(name)).toBe(value);
+  });
+
+  it('treats null and undefined as the value-0 (unspecified) type', () => {
+    const unspecified = ordReactionRoleToReaction(0);
+    expect(ordReactionRoleToReaction(null)).toBe(unspecified);
+    expect(ordReactionRoleToReaction(undefined)).toBe(unspecified);
+  });
+
+  it('applies the same factory behavior to another converter (time unit)', () => {
+    const value = firstNonZeroValue(ord.Time.TimeUnit);
+    const name = ordTimeTypeToReaction(value);
+    expect(reactionTimeTypeToOrd(name)).toBe(value);
+    expect(ordTimeTypeToReaction(undefined)).toBe(ordTimeTypeToReaction(0));
+  });
+});

--- a/ui/src/store/entities/reactions/reactionEntityTypes/reactionEntityTypes.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionEntityTypes/reactionEntityTypes.converters.test.ts
@@ -23,8 +23,13 @@ import {
 } from './reactionEntityTypes.converters.ts';
 
 // The first enum member with a non-zero numeric value (i.e. not UNSPECIFIED).
-const firstNonZeroValue = (enumObject: Record<string, unknown>): number =>
-  Object.values(enumObject).find((value): value is number => typeof value === 'number' && value !== 0)!;
+const firstNonZeroValue = (enumObject: Record<string, unknown>): number => {
+  const value = Object.values(enumObject).find((value): value is number => typeof value === 'number' && value !== 0);
+  if (value === undefined) {
+    throw new Error('expected the enum to have a non-zero numeric member');
+  }
+  return value;
+};
 
 describe('generated entity-type converters', () => {
   it('round-trips a known ord value through its name (reaction role)', () => {

--- a/ui/src/store/entities/reactions/reactionNotes/reactionNotes.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionNotes/reactionNotes.converters.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { ordNotesToReaction, reactionNotesToOrd } from './reactionNotes.converters.ts';
+import { ReactionBoolean } from '../reactionEntity/reactionEntity.types.ts';
+import type { ReactionNotes } from './reactionNotes.types.ts';
+
+const unspecifiedNotes: ReactionNotes = {
+  isHeterogeneous: ReactionBoolean.Unspecified,
+  formsPrecipitate: ReactionBoolean.Unspecified,
+  isExothermic: ReactionBoolean.Unspecified,
+  offgasses: ReactionBoolean.Unspecified,
+  isSensitiveToMoisture: ReactionBoolean.Unspecified,
+  isSensitiveToOxygen: ReactionBoolean.Unspecified,
+  isSensitiveToLight: ReactionBoolean.Unspecified,
+};
+
+describe('ordNotesToReaction', () => {
+  it('defaults every flag to Unspecified for empty input', () => {
+    expect(ordNotesToReaction(null)).toEqual(unspecifiedNotes);
+  });
+
+  it('maps ord booleans to the tri-state enum and passes other fields through', () => {
+    const result = ordNotesToReaction({
+      isHeterogeneous: true,
+      isExothermic: false,
+      procedureDetails: 'stir overnight',
+    });
+    expect(result.isHeterogeneous).toBe(ReactionBoolean.True);
+    expect(result.isExothermic).toBe(ReactionBoolean.False);
+    expect(result.offgasses).toBe(ReactionBoolean.Unspecified);
+    expect(result.procedureDetails).toBe('stir overnight');
+  });
+});
+
+describe('reactionNotesToOrd', () => {
+  it('collapses an all-unspecified, empty-text notes object to null', () => {
+    expect(reactionNotesToOrd(unspecifiedNotes)).toBeNull();
+  });
+
+  it('maps the tri-state enum back to ord booleans (null for Unspecified)', () => {
+    const result = reactionNotesToOrd({
+      ...unspecifiedNotes,
+      isExothermic: ReactionBoolean.True,
+      offgasses: ReactionBoolean.False,
+    });
+    expect(result).toMatchObject({ isExothermic: true, offgasses: false, isHeterogeneous: null });
+  });
+
+  it('keeps the object when only free-text fields are set', () => {
+    const result = reactionNotesToOrd({ ...unspecifiedNotes, safetyNotes: 'handle with care' });
+    expect(result?.safetyNotes).toBe('handle with care');
+  });
+});

--- a/ui/src/store/entities/reactions/reactionObservation/reactionObservation.converter.test.ts
+++ b/ui/src/store/entities/reactions/reactionObservation/reactionObservation.converter.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { ordObservationToReaction, reactionObservationToOrd } from './reactionObservation.converter.ts';
+import { AppDataType } from '../reactionData/reactionData.types.ts';
+
+describe('ordObservationToReaction', () => {
+  it('assigns an id, the comment, a time, and the named image data', () => {
+    const result = ordObservationToReaction({ comment: 'gas evolved', image: { url: 'https://img' } });
+    expect(typeof result.id).toBe('string');
+    expect(result.comment).toBe('gas evolved');
+    expect(result.image.name).toBe('Observation');
+    expect(result.image.data).toMatchObject({ type: AppDataType.Url, value: 'https://img' });
+    expect(result.time).toBeDefined();
+  });
+
+  it('defaults a missing comment to an empty string', () => {
+    expect(ordObservationToReaction({}).comment).toBe('');
+  });
+});
+
+describe('reactionObservationToOrd', () => {
+  it('round-trips the comment and image back to ord shape', () => {
+    const observation = ordObservationToReaction({ comment: 'precipitate', image: { stringValue: 'note' } });
+    const result = reactionObservationToOrd(observation);
+    expect(result.comment).toBe('precipitate');
+    expect(result.image?.stringValue).toBe('note');
+  });
+});

--- a/ui/src/store/entities/reactions/reactionProvenance/reactionProvenance.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionProvenance/reactionProvenance.converters.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ordPersonToReactionPerson,
+  reactionPersonToOrdPerson,
+  ordRecordEventToReaction,
+  reactionRecordEventToOrd,
+  ordProvenanceToReaction,
+  reactionProvenanceToOrd,
+} from './reactionProvenance.converters.ts';
+
+describe('person converters', () => {
+  it('substitutes an empty Person object for nullish input', () => {
+    expect(ordPersonToReactionPerson(null)).toBeTypeOf('object');
+    expect(ordPersonToReactionPerson(undefined)).not.toBeNull();
+  });
+
+  it('passes an existing person through in both directions', () => {
+    const person = { name: 'Ada Lovelace', orcid: '0000' };
+    expect(ordPersonToReactionPerson(person)).toBe(person);
+    expect(reactionPersonToOrdPerson(person)).toBe(person);
+  });
+});
+
+describe('record event converters', () => {
+  it('builds an id-bearing record event with defaults for empty input', () => {
+    const result = ordRecordEventToReaction(null);
+    expect(typeof result.id).toBe('string');
+    expect(result.time).toBeNull();
+    expect(result.person).toBeTypeOf('object');
+  });
+
+  it('carries details and a person, and formats a present time', () => {
+    const result = ordRecordEventToReaction({
+      details: 'created',
+      time: { value: '2024-06-01T12:00:00' },
+      person: { name: 'Grace Hopper' },
+    });
+    expect(result.details).toBe('created');
+    expect(result.person.name).toBe('Grace Hopper');
+    expect(result.time).toBeTruthy();
+  });
+
+  it('maps a record event back to ord shape, dropping a null time', () => {
+    const result = reactionRecordEventToOrd({ id: 'x', time: null, details: 'edited', person: { name: 'Ada' } });
+    expect(result.time).toBeNull();
+    expect(result.details).toBe('edited');
+    expect(result.person).toEqual({ name: 'Ada' });
+  });
+});
+
+describe('provenance converters', () => {
+  it('builds a default provenance with an id and empty recordModified list', () => {
+    const result = ordProvenanceToReaction(null);
+    expect(typeof result.id).toBe('string');
+    expect(result.recordModified).toEqual([]);
+    expect(typeof result.recordCreated.id).toBe('string');
+    expect(result.experimentStart).toBeNull();
+  });
+
+  it('strips the id and maps nested events when converting back to ord', () => {
+    const provenance = ordProvenanceToReaction(null);
+    const result = reactionProvenanceToOrd(provenance);
+    expect(result).not.toHaveProperty('id');
+    expect(result.recordModified).toEqual([]);
+    expect(result.recordCreated).toBeDefined();
+    expect(result.experimentStart).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Continues the UI unit-test backfill, batched into one larger PR. Adds **36 tests** across pure converters and helpers that were previously uncovered:

- **reactionAmount converters** — dimension nesting (mass/moles/volume), unit-value resolution, `volumeIncludesSolutes` only for volumes, unspecified defaults, and a round trip.
- **reactionNotes converters** — tri-state boolean ↔ ord boolean mapping and the null-if-empty collapse.
- **reactionObservation converter** — id/comment/time/image mapping + round trip.
- **reactionProvenance converters** — person / record-event / provenance defaults and the ord round trip.
- **reactionEntityTypes converters** — the generated type↔ord factory (known-value round trip; null/undefined → unspecified).
- **reactionForm utils** — `createBooleanInput`, `ordMapToKeyValueObject`, `wrapInputsWithGrid`.
- **date utils** — timezone conversions (instant preserved + round trip) and human-readable display formatting.

## Gates

- `vitest run` (new files): 36/36 pass.
- `tsc -b`, `eslint`, `prettier --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 36 unit tests across pure converter functions and utility helpers that had no prior test coverage, continuing the UI test backfill effort. All new files are test-only; no production code is changed.

- **Converter tests** (`reactionAmount`, `reactionNotes`, `reactionObservation`, `reactionProvenance`, `reactionEntityTypes`) cover dimension nesting, tri-state boolean mapping, id assignment, and ord round-trips with both happy-path and null/unspecified defaults.
- **Utility tests** (`createBooleanInput`, `ordMapToKeyValueObject`, `wrapInputsWithGrid`) verify the shape and edge cases of the shared form-builder helpers.
- **Date tests** use timestamp-invariant assertions (instant preservation + UTC offset) instead of round-trips through the guessed timezone, so they remain meaningful on UTC CI runners; all feedback from the previous review round has been incorporated.

<h3>Confidence Score: 5/5</h3>

Test-only additions with no changes to production code; all 36 tests pass and the toolchain (tsc, eslint, prettier) is clean.

Every file in this PR is a new test file. No production converter or utility logic was modified. The tests correctly exercise the converters they target, all prior review feedback was addressed, and the static analysis gates are clean.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/common/utils/date.test.ts | New test file for date utilities; uses timestamp-invariant assertions to stay meaningful on UTC CI runners, addressing the previously raised concern. |
| ui/src/store/entities/reactions/reactionAmount/reactionAmount.converters.test.ts | New tests covering all three dimensions (mass, moles, volume), unspecified defaults, and a full round-trip; previously flagged issues (misleading comment, missing moles case) have been corrected. |
| ui/src/store/entities/reactions/reactionEntityTypes/reactionEntityTypes.converters.test.ts | New tests for generated entity-type converters; firstNonZeroValue now throws an explicit Error on misconfiguration instead of silently returning undefined. |
| ui/src/store/entities/reactions/reactionObservation/reactionObservation.converter.test.ts | New tests for observation converter covering id/comment/time/image mapping and a round-trip. |
| ui/src/store/entities/reactions/reactionProvenance/reactionProvenance.converters.test.ts | New tests for person, record-event, and provenance converters, including defaults and the id-stripping behavior of reactionProvenanceToOrd. |
| ui/src/store/entities/reactions/reactionNotes/reactionNotes.converters.test.ts | New tests covering tri-state boolean mapping, pass-through of free-text fields, and the null-if-empty collapse. |
| ui/src/common/utils/reactionForm/createBooleanInput.test.ts | New single-case test verifying createBooleanInput produces the correct segmented-select node shape. |
| ui/src/common/utils/reactionForm/ordMapToKeyValueObject.test.ts | New tests covering the happy path, string-value preservation, and empty-record edge case. |
| ui/src/common/utils/reactionForm/wrapInputsWithGrid.test.ts | New tests for wrapInputsWithGrid covering multi-input, single-input, and zero-input cases. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph "New Test Files"
        DT[date.test.ts]
        CB[createBooleanInput.test.ts]
        OK[ordMapToKeyValueObject.test.ts]
        WG[wrapInputsWithGrid.test.ts]
        RA[reactionAmount.converters.test.ts]
        RE[reactionEntityTypes.converters.test.ts]
        RN[reactionNotes.converters.test.ts]
        RO[reactionObservation.converter.test.ts]
        RP[reactionProvenance.converters.test.ts]
    end

    subgraph "Units Under Test"
        DU[date.ts]
        CBU[createBooleanInput.ts]
        OKU[ordMapToKeyValueObject.ts]
        WGU[wrapInputsWithGrid.ts]
        RAC[reactionAmount.converters.ts]
        REC[reactionEntityTypes.converters.ts]
        RNC[reactionNotes.converters.ts]
        ROC[reactionObservation.converter.ts]
        RPC[reactionProvenance.converters.ts]
    end

    DT --> DU
    CB --> CBU
    OK --> OKU
    WG --> WGU
    RA --> RAC
    RE --> REC
    RN --> RNC
    RO --> ROC
    RP --> RPC

    RAC -->|ordAmountToReaction / reactionAmountToOrd| ORD[(ord protobuf)]
    RNC -->|ordNotesToReaction / reactionNotesToOrd| ORD
    ROC -->|ordObservationToReaction / reactionObservationToOrd| ORD
    RPC -->|ordProvenanceToReaction / reactionProvenanceToOrd| ORD
    REC -->|ordReactionRoleToReaction / ordTimeTypeToReaction| ORD
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/open-reaction-database/ord-app/commit/81eab6337efc02b02e028b9a8c62aa806b46d1f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35038757)</sub>

<!-- /greptile_comment -->