### PR TITLE
fix(ui): resolve react-hooks/exhaustive-deps warnings

### DIFF
--- a/ui/src/common/hooks/useAuth.ts
+++ b/ui/src/common/hooks/useAuth.ts
@@ -87,7 +87,7 @@ export function useAuth() {
     if (user) {
       provisionUser();
     }
-  }, [dispatch, user, getAccessTokenSilently, getIdTokenClaims]);
+  }, [dispatch, user, getAccessTokenSilently, getIdTokenClaims, loginWithRedirect]);
 
   return isAppLoading;
 }

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseCreate.ts
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseCreate.ts
@@ -30,10 +30,12 @@ export const buildUseCreate = <T = unknown>(
     const dispatch = useAppDispatch();
     const { reactionId } = useContext(reactionContext);
     const { pathComponents } = useContext(reactionEntityContext);
-    const entityPathComponents: ReactionPathComponents = typeof entityName === 'string' ? [entityName] : entityName;
 
     return useCallback(
       (newIndex: number, entitiesList: Array<T>, creationInfo?: Partial<T>) => {
+        // Derived from the stable factory arg `entityName`; computed here so it isn't a render-scope
+        // dependency that would defeat the useCallback memoization.
+        const entityPathComponents: ReactionPathComponents = typeof entityName === 'string' ? [entityName] : entityName;
         const [key, newEntity] = createKeyWithEmpty(newIndex, entitiesList, creationInfo);
         const updatedPathComponents = pathComponents.concat(entityPathComponents).concat(key);
 


### PR DESCRIPTION
## Summary

Clears the two `react-hooks/exhaustive-deps` warnings surfaced by `eslint src`. No behavior change.

- **`useAuth`** — the user-provisioning effect calls `loginWithRedirect` in its `catch` branch but omitted it from the dependency array. Added it; the sibling redirect effect already lists `loginWithRedirect`, so this is consistent.
- **`buildUseCreate`** — `entityPathComponents` was derived in render scope from the stable factory arg `entityName` and used inside the memoized callback without being a declared dep. Rather than add the freshly-allocated array to the deps (which would defeat the `useCallback` memoization on every render), it's now computed **inside** the callback from `entityName`. Result is identical — `entityName` never changes for a given hook instance — and memoization is preserved.

## Gates

- `eslint src`: warning-clean (was 2 warnings).
- `tsc -b`, `prettier --check`: clean.
- `vitest run`: 183/183 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two `react-hooks/exhaustive-deps` ESLint warnings with no behavior change. Both fixes correctly identify stable values that were missing from hook dependency arrays.

- **`useAuth.ts`**: Adds `loginWithRedirect` to the dependency array of the user-provisioning effect, which calls it in the `catch` branch — consistent with how the sibling redirect effect already declares it.
- **`buildUseCreate.ts`**: Moves the `entityPathComponents` derivation from render scope into the `useCallback` body, so `entityName` (a stable factory-closure arg) drives the computation without defeating memoization by introducing a freshly-allocated array as a dependency.

<h3>Confidence Score: 5/5</h3>

Both changes are minimal, correct, and safe to merge — they silence lint warnings without altering runtime behavior.

The `useAuth` dep-array addition is consistent with Auth0's stable function references and with the sibling effect that already declares `loginWithRedirect`. The `buildUseCreate` refactor moves a pure derivation into the callback body where `entityName` is a stable closure variable, so the computed value is identical on every call — memoization is preserved and no stale-closure risk is introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/common/hooks/useAuth.ts | Adds `loginWithRedirect` to the dep array of the user-provisioning effect; matches its usage in the catch branch and mirrors the sibling redirect effect. |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseCreate.ts | Moves `entityPathComponents` derivation inside the `useCallback` body; preserves memoization since `entityName` is a stable factory-closure variable that never changes for a given hook instance. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Component
    participant uA as useAuth
    participant A0 as Auth0
    participant BE as Backend

    C->>uA: mount
    Note over uA: Effect 1 (redirect guard)
    uA->>A0: check isAuthenticated / isLoading
    alt not authenticated
        uA->>A0: loginWithRedirect()
    end

    Note over uA: Effect 2 (token setter)
    uA->>A0: getAccessTokenSilently (register getter)

    Note over uA: Effect 3 (noAuth dev mode only)
    uA->>BE: dispatch(createUser) with static dev token

    Note over uA: Effect 4 (provision user — CHANGED)
    uA->>A0: getIdTokenClaims() + getAccessTokenSilently()
    alt success
        uA->>BE: dispatch(createUser)
    else failure (catch)
        uA->>A0: loginWithRedirect() [now in dep array]
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): resolve react-hooks/exhaustive-..."](https://github.com/open-reaction-database/ord-app/commit/b83683b8fae3bb4cd91aba1c654a9140207c48c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35039070)</sub>

<!-- /greptile_comment -->