### PR TITLE
test(ui): clipboard, file-name hook, text formatting, notifications

### DIFF
--- a/ui/src/common/components/inputs/FileControl/useFileNameHref.test.tsx
+++ b/ui/src/common/components/inputs/FileControl/useFileNameHref.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFileNameHref } from './useFileNameHref.ts';
+
+describe('useFileNameHref', () => {
+  it('joins the name with the dot-stripped format and builds a base64 data href', () => {
+    const { result } = renderHook(() => useFileNameHref('molecule', { format: '.pb', value: 'YWJj' }));
+    expect(result.current.fileName).toBe('molecule.pb');
+    expect(result.current.href).toBe('data:application/octet-stream;base64,YWJj');
+  });
+
+  it('falls back to empty format/value when there is no file value', () => {
+    const { result } = renderHook(() => useFileNameHref('molecule', null));
+    expect(result.current.fileName).toBe('molecule.');
+    expect(result.current.href).toBe('data:application/octet-stream;base64,');
+  });
+});

--- a/ui/src/common/components/inputs/FileControl/useFileNameHref.test.tsx
+++ b/ui/src/common/components/inputs/FileControl/useFileNameHref.test.tsx
@@ -24,9 +24,9 @@ describe('useFileNameHref', () => {
     expect(result.current.href).toBe('data:application/octet-stream;base64,YWJj');
   });
 
-  it('falls back to empty format/value when there is no file value', () => {
+  it('omits the extension (no trailing dot) and empties the href when there is no file value', () => {
     const { result } = renderHook(() => useFileNameHref('molecule', null));
-    expect(result.current.fileName).toBe('molecule.');
+    expect(result.current.fileName).toBe('molecule');
     expect(result.current.href).toBe('data:application/octet-stream;base64,');
   });
 });

--- a/ui/src/common/components/inputs/FileControl/useFileNameHref.ts
+++ b/ui/src/common/components/inputs/FileControl/useFileNameHref.ts
@@ -21,8 +21,10 @@ export function useFileNameHref(name: string, value: FileControlValue | null) {
   const stringValue = value?.value ?? '';
 
   const fileName = useMemo(() => {
-    // In case there are incorrect saved format files
-    return [name, format.replace('.', '')].join('.');
+    // Guard against incorrect saved format files; omit the extension entirely when there is no
+    // format so we don't produce a trailing-dot filename (which some platforms mishandle).
+    const extension = format.replace('.', '');
+    return extension ? `${name}.${extension}` : name;
   }, [format, name]);
 
   const href = useMemo(() => {

--- a/ui/src/common/hooks/useTextFormatting.test.ts
+++ b/ui/src/common/hooks/useTextFormatting.test.ts
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 import { describe, it, expect } from 'vitest';
-import formatting from '../dictionary/formatting.json';
 import { getFormattedValue } from './useTextFormatting.ts';
 
 describe('getFormattedValue', () => {
   it('maps a known key to its formatted symbol', () => {
-    const [key, mapped] = Object.entries(formatting)[0];
-    expect(getFormattedValue(key)).toBe(mapped);
+    expect(getFormattedValue('LITER')).toBe('L');
   });
 
   it('returns the input unchanged when there is no mapping', () => {

--- a/ui/src/common/hooks/useTextFormatting.test.ts
+++ b/ui/src/common/hooks/useTextFormatting.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import formatting from '../dictionary/formatting.json';
+import { getFormattedValue } from './useTextFormatting.ts';
+
+describe('getFormattedValue', () => {
+  it('maps a known key to its formatted symbol', () => {
+    const [key, mapped] = Object.entries(formatting)[0];
+    expect(getFormattedValue(key)).toBe(mapped);
+  });
+
+  it('returns the input unchanged when there is no mapping', () => {
+    expect(getFormattedValue('__not_a_formatting_key__')).toBe('__not_a_formatting_key__');
+  });
+});

--- a/ui/src/common/utils/copyToClipboard.test.ts
+++ b/ui/src/common/utils/copyToClipboard.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { copyToClipboard } from './copyToClipboard.ts';
+
+const writeText = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(globalThis, 'navigator', { value: { clipboard: { writeText } }, configurable: true });
+});
+
+describe('copyToClipboard', () => {
+  it('writes the given text to the clipboard', () => {
+    writeText.mockResolvedValue(undefined);
+    copyToClipboard('hello world');
+    expect(writeText).toHaveBeenCalledWith('hello world');
+  });
+
+  it('does not throw when the clipboard write is rejected', () => {
+    writeText.mockRejectedValue(new Error('denied'));
+    expect(() => copyToClipboard('x')).not.toThrow();
+    expect(writeText).toHaveBeenCalledWith('x');
+  });
+});

--- a/ui/src/common/utils/copyToClipboard.test.ts
+++ b/ui/src/common/utils/copyToClipboard.test.ts
@@ -30,9 +30,13 @@ describe('copyToClipboard', () => {
     expect(writeText).toHaveBeenCalledWith('hello world');
   });
 
-  it('does not throw when the clipboard write is rejected', () => {
-    writeText.mockRejectedValue(new Error('denied'));
+  it('logs the error and does not throw when the clipboard write is rejected', async () => {
+    const error = new Error('denied');
+    writeText.mockRejectedValue(error);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
     expect(() => copyToClipboard('x')).not.toThrow();
     expect(writeText).toHaveBeenCalledWith('x');
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(error));
   });
 });

--- a/ui/src/common/utils/showNotification.test.tsx
+++ b/ui/src/common/utils/showNotification.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { notifications } from '@mantine/notifications';
+import { showNotification } from './showNotification.tsx';
+import { NotificationVariant } from 'common/types/notification.ts';
+
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+const showMock = vi.mocked(notifications.show);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('showNotification', () => {
+  it('forwards the message and the shared default options to notifications.show', () => {
+    showNotification({ variant: NotificationVariant.SUCCESS, message: 'Saved' });
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(showMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Saved', autoClose: 4000, color: 'transparent', withBorder: false }),
+    );
+  });
+
+  it('chooses a different icon for the success and error variants', () => {
+    showNotification({ variant: NotificationVariant.SUCCESS, message: 'ok' });
+    showNotification({ variant: NotificationVariant.ERROR, message: 'bad' });
+    expect(showMock.mock.calls[0][0].icon).not.toEqual(showMock.mock.calls[1][0].icon);
+  });
+});


### PR DESCRIPTION
## Summary

Batch 5 of the UI unit-test backfill — **4 test files, 8 tests** — the last of the easily-isolated pure functions/hooks.

- **`copyToClipboard`** — writes text via `navigator.clipboard.writeText`; swallows a rejected write without throwing.
- **`useFileNameHref`** — name + dot-stripped format → filename and a base64 `data:` href, with the null-value fallback (`renderHook`).
- **`getFormattedValue`** (useTextFormatting) — maps a known dictionary key to its symbol; passes unknown keys through unchanged.
- **`showNotification`** — forwards the message + shared default options to `notifications.show` and selects a per-variant icon (`@mantine/notifications` mocked).

## Gates

- `vitest run`: 309/309 pass (8 new).
- `tsc -b`, `eslint`, `prettier --check`: clean.

## Note on remaining backfill

This batch exhausts the pure-logic surface (converters, transforms, selectors, reducers, utils, hooks). What's left is largely **React components** (~40 `.tsx`, which need a Mantine provider + `matchMedia`/observer polyfills) and **async thunks / the composite `reactions.reducer`** (which need a mock store + stubbed API). Those are a larger, infra-dependent surface — happy to continue, but flagging it as a natural point to confirm scope/approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds four unit test files covering `copyToClipboard`, `useFileNameHref`, `getFormattedValue` (useTextFormatting), and `showNotification`; also fixes a trailing-dot filename bug in `useFileNameHref.ts` when no file format is present.

- **`useFileNameHref.ts` bug fix**: the old `[name, format.replace('.', '')].join('.')` always appended a dot, producing `molecule.` when format was absent; the new guard returns just `name` when the stripped extension is empty.
- **Test additions**: 8 new tests mirror the previous review feedback — `LITER → L` is hardcoded rather than dynamically selected, and the clipboard rejection test now asserts on the `console.error` spy via `vi.waitFor`.
- **`showNotification` coverage**: verifies both the shared defaults (`autoClose`, `color`, `withBorder`) and that the SUCCESS/ERROR variants produce distinct icons.

<h3>Confidence Score: 5/5</h3>

Pure test additions plus a narrow one-line guard in the filename hook; no production logic paths are removed or broadly changed.

The only production change is the conditional extension guard in useFileNameHref.ts, which is directly covered by the new test for the null-value path. All previous review feedback has been incorporated. No regressions are expected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/inputs/FileControl/useFileNameHref.ts | Bug fix: guards against trailing-dot filename when format is absent; logic is correct and well-commented. |
| ui/src/common/components/inputs/FileControl/useFileNameHref.test.tsx | New tests for both the happy path and the null-value path; correctly exercises the trailing-dot fix and verifies the base64 data href. |
| ui/src/common/utils/copyToClipboard.test.ts | Two-test suite; happy path and rejection path are both covered; the rejection test now spies on console.error and uses vi.waitFor, addressing previous feedback. |
| ui/src/common/hooks/useTextFormatting.test.ts | Pins a specific key ('LITER') per previous review guidance; pass-through for unknown keys is also verified. |
| ui/src/common/utils/showNotification.test.tsx | Mocks @mantine/notifications cleanly; checks shared defaults and per-variant icon divergence; does not assert the radius default, minor gap. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["useFileNameHref(name, value)"] --> B{value null?}
    B -- "No" --> C["format = value.format ?? ''"]
    B -- "Yes" --> D["format = ''"]
    C --> E["extension = format.replace('.', '')"]
    D --> E
    E --> F{extension empty?}
    F -- "Yes (null/no-format case)" --> G["fileName = name"]
    F -- "No (.pb → pb)" --> H["fileName = name + '.' + extension"]
    G --> I["href = 'data:application/octet-stream;base64,' + ''"]
    H --> J["href = 'data:application/octet-stream;base64,' + value.value"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): drop trailing-dot filename when..."](https://github.com/open-reaction-database/ord-app/commit/15a894dd01858c20e6d4621cb47294730b18349f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35046890)</sub>

<!-- /greptile_comment -->