### PR TITLE
test(ui): input/conditions converters, models registry, enumeration reducer, indigo (+ VesselAttachments converter fix)

### DIFF
--- a/ui/src/common/utils/indigo.test.ts
+++ b/ui/src/common/utils/indigo.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderSvg } from './indigo.ts';
+
+// renderSvg guards before touching the (async-loaded) wasm module, which is never
+// initialized in this unit test, so both guard branches return null.
+describe('renderSvg', () => {
+  it('returns null for a null component', () => {
+    expect(renderSvg(null)).toBeNull();
+  });
+
+  it('returns null when the indigo module has not been initialized', () => {
+    expect(renderSvg('CCO')).toBeNull();
+  });
+});

--- a/ui/src/store/entities/reactions/reactionConditions/reactionConditions.converter.test.ts
+++ b/ui/src/store/entities/reactions/reactionConditions/reactionConditions.converter.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ordTemperatureMeasurementToReaction,
+  reactionTemperatureMeasurementToOrd,
+  ordPressureMeasurementToReaction,
+  reactionPressureMeasurementToOrd,
+  ordTemperatureConditionToReaction,
+  ordStirringConditionToReaction,
+  reactionStirringConditionToOrd,
+} from './reactionConditions.converter.ts';
+
+describe('temperature measurement converters', () => {
+  it('assigns an id, maps the type to a name, and carries details', () => {
+    const result = ordTemperatureMeasurementToReaction({ type: undefined, details: 'thermocouple' });
+    expect(typeof result.id).toBe('string');
+    expect(typeof result.type).toBe('string');
+    expect(result.details).toBe('thermocouple');
+    expect(result.temperature).toBeTypeOf('object');
+    expect(result.time).toBeTypeOf('object');
+  });
+
+  it('maps a measurement back to ord with a numeric type', () => {
+    const reaction = ordTemperatureMeasurementToReaction({ details: 'probe' });
+    const ord = reactionTemperatureMeasurementToOrd(reaction);
+    expect(typeof ord.type).toBe('number');
+    expect(ord.details).toBe('probe');
+  });
+});
+
+describe('pressure measurement converters', () => {
+  it('round-trips type/details through ord', () => {
+    const reaction = ordPressureMeasurementToReaction({ type: undefined, details: 'gauge' });
+    expect(typeof reaction.id).toBe('string');
+    const ord = reactionPressureMeasurementToOrd(reaction);
+    expect(typeof ord.type).toBe('number');
+    expect(ord.details).toBe('gauge');
+  });
+});
+
+describe('ordTemperatureConditionToReaction', () => {
+  it('defaults the measurements list to an empty array and fills control/setpoint', () => {
+    const result = ordTemperatureConditionToReaction(null);
+    expect(result.temperatureMeasurements).toEqual([]);
+    expect(result.control).toBeTypeOf('object');
+    expect(result.setpoint).toBeTypeOf('object');
+  });
+});
+
+describe('stirring condition converters', () => {
+  it('maps type/details/rate from ord', () => {
+    const result = ordStirringConditionToReaction({ details: 'magnetic bar' });
+    expect(typeof result.type).toBe('string');
+    expect(result.details).toBe('magnetic bar');
+    expect(result.rate).toBeTypeOf('object');
+  });
+
+  it('collapses an empty, unspecified-type stirring condition to null', () => {
+    const empty = ordStirringConditionToReaction(null);
+    expect(reactionStirringConditionToOrd(empty)).toBeNull();
+  });
+});

--- a/ui/src/store/entities/reactions/reactions.models.test.ts
+++ b/ui/src/store/entities/reactions/reactions.models.test.ts
@@ -20,6 +20,10 @@ import {
   reactionToOrdConvertersByNodeEntity,
 } from './reactions.models.ts';
 import { ReactionNodeEntity } from './reactions.types.ts';
+import {
+  ordVesselAttachmentToReaction,
+  ordVesselPreparationToReaction,
+} from './reactionSetup/reactionSetup.converter.ts';
 
 describe('node-entity converter registries', () => {
   const entities = Object.values(ReactionNodeEntity);
@@ -32,6 +36,16 @@ describe('node-entity converter registries', () => {
       );
       expect(reactionToOrdConvertersByNodeEntity[entity], `reaction->ord for ${entity}`).toBeTypeOf('function');
     }
+  });
+
+  it('wires vessel attachments and preparations to their own distinct ord->reaction converters', () => {
+    // Guards against the copy-paste that pointed VesselAttachments at the preparation converter.
+    expect(ordToReactionConvertersByNodeEntity[ReactionNodeEntity.VesselAttachments].convert).toBe(
+      ordVesselAttachmentToReaction,
+    );
+    expect(ordToReactionConvertersByNodeEntity[ReactionNodeEntity.VesselPreparations].convert).toBe(
+      ordVesselPreparationToReaction,
+    );
   });
 
   it('lists every node entity among the allowed entity names', () => {

--- a/ui/src/store/entities/reactions/reactions.models.test.ts
+++ b/ui/src/store/entities/reactions/reactions.models.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  allowedNodeEntityNames,
+  ordToReactionConvertersByNodeEntity,
+  reactionToOrdConvertersByNodeEntity,
+} from './reactions.models.ts';
+import { ReactionNodeEntity } from './reactions.types.ts';
+
+describe('node-entity converter registries', () => {
+  const entities = Object.values(ReactionNodeEntity);
+
+  it('exposes an ord->reaction and reaction->ord converter for every node entity', () => {
+    for (const entity of entities) {
+      // ord->reaction entries wrap the converter in { hasName, convert }; reaction->ord entries are bare functions.
+      expect(ordToReactionConvertersByNodeEntity[entity].convert, `ord->reaction convert for ${entity}`).toBeTypeOf(
+        'function',
+      );
+      expect(reactionToOrdConvertersByNodeEntity[entity], `reaction->ord for ${entity}`).toBeTypeOf('function');
+    }
+  });
+
+  it('lists every node entity among the allowed entity names', () => {
+    for (const entity of entities) {
+      expect(allowedNodeEntityNames).toContain(entity);
+    }
+  });
+});

--- a/ui/src/store/entities/reactions/reactions.models.ts
+++ b/ui/src/store/entities/reactions/reactions.models.ts
@@ -40,6 +40,7 @@ import {
 } from './reactionEntity/reactionEntity.converters.ts';
 import {
   ordSetupToReactionSetup,
+  ordVesselAttachmentToReaction,
   ordVesselPreparationToReaction,
   reactionSetupToOrd,
   reactionVesselAttachmentToOrd,
@@ -178,7 +179,7 @@ export const ordToReactionConvertersByNodeEntity: Record<ReactionNodeEntity, Ord
   },
   [ReactionNodeEntity.VesselAttachments]: {
     hasName: false,
-    convert: ordVesselPreparationToReaction,
+    convert: ordVesselAttachmentToReaction,
   },
 };
 

--- a/ui/src/store/entities/reactions/reactionsInputs/reactionsInputs.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionsInputs/reactionsInputs.converters.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ordCrudeComponentToReaction,
+  reactionCrudeComponentToOrd,
+  ordInputWithoutNameToReaction,
+  ordInputToReaction,
+  ordInputsToReactionInputs,
+  reactionInputsToOrdInputs,
+} from './reactionsInputs.converters.ts';
+import { ReactionBoolean } from '../reactionEntity/reactionEntity.types.ts';
+
+describe('crude component converters', () => {
+  it('maps booleans to the tri-state enum and assigns an id', () => {
+    const result = ordCrudeComponentToReaction({ reactionId: 'r1', includesWorkup: true, hasDerivedAmount: false });
+    expect(typeof result.id).toBe('string');
+    expect(result.reactionId).toBe('r1');
+    expect(result.includesWorkup).toBe(ReactionBoolean.True);
+    expect(result.hasDerivedAmount).toBe(ReactionBoolean.False);
+  });
+
+  it('maps the tri-state enum back to ord booleans', () => {
+    const reaction = ordCrudeComponentToReaction({ reactionId: 'r1', includesWorkup: true, hasDerivedAmount: false });
+    const ord = reactionCrudeComponentToOrd(reaction);
+    expect(ord.reactionId).toBe('r1');
+    expect(ord.includesWorkup).toBe(true);
+    expect(ord.hasDerivedAmount).toBe(false);
+  });
+});
+
+describe('ordInputWithoutNameToReaction', () => {
+  it('assigns an id and defaults component lists to empty arrays', () => {
+    const result = ordInputWithoutNameToReaction({});
+    expect(typeof result.id).toBe('string');
+    expect(result.components).toEqual([]);
+    expect(result.crudeComponents).toEqual([]);
+  });
+
+  it('preserves additionOrder', () => {
+    expect(ordInputWithoutNameToReaction({ additionOrder: 2 }).additionOrder).toBe(2);
+  });
+});
+
+describe('ordInputToReaction', () => {
+  it('prepends the input name to the converted input', () => {
+    const result = ordInputToReaction({}, 'Reagent A');
+    expect(result.name).toBe('Reagent A');
+    expect(typeof result.id).toBe('string');
+  });
+});
+
+describe('input map converters', () => {
+  it('keys converted inputs by their generated id', () => {
+    const result = ordInputsToReactionInputs({ reagent: {}, solvent: {} });
+    const entries = Object.values(result);
+    expect(entries).toHaveLength(2);
+    expect(entries.map(input => input.name).sort()).toEqual(['reagent', 'solvent']);
+    expect(Object.keys(result).sort()).toEqual(entries.map(input => input.id).sort());
+  });
+
+  it('round-trips a single input back to an ord map keyed by name', () => {
+    const reactionInputs = ordInputsToReactionInputs({ reagent: { additionOrder: 1 } });
+    const ordInputs = reactionInputsToOrdInputs(reactionInputs);
+    expect(Object.keys(ordInputs ?? {})).toEqual(['reagent']);
+    expect(ordInputs?.reagent.additionOrder).toBe(1);
+  });
+});

--- a/ui/src/store/entities/reactions/reactionsInputs/reactionsInputs.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactionsInputs/reactionsInputs.converters.test.ts
@@ -65,11 +65,12 @@ describe('ordInputToReaction', () => {
 
 describe('input map converters', () => {
   it('keys converted inputs by their generated id', () => {
+    const byString = (a: string, b: string) => a.localeCompare(b);
     const result = ordInputsToReactionInputs({ reagent: {}, solvent: {} });
     const entries = Object.values(result);
     expect(entries).toHaveLength(2);
-    expect(entries.map(input => input.name).sort()).toEqual(['reagent', 'solvent']);
-    expect(Object.keys(result).sort()).toEqual(entries.map(input => input.id).sort());
+    expect(entries.map(input => input.name).sort(byString)).toEqual(['reagent', 'solvent']);
+    expect(Object.keys(result).sort(byString)).toEqual(entries.map(input => input.id).sort(byString));
   });
 
   it('round-trips a single input back to an ord map keyed by name', () => {

--- a/ui/src/store/features/enumerationSetup/enumerationSetup.reducer.test.ts
+++ b/ui/src/store/features/enumerationSetup/enumerationSetup.reducer.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { enumerationSetupReducer } from './enumerationSetup.reducer.tsx';
+import { setEnumerationSetupOpenedAction } from './enumerationSetup.actions.ts';
+import { startEnumerationActions } from '../../entities/enumeration/enumeration.actions.ts';
+
+describe('enumerationSetupReducer', () => {
+  it('toggles the opened flag via setEnumerationSetupOpenedAction', () => {
+    const opened = enumerationSetupReducer(undefined, setEnumerationSetupOpenedAction(true));
+    expect(opened.isEnumerationSetupOpened).toBe(true);
+    const closed = enumerationSetupReducer(opened, setEnumerationSetupOpenedAction(false));
+    expect(closed.isEnumerationSetupOpened).toBe(false);
+  });
+
+  it('closes the setup when enumeration starts', () => {
+    const opened = enumerationSetupReducer(undefined, setEnumerationSetupOpenedAction(true));
+    const result = enumerationSetupReducer(opened, startEnumerationActions({} as never));
+    expect(result.isEnumerationSetupOpened).toBe(false);
+  });
+});

--- a/ui/src/store/features/enumerationSetup/enumerationSetup.reducer.test.ts
+++ b/ui/src/store/features/enumerationSetup/enumerationSetup.reducer.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect } from 'vitest';
 import { enumerationSetupReducer } from './enumerationSetup.reducer.tsx';
 import { setEnumerationSetupOpenedAction } from './enumerationSetup.actions.ts';
 import { startEnumerationActions } from '../../entities/enumeration/enumeration.actions.ts';
+import type { StartEnumeration } from '../../entities/enumeration/enumeration.types.ts';
 
 describe('enumerationSetupReducer', () => {
   it('toggles the opened flag via setEnumerationSetupOpenedAction', () => {
@@ -28,7 +29,7 @@ describe('enumerationSetupReducer', () => {
 
   it('closes the setup when enumeration starts', () => {
     const opened = enumerationSetupReducer(undefined, setEnumerationSetupOpenedAction(true));
-    const result = enumerationSetupReducer(opened, startEnumerationActions({} as never));
+    const result = enumerationSetupReducer(opened, startEnumerationActions({} as unknown as StartEnumeration));
     expect(result.isEnumerationSetupOpened).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Batch 4 of the UI unit-test backfill — **5 test files, 19 tests**, covering the last large pure-logic converters plus a registry, a reducer, and a guard.

> 🐞 **Also fixes a real source bug** (surfaced by the registry test + Greptile review): `ordToReactionConvertersByNodeEntity` mapped `VesselAttachments` to `ordVesselPreparationToReaction`, so vessel attachments were converted ord→reaction with the wrong (preparation) type enum. Now uses `ordVesselAttachmentToReaction`, and the test asserts the two resolve to distinct converters so it can't regress.

- **`reactionsInputs.converters`** — crude-component boolean mapping, input defaults (empty component lists), name prepending, and id↔name map keying.
- **`reactionConditions.converter`** — temperature/pressure measurement converters, temperature-condition defaults, stirring-condition null collapse.
- **`reactions.models`** — registry completeness: every `ReactionNodeEntity` has an ord→reaction (`.convert`) and reaction→ord converter, and appears in `allowedNodeEntityNames`.
- **`enumerationSetup.reducer`** — open/close toggling and close-on-enumeration-start.
- **`indigo.renderSvg`** — null-component and uninitialized-module guard branches.

## Gates

- `vitest run`: 276/276 pass (19 new).
- `tsc -b`, `eslint`, `prettier --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 19 unit tests across 5 new test files covering input/conditions converters, the models registry, the enumeration reducer, and the indigo render guard, and simultaneously fixes a real source bug where `VesselAttachments` in `ordToReactionConvertersByNodeEntity` incorrectly pointed to `ordVesselPreparationToReaction` instead of `ordVesselAttachmentToReaction`.

- **Bug fix** (`reactions.models.ts`): `VesselAttachments` now maps to `ordVesselAttachmentToReaction`; the new registry test pins both vessel entries to their distinct converters so the regression cannot reoccur.
- **New tests** (`reactionsInputs.converters`, `reactionConditions.converter`, `enumerationSetup.reducer`, `indigo`): cover boolean→enum mapping, round-trip type conversion, empty-array defaults, name-prepending, open/close toggling, and null-guard branches.
- The `enumerationSetup.reducer.test.ts` now casts through `unknown` (`as unknown as StartEnumeration`) per the earlier review thread, rather than the more opaque `as never` bypass.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one source change is a targeted correction of a confirmed copy-paste bug, and the new tests lock in the correct wiring so it cannot regress.

All changes are additive test files plus a single well-contained bug fix. The bug fix is correct, directly verified by the new distinctness assertion, and the previously-discussed cast has been updated as requested. No logic is removed or restructured, and the test suite passes cleanly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.models.ts | One-line fix: imports `ordVesselAttachmentToReaction` and assigns it to the `VesselAttachments` entry in the converter registry, replacing the incorrect `ordVesselPreparationToReaction` copy-paste. |
| ui/src/store/entities/reactions/reactions.models.test.ts | New test file: registry completeness check (all entities expose both converter directions), specific vessel-attachment/preparation distinctness assertion, and `allowedNodeEntityNames` coverage test. |
| ui/src/store/entities/reactions/reactionsInputs/reactionsInputs.converters.test.ts | New test file: covers crude-component boolean to enum mapping, `ordInputWithoutNameToReaction` defaults, name-prepending in `ordInputToReaction`, and round-trip of the full input map. |
| ui/src/store/entities/reactions/reactionConditions/reactionConditions.converter.test.ts | New test file: temperature and pressure measurement round-trips, temperature-condition empty-array/object defaults, and stirring-condition null collapse. |
| ui/src/store/features/enumerationSetup/enumerationSetup.reducer.test.ts | New test file: toggle via `setEnumerationSetupOpenedAction` and close-on-start via `startEnumerationActions`; uses `as unknown as StartEnumeration` cast per prior review feedback. |
| ui/src/common/utils/indigo.test.ts | New test file: verifies `renderSvg` guard branches return null for a null component and for an uninitialized WASM module. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ordToReactionConvertersByNodeEntity] --> B{ReactionNodeEntity}
    B --> C[VesselPreparations\nordVesselPreparationToReaction]
    B --> D[VesselAttachments\nordVesselAttachmentToReaction - fixed]
    B --> E[All other entities\ncorrect converters]

    F[reactionToOrdConvertersByNodeEntity] --> G{ReactionNodeEntity}
    G --> H[VesselPreparations\nreactionVesselPreparationToOrd]
    G --> I[VesselAttachments\nreactionVesselAttachmentToOrd]

    J[reactions.models.test.ts] --> K{Assertions}
    K --> L[Every entity has both directions]
    K --> M[VesselAttachments != VesselPreparations converter]
    K --> N[Every entity in allowedNodeEntityNames]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(ui): use localeCompare in sorts to ..."](https://github.com/open-reaction-database/ord-app/commit/0097773ed9b9fba9d2466effaee79ec21448c8af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35044603)</sub>

<!-- /greptile_comment -->