### PR TITLE
test(ui): feature selectors, selector factory, setup/path utils

### DIFF
--- a/ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts
+++ b/ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as htmlToImage from 'html-to-image';
+import { copyPreviewAsImage } from './reactionPreview.utils.ts';
+import { showNotification } from 'common/utils/showNotification.tsx';
+import { NotificationVariant } from 'common/types/notification.ts';
+
+vi.mock('html-to-image', () => ({ toBlob: vi.fn() }));
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
+
+const toBlobMock = vi.mocked(htmlToImage.toBlob);
+const notifyMock = vi.mocked(showNotification);
+const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+const node = { scrollWidth: 120 } as HTMLDivElement;
+
+const expectNotified = (variant: NotificationVariant) =>
+  expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ variant }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal(
+    'ClipboardItem',
+    vi.fn((items: unknown) => ({ items })),
+  );
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { clipboard: { write: clipboardWrite } },
+    configurable: true,
+  });
+});
+
+describe('copyPreviewAsImage', () => {
+  it('notifies an error and does nothing when there is no node', async () => {
+    await copyPreviewAsImage(null);
+    expect(toBlobMock).not.toHaveBeenCalled();
+    expectNotified(NotificationVariant.ERROR);
+  });
+
+  it('writes the rendered blob to the clipboard and reports success', async () => {
+    toBlobMock.mockResolvedValue(new Blob(['x'], { type: 'image/png' }));
+    await copyPreviewAsImage(node);
+    expect(clipboardWrite).toHaveBeenCalledTimes(1);
+    expectNotified(NotificationVariant.SUCCESS);
+  });
+
+  it('notifies an error when rendering produces no blob', async () => {
+    toBlobMock.mockResolvedValue(null);
+    await copyPreviewAsImage(node);
+    expect(clipboardWrite).not.toHaveBeenCalled();
+    expectNotified(NotificationVariant.ERROR);
+  });
+
+  it('notifies an error when rendering throws', async () => {
+    toBlobMock.mockRejectedValue(new Error('boom'));
+    await copyPreviewAsImage(node);
+    expectNotified(NotificationVariant.ERROR);
+  });
+});

--- a/ui/src/store/entities/reactions/reactionSetup/reactionSetup.converter.test.ts
+++ b/ui/src/store/entities/reactions/reactionSetup/reactionSetup.converter.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ordVesselAttachmentToReaction,
+  reactionVesselAttachmentToOrd,
+  ordVesselPreparationToReaction,
+  reactionVesselPreparationToOrd,
+  ordVesselSetupToReaction,
+  ordSetupToReactionSetup,
+} from './reactionSetup.converter.ts';
+import { ReactionBoolean } from '../reactionEntity/reactionEntity.types.ts';
+
+describe('vessel attachment converters', () => {
+  it('assigns an id and maps the type to a name, then back to a number', () => {
+    const reaction = ordVesselAttachmentToReaction({ type: undefined, details: 'reflux condenser' });
+    expect(typeof reaction.id).toBe('string');
+    expect(reaction.details).toBe('reflux condenser');
+    expect(typeof reaction.type).toBe('string');
+
+    const ord = reactionVesselAttachmentToOrd(reaction);
+    expect(typeof ord.type).toBe('number');
+    expect(ord.details).toBe('reflux condenser');
+  });
+});
+
+describe('vessel preparation converters', () => {
+  it('round-trips type and details', () => {
+    const reaction = ordVesselPreparationToReaction({ type: undefined, details: 'oven dried' });
+    expect(typeof reaction.id).toBe('string');
+    expect(reaction.details).toBe('oven dried');
+
+    const ord = reactionVesselPreparationToOrd(reaction);
+    expect(typeof ord.type).toBe('number');
+    expect(ord.details).toBe('oven dried');
+  });
+});
+
+describe('ordVesselSetupToReaction', () => {
+  it('defaults preparation/attachment lists to empty arrays for an empty vessel', () => {
+    const vessel = ordVesselSetupToReaction(null);
+    expect(vessel.vesselPreparations).toEqual([]);
+    expect(vessel.vesselAttachments).toEqual([]);
+    expect(typeof vessel.type).toBe('string');
+  });
+});
+
+describe('ordSetupToReactionSetup', () => {
+  it('assigns an id and supplies defaults for an empty setup', () => {
+    const setup = ordSetupToReactionSetup(null);
+    // withId adds the app-only id at runtime even though ReactionSetup doesn't surface it in its type.
+    expect(setup).toHaveProperty('id', expect.any(String));
+    expect(setup.isAutomated).toBe(ReactionBoolean.Unspecified);
+    expect(setup.automationCode).toEqual({});
+    expect(setup.vessel).toBeTypeOf('object');
+    expect(setup.environment).toBeTypeOf('object');
+  });
+});

--- a/ui/src/store/features/enumerationSetup/enumerationSetup.selectors.test.ts
+++ b/ui/src/store/features/enumerationSetup/enumerationSetup.selectors.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectIsEnumerationSetupOpened } from './enumerationSetup.selectors.ts';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const buildState = (isEnumerationSetupOpened: boolean): AppState =>
+  ({ features: { enumerationSetup: { isEnumerationSetupOpened } } }) as unknown as AppState;
+
+describe('selectIsEnumerationSetupOpened', () => {
+  it('reads the open flag from the slice', () => {
+    expect(selectIsEnumerationSetupOpened(buildState(true))).toBe(true);
+    expect(selectIsEnumerationSetupOpened(buildState(false))).toBe(false);
+  });
+});

--- a/ui/src/store/features/reactionForm/reactionForm.selectors.test.ts
+++ b/ui/src/store/features/reactionForm/reactionForm.selectors.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectReactionPathComponentsList } from './reactionForm.selectors.ts';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const buildState = (reactionPathComponentsList: unknown): AppState =>
+  ({ features: { reactionForm: { reactionPathComponentsList } } }) as unknown as AppState;
+
+describe('selectReactionPathComponentsList', () => {
+  it('returns the path-components list from the slice', () => {
+    const list = [['inputs', 'i1']];
+    expect(selectReactionPathComponentsList(buildState(list))).toBe(list);
+  });
+
+  it('returns an empty list when nothing is open', () => {
+    expect(selectReactionPathComponentsList(buildState([]))).toEqual([]);
+  });
+});

--- a/ui/src/store/features/reactionLookup/reactionLookup.selectors.test.ts
+++ b/ui/src/store/features/reactionLookup/reactionLookup.selectors.test.ts
@@ -24,11 +24,18 @@ import type { AppState } from 'store/configureAppStore.ts';
 const buildState = (reactionLookup: Record<string, unknown>): AppState =>
   ({ features: { reactionLookup } }) as unknown as AppState;
 
+const state = buildState({ isOpened: true, isLoading: false, hasError: true });
+
 describe('reactionLookup selectors', () => {
-  it('reads the isOpened, isLoading, and hasError flags', () => {
-    const state = buildState({ isOpened: true, isLoading: false, hasError: true });
+  it('selectIsReactionLookupOpen reads the isOpened flag', () => {
     expect(selectIsReactionLookupOpen(state)).toBe(true);
+  });
+
+  it('selectReactionLookupIsLoading reads the isLoading flag', () => {
     expect(selectReactionLookupIsLoading(state)).toBe(false);
+  });
+
+  it('selectHasReactionLookupError reads the hasError flag', () => {
     expect(selectHasReactionLookupError(state)).toBe(true);
   });
 });

--- a/ui/src/store/features/reactionLookup/reactionLookup.selectors.test.ts
+++ b/ui/src/store/features/reactionLookup/reactionLookup.selectors.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  selectIsReactionLookupOpen,
+  selectReactionLookupIsLoading,
+  selectHasReactionLookupError,
+} from './reactionLookup.selectors.ts';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const buildState = (reactionLookup: Record<string, unknown>): AppState =>
+  ({ features: { reactionLookup } }) as unknown as AppState;
+
+describe('reactionLookup selectors', () => {
+  it('reads the isOpened, isLoading, and hasError flags', () => {
+    const state = buildState({ isOpened: true, isLoading: false, hasError: true });
+    expect(selectIsReactionLookupOpen(state)).toBe(true);
+    expect(selectReactionLookupIsLoading(state)).toBe(false);
+    expect(selectHasReactionLookupError(state)).toBe(true);
+  });
+});

--- a/ui/src/store/features/reactionRename/reactionRename.selector.test.ts
+++ b/ui/src/store/features/reactionRename/reactionRename.selector.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectIsReactionRenameOpened } from './reactionRename.selector.ts';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const buildState = (reactionRename: unknown): AppState => ({ features: { reactionRename } }) as unknown as AppState;
+
+describe('selectIsReactionRenameOpened', () => {
+  it('returns the whole reactionRename slice', () => {
+    expect(selectIsReactionRenameOpened(buildState({ reactionId: 5 }))).toEqual({ reactionId: 5 });
+    expect(selectIsReactionRenameOpened(buildState(null))).toBeNull();
+  });
+});

--- a/ui/src/store/features/templateFromFileError/templateFromFileError.selectors.test.ts
+++ b/ui/src/store/features/templateFromFileError/templateFromFileError.selectors.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectTemplateFromFileError } from './templateFromFileError.selectors.ts';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const buildState = (templateFromFileError: unknown): AppState =>
+  ({ features: { templateFromFileError } }) as unknown as AppState;
+
+describe('selectTemplateFromFileError', () => {
+  it('returns the whole templateFromFileError slice', () => {
+    expect(selectTemplateFromFileError(buildState('parse failed'))).toBe('parse failed');
+    expect(selectTemplateFromFileError(buildState(null))).toBeNull();
+  });
+});

--- a/ui/src/store/features/variablesSidebar/variablesSidebar.selectors.test.ts
+++ b/ui/src/store/features/variablesSidebar/variablesSidebar.selectors.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectIsVariablesSidebarOpened } from './variablesSidebar.selectors.ts';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const buildState = (isVariablesSidebarOpened: boolean): AppState =>
+  ({ features: { variablesSidebar: { isVariablesSidebarOpened } } }) as unknown as AppState;
+
+describe('selectIsVariablesSidebarOpened', () => {
+  it('reads the open flag from the slice', () => {
+    expect(selectIsVariablesSidebarOpened(buildState(true))).toBe(true);
+    expect(selectIsVariablesSidebarOpened(buildState(false))).toBe(false);
+  });
+});

--- a/ui/src/store/utils/createSelectorFactory.test.ts
+++ b/ui/src/store/utils/createSelectorFactory.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { createSelectorFactory } from './createSelectorFactory.ts';
+import type { AppState } from '../configureAppStore.ts';
+
+interface Slice {
+  count: number;
+  name: string;
+}
+
+const slice: Slice = { count: 3, name: 'set' };
+const state = { features: { errorPage: slice } } as unknown as AppState;
+const selectRoot = (s: AppState) => (s as unknown as { features: { errorPage: Slice } }).features.errorPage;
+
+describe('createSelectorFactory', () => {
+  const { buildSelector } = createSelectorFactory(selectRoot);
+
+  it('builds selectors that read a leaf through the chosen root slice', () => {
+    expect(buildSelector((s: Slice) => s.count)(state)).toBe(3);
+    expect(buildSelector((s: Slice) => s.name)(state)).toBe('set');
+  });
+
+  it('passes the whole root slice through when the leaf selector is identity', () => {
+    expect(buildSelector(s => s)(state)).toBe(slice);
+  });
+});

--- a/ui/src/store/utils/replaceNameIdInReactionComponentPath.test.ts
+++ b/ui/src/store/utils/replaceNameIdInReactionComponentPath.test.ts
@@ -41,6 +41,11 @@ describe('replaceNameIdInReactionComponentPath', () => {
     ]);
   });
 
+  it('throws when the referenced input is not present in the reaction map', () => {
+    // findEntityByName uses a non-null assertion, so a missing key throws on the subsequent access.
+    expect(() => replaceNameIdInReactionComponentPath(['inputs', 'missing-key'], reactionWithInput, 'id')).toThrow();
+  });
+
   it('rewrites a condition `measurements` segment to its prefixed form and back', () => {
     expect(replaceNameIdInReactionComponentPath(['temperature', 'measurements'], {} as AppReaction, 'id')).toEqual([
       'temperature',

--- a/ui/src/store/utils/replaceNameIdInReactionComponentPath.test.ts
+++ b/ui/src/store/utils/replaceNameIdInReactionComponentPath.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { replaceNameIdInReactionComponentPath } from './replaceNameIdInReactionComponentPath.ts';
+import type { AppReaction } from '../entities/reactions/reactions.types.ts';
+
+const reactionWithInput = { inputs: { 'uuid-1': { id: 'i1', name: 'reagent' } } } as unknown as AppReaction;
+
+describe('replaceNameIdInReactionComponentPath', () => {
+  it('leaves a path without map keys or condition measurements unchanged', () => {
+    expect(replaceNameIdInReactionComponentPath(['setup', 'vessel'], {} as AppReaction, 'id')).toEqual([
+      'setup',
+      'vessel',
+    ]);
+  });
+
+  it('replaces an input name with its id when resolving to id', () => {
+    expect(replaceNameIdInReactionComponentPath(['inputs', 'reagent'], reactionWithInput, 'id')).toEqual([
+      'inputs',
+      'i1',
+    ]);
+  });
+
+  it('replaces an input id with its name when resolving to name', () => {
+    expect(replaceNameIdInReactionComponentPath(['inputs', 'i1'], reactionWithInput, 'name')).toEqual([
+      'inputs',
+      'reagent',
+    ]);
+  });
+
+  it('rewrites a condition `measurements` segment to its prefixed form and back', () => {
+    expect(replaceNameIdInReactionComponentPath(['temperature', 'measurements'], {} as AppReaction, 'id')).toEqual([
+      'temperature',
+      'temperatureMeasurements',
+    ]);
+    expect(
+      replaceNameIdInReactionComponentPath(['temperature', 'temperatureMeasurements'], {} as AppReaction, 'name'),
+    ).toEqual(['temperature', 'measurements']);
+  });
+});


### PR DESCRIPTION
## Summary

Batch 3 of the UI unit-test backfill — **10 test files, 21 tests** covering the remaining feature selectors plus a few pure utilities.

- **Feature selectors** (mock-state pattern): `reactionLookup`, `reactionForm`, `reactionRename`, `templateFromFileError`, `variablesSidebar`, `enumerationSetup`.
- **`createSelectorFactory`** — leaf selection through the chosen root slice, and identity pass-through.
- **`reactionPreview.utils.copyPreviewAsImage`** — all four branches (no node, blob → clipboard success, no blob, render throws), with `html-to-image`, `navigator.clipboard`, and `showNotification` mocked.
- **`reactionSetup.converter`** — vessel attachment/preparation round trips and `ordSetupToReactionSetup` defaults.
- **`replaceNameIdInReactionComponentPath`** — name↔id resolution via input map keys and the condition `measurements` segment rewrite.

## Gates

- `vitest run`: 243/243 pass (21 new).
- `tsc -b`, `eslint`, `prettier --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 10 new test files (21 tests) as the third batch of UI unit-test backfill, covering feature selectors, `createSelectorFactory`, converter round-trips, `copyPreviewAsImage` branches, and `replaceNameIdInReactionComponentPath` path rewriting — all test-only, no production code changes.

- **Feature selector tests** use a consistent mock-state pattern (`buildState` casting partial objects to `AppState`) across `reactionLookup`, `reactionForm`, `reactionRename`, `templateFromFileError`, `variablesSidebar`, and `enumerationSetup`.
- **`reactionPreview.utils.test.ts`** covers all four branches of `copyPreviewAsImage` (no node, blob success, no blob, render throws) with properly isolated mocks for `html-to-image`, `navigator.clipboard`, and `showNotification`.
- **`replaceNameIdInReactionComponentPath.test.ts`** now includes the missing-key throw case and the `measurements` segment rewrite/revert, addressing both items flagged in the previous review round.

<h3>Confidence Score: 5/5</h3>

Pure test additions with no production code changes; all 243 tests pass and the new cases address both items raised in the prior review round.

Every file in this PR is a new test file. No logic was modified, no source files were touched, and the tests correctly reflect the behaviour of the underlying implementations as verified by reading the source.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts | Tests all four branches of copyPreviewAsImage (no node, blob success, no blob, render throws) with correct mocking of html-to-image, clipboard, and showNotification. |
| ui/src/store/entities/reactions/reactionSetup/reactionSetup.converter.test.ts | Round-trip tests for vessel attachment/preparation converters and ordSetupToReactionSetup defaults; comment correctly notes the runtime id field not present in the TypeScript type. |
| ui/src/store/features/enumerationSetup/enumerationSetup.selectors.test.ts | Straightforward mock-state test for selectIsEnumerationSetupOpened covering both true/false values. |
| ui/src/store/features/reactionForm/reactionForm.selectors.test.ts | Two-case test for selectReactionPathComponentsList verifying reference equality and empty-list return. |
| ui/src/store/features/reactionLookup/reactionLookup.selectors.test.ts | Three selectors now each get their own it block as recommended in previous review; shared state constant correctly distinguishes isLoading/hasError values. |
| ui/src/store/features/reactionRename/reactionRename.selector.test.ts | Tests selectIsReactionRenameOpened returning the whole slice (object or null); test description accurately reflects that the selector returns the full slice, not a boolean. |
| ui/src/store/features/templateFromFileError/templateFromFileError.selectors.test.ts | Clean two-case test covering string and null values for selectTemplateFromFileError. |
| ui/src/store/features/variablesSidebar/variablesSidebar.selectors.test.ts | Clean two-case test for selectIsVariablesSidebarOpened following the same pattern as the other feature-selector tests. |
| ui/src/store/utils/createSelectorFactory.test.ts | Tests leaf-property selection and identity pass-through for buildSelector; isolated Slice interface avoids coupling to AppState internals. |
| ui/src/store/utils/replaceNameIdInReactionComponentPath.test.ts | Five-case test covering unchanged paths, name-to-id, id-to-name resolution, missing-key throw, and measurements segment rewrite/revert. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[copyPreviewAsImage called] --> B{node is null?}
    B -- yes --> C[showNotification ERROR]
    B -- no --> D[htmlToImage.toBlob]
    D --> E{throws?}
    E -- yes --> F[showNotification ERROR]
    E -- no --> G{blob is null?}
    G -- yes --> H[showNotification ERROR]
    G -- no --> I[navigator.clipboard.write]
    I --> J[showNotification SUCCESS]

    style C fill:#f88,stroke:#c00
    style F fill:#f88,stroke:#c00
    style H fill:#f88,stroke:#c00
    style J fill:#8f8,stroke:#080
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): address Greptile feedback on b..."](https://github.com/open-reaction-database/ord-app/commit/667312a275176a84925ec5662f272797a71705c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35043798)</sub>

<!-- /greptile_comment -->