### PR TITLE
test(ui): component test suite (~53 components: prop, connected, mount-safety) + render helpers

### DIFF
--- a/ui/src/common/components/DownloadMenu/DownloadMenu.test.tsx
+++ b/ui/src/common/components/DownloadMenu/DownloadMenu.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { DownloadMenu } from './DownloadMenu.tsx';
+
+describe('DownloadMenu', () => {
+  it('renders its target element', () => {
+    renderWithProviders(
+      <DownloadMenu
+        url="/datasets/1/download"
+        options={[{ label: 'JSON', format: 'json' }]}
+        target={<button>download</button>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'download' })).toBeInTheDocument();
+  });
+});

--- a/ui/src/common/components/FormModal/FormModal.test.tsx
+++ b/ui/src/common/components/FormModal/FormModal.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { FormModal } from './FormModal.tsx';
+
+describe('FormModal', () => {
+  it('renders the title, content, and default submit label, wiring up close/submit', () => {
+    const onClose = vi.fn();
+    // FormModal types onSubmit as () => void but wires it to the form's onSubmit; preventDefault
+    // via an optional event param keeps it type-compatible while avoiding a jsdom navigation.
+    const onSubmit = vi.fn((event?: { preventDefault: () => void }) => event?.preventDefault());
+    renderWithMantine(
+      <FormModal
+        title="New dataset"
+        onClose={onClose}
+        onSubmit={onSubmit}
+      >
+        <span>body content</span>
+      </FormModal>,
+    );
+    expect(screen.getByText('New dataset')).toBeInTheDocument();
+    expect(screen.getByText('body content')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('uses a custom submit label when provided', () => {
+    renderWithMantine(
+      <FormModal
+        title="t"
+        onClose={() => {}}
+        onSubmit={() => {}}
+        submitTitle="Save"
+      >
+        <span>x</span>
+      </FormModal>,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+});

--- a/ui/src/common/components/GroupsListWithRoles/GroupsListWithRoles.test.tsx
+++ b/ui/src/common/components/GroupsListWithRoles/GroupsListWithRoles.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { GroupsListWithRoles } from './GroupsListWithRoles.tsx';
+import { USER_ROLES } from 'common/types';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const stateWithGroups = {
+  entities: {
+    groups: {
+      groupsById: {
+        1: { id: 1, name: 'Alpha', role: USER_ROLES.ADMIN },
+        2: { id: 2, name: 'Beta', role: USER_ROLES.VIEWER },
+      },
+    },
+  },
+} as unknown as Partial<AppState>;
+
+describe('GroupsListWithRoles', () => {
+  it('renders no group rows when the store has no matching groups', () => {
+    renderWithProviders(<GroupsListWithRoles data={[]} />, { preloadedState: {} });
+    expect(screen.queryByText('Alpha:')).toBeNull();
+    expect(screen.queryByText('+1')).toBeNull();
+  });
+
+  it('shows the highest-priority group first and a counter for the rest', () => {
+    renderWithProviders(
+      <GroupsListWithRoles
+        data={[
+          { id: 1, name: 'Alpha', role: USER_ROLES.ADMIN },
+          { id: 2, name: 'Beta', role: USER_ROLES.VIEWER },
+        ]}
+      />,
+      { preloadedState: stateWithGroups },
+    );
+    // Admin (Alpha) sorts ahead of Viewer (Beta) and is shown inline.
+    expect(screen.getByText('Alpha:')).toBeInTheDocument();
+    expect(screen.getByText('admin')).toBeInTheDocument();
+    // The single remaining group is collapsed into a +1 counter.
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+});

--- a/ui/src/common/components/GroupsListWithRoles/GroupsListWithRoles.test.tsx
+++ b/ui/src/common/components/GroupsListWithRoles/GroupsListWithRoles.test.tsx
@@ -32,10 +32,16 @@ const stateWithGroups = {
 } as unknown as Partial<AppState>;
 
 describe('GroupsListWithRoles', () => {
-  it('renders no group rows when the store has no matching groups', () => {
+  it('renders nothing when data is empty', () => {
     renderWithProviders(<GroupsListWithRoles data={[]} />, { preloadedState: {} });
     expect(screen.queryByText('Alpha:')).toBeNull();
-    expect(screen.queryByText('+1')).toBeNull();
+  });
+
+  it('renders nothing when the referenced groups are absent from the store', () => {
+    renderWithProviders(<GroupsListWithRoles data={[{ id: 99, name: 'Ghost', role: USER_ROLES.VIEWER }]} />, {
+      preloadedState: {},
+    });
+    expect(screen.queryByText('Ghost:')).toBeNull();
   });
 
   it('shows the highest-priority group first and a counter for the rest', () => {

--- a/ui/src/common/components/InputModal/InputModal.test.tsx
+++ b/ui/src/common/components/InputModal/InputModal.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { InputModal } from './InputModal.tsx';
+
+describe('InputModal', () => {
+  it('renders the title and the input seeded with the initial value', () => {
+    renderWithMantine(
+      <InputModal
+        title="Rename dataset"
+        onClose={() => {}}
+        onSubmit={async () => {}}
+        inputLabel="Name"
+        initialValue="old name"
+      />,
+    );
+    expect(screen.getByText('Rename dataset')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('old name')).toBeInTheDocument();
+  });
+
+  it('submits the current value', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithMantine(
+      <InputModal
+        title="Rename"
+        onClose={() => {}}
+        onSubmit={onSubmit}
+        inputLabel="Name"
+        initialValue="kept"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('kept'));
+  });
+});

--- a/ui/src/common/components/ReactionCard/ReactionCard.test.tsx
+++ b/ui/src/common/components/ReactionCard/ReactionCard.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionCard } from './ReactionCard.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionCard as unknown as () => JSX.Element;
+
+describe('ReactionCard', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/common/components/ReactionPreview/ReactionComponentPreview.test.tsx
+++ b/ui/src/common/components/ReactionPreview/ReactionComponentPreview.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionComponentPreview } from './ReactionComponentPreview.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionComponentPreview as unknown as () => JSX.Element;
+
+describe('ReactionComponentPreview', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/common/components/display/DataTable/DataTable.test.tsx
+++ b/ui/src/common/components/display/DataTable/DataTable.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import type { MRT_ColumnDef } from 'mantine-react-table';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { DataTable } from './DataTable.tsx';
+
+interface Row {
+  name: string;
+}
+
+const columns: Array<MRT_ColumnDef<Row>> = [{ accessorKey: 'name', header: 'Name' }];
+
+describe('DataTable', () => {
+  it('renders the column header and a cell for each row', () => {
+    renderWithMantine(
+      <DataTable
+        columns={columns}
+        data={[{ name: 'Acetone' }, { name: 'Water' }]}
+      />,
+    );
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Acetone')).toBeInTheDocument();
+    expect(screen.getByText('Water')).toBeInTheDocument();
+  });
+});

--- a/ui/src/common/components/inputs/FileControl/FileControl.test.tsx
+++ b/ui/src/common/components/inputs/FileControl/FileControl.test.tsx
@@ -42,7 +42,7 @@ describe('FileControl', () => {
       />,
     );
     expect(screen.getByRole('link', { name: 'molecule.pb' })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button', { name: /remove file/i }));
     expect(onChange).toHaveBeenCalledWith(null);
   });
 });

--- a/ui/src/common/components/inputs/FileControl/FileControl.test.tsx
+++ b/ui/src/common/components/inputs/FileControl/FileControl.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { FileControl } from './FileControl.tsx';
+
+describe('FileControl', () => {
+  it('renders the labelled file input when there is no value', () => {
+    renderWithMantine(
+      <FileControl
+        name="data"
+        label="Data file"
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Data file')).toBeInTheDocument();
+  });
+
+  it('shows a download link for the stored file and clears it on remove', () => {
+    const onChange = vi.fn();
+    renderWithMantine(
+      <FileControl
+        name="molecule"
+        label="File"
+        value={{ value: 'YWJj', format: 'pb' }}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByRole('link', { name: 'molecule.pb' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/ui/src/common/components/inputs/FileControl/FileControl.tsx
+++ b/ui/src/common/components/inputs/FileControl/FileControl.tsx
@@ -80,6 +80,7 @@ export function FileControl({ name, value, disabled, onChange, label }: Readonly
             {fileName}
           </a>
           <ActionIcon
+            aria-label="Remove file"
             onClick={handleRemoveFile}
             variant="transparent"
             color="red"

--- a/ui/src/common/components/inputs/ValuePrecisionUnitControl/ValuePrecisionUnitControl.test.tsx
+++ b/ui/src/common/components/inputs/ValuePrecisionUnitControl/ValuePrecisionUnitControl.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { ValuePrecisionUnitControl } from './ValuePrecisionUnitControl.tsx';
+
+describe('ValuePrecisionUnitControl', () => {
+  it('renders the current value and the available unit options', () => {
+    renderWithMantine(
+      <ValuePrecisionUnitControl
+        options={['G', 'MG']}
+        value={{ value: 5, precision: null, units: 'G' }}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+    expect(screen.getByText('G')).toBeInTheDocument();
+    expect(screen.getByText('MG')).toBeInTheDocument();
+  });
+});

--- a/ui/src/common/components/interactions/ConfirmPopover/ConfirmPopover.test.tsx
+++ b/ui/src/common/components/interactions/ConfirmPopover/ConfirmPopover.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { ConfirmPopover } from './ConfirmPopover.tsx';
+
+describe('ConfirmPopover', () => {
+  it('renders the title/text and OK/Cancel actions when opened', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    renderWithMantine(
+      <ConfirmPopover
+        opened
+        target={<button>open</button>}
+        title="Delete reaction?"
+        text="This cannot be undone."
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    expect(screen.getByText('Delete reaction?')).toBeInTheDocument();
+    expect(screen.getByText('This cannot be undone.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/features/datasets/CreateDatasetFromFile/CreateDatasetFromFile.test.tsx
+++ b/ui/src/features/datasets/CreateDatasetFromFile/CreateDatasetFromFile.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { CreateDatasetFromFile } from './CreateDatasetFromFile.tsx';
+
+describe('CreateDatasetFromFile', () => {
+  it('renders the from-file form with a group selector and Save action', () => {
+    renderWithProviders(<CreateDatasetFromFile onClose={() => {}} />, { preloadedState: {} });
+    expect(screen.getByText('Create Dataset from File')).toBeInTheDocument();
+    expect(screen.getByText('Group')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/datasets/CreateNewDataset/CreateNewDataset.test.tsx
+++ b/ui/src/features/datasets/CreateNewDataset/CreateNewDataset.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { CreateNewDataset } from './CreateNewDataset.tsx';
+
+describe('CreateNewDataset', () => {
+  it('renders the create-from-scratch form with a group selector and Save action', () => {
+    renderWithProviders(<CreateNewDataset onClose={() => {}} />, { preloadedState: {} });
+    expect(screen.getByText('Create Dataset from Scratch')).toBeInTheDocument();
+    expect(screen.getByText('Group')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/datasets/DatasetTable/DatasetTable.test.tsx
+++ b/ui/src/features/datasets/DatasetTable/DatasetTable.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { DatasetTable } from './DatasetTable.tsx';
+
+describe('DatasetTable', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<DatasetTable />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/datasets/ShareDataset/ShareDatasetSidebar.test.tsx
+++ b/ui/src/features/datasets/ShareDataset/ShareDatasetSidebar.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ShareDatasetSidebar } from './ShareDatasetSidebar.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ShareDatasetSidebar as unknown as () => JSX.Element;
+
+describe('ShareDatasetSidebar', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/enumeration/EnumerateButton.test.tsx
+++ b/ui/src/features/enumeration/EnumerateButton.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { EnumerateButton } from './EnumerateButton.tsx';
+
+describe('EnumerateButton', () => {
+  it('renders the enumerate paper button', () => {
+    renderWithProviders(<EnumerateButton />);
+    expect(screen.getByText('Enumerate')).toBeInTheDocument();
+    expect(screen.getByText('Create dataset from template')).toBeInTheDocument();
+  });
+
+  it('opens the enumeration setup in the store when clicked', () => {
+    const { store } = renderWithProviders(<EnumerateButton />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(store.getState().features.enumerationSetup.isEnumerationSetupOpened).toBe(true);
+  });
+});

--- a/ui/src/features/enumeration/EnumerationProgress/EnumerationProgress.test.tsx
+++ b/ui/src/features/enumeration/EnumerationProgress/EnumerationProgress.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { EnumerationProgressDisplay } from './EnumerationProgress.tsx';
+import type { EnumerationProgress } from 'store/entities/enumeration/enumeration.types.ts';
+
+describe('EnumerationProgressDisplay', () => {
+  it('renders the waiting modal while enumerating', () => {
+    const progress = {
+      index: 5,
+      templateCSV: { content: Array.from({ length: 10 }) },
+    } as unknown as EnumerationProgress;
+    renderWithMantine(
+      <EnumerationProgressDisplay
+        enumerationProgress={progress}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText('Please wait')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/enumeration/EnumerationSetup/EnumerationSetup.test.tsx
+++ b/ui/src/features/enumeration/EnumerationSetup/EnumerationSetup.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { EnumerationSetup } from './EnumerationSetup.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = EnumerationSetup as unknown as () => JSX.Element;
+
+describe('EnumerationSetup', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/enumeration/EnumerationWizard.test.tsx
+++ b/ui/src/features/enumeration/EnumerationWizard.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { EnumerationWizard } from './EnumerationWizard.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = EnumerationWizard as unknown as () => JSX.Element;
+
+describe('EnumerationWizard', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/groups/GroupSelector/GroupSelector.test.tsx
+++ b/ui/src/features/groups/GroupSelector/GroupSelector.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { GroupSelector } from './GroupSelector.tsx';
+
+describe('GroupSelector', () => {
+  it('renders a labelled, placeholdered group select', () => {
+    renderWithProviders(<GroupSelector />, { preloadedState: {} });
+    expect(screen.getByText('Group')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Select a group')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/groups/GroupsList/GroupsList.test.tsx
+++ b/ui/src/features/groups/GroupsList/GroupsList.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { GroupsList } from './GroupsList.tsx';
+import { USER_ROLES } from 'common/types';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const withGroups = {
+  entities: {
+    groups: {
+      groupsById: { 1: { id: 1, name: 'Alpha', role: USER_ROLES.ADMIN } },
+      groupNameSearch: '',
+    },
+  },
+} as unknown as Partial<AppState>;
+
+describe('GroupsList', () => {
+  it('lists the groups from the store', () => {
+    renderWithProviders(<GroupsList />, { preloadedState: withGroups });
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/groups/GroupsSidebar/GroupsDrawer/AddMemberInput/AddMemberInput.test.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsDrawer/AddMemberInput/AddMemberInput.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { AddMemberInput } from './AddMemberInput.tsx';
+
+describe('AddMemberInput', () => {
+  it('renders the member input and keeps Add disabled without admin rights or a value', () => {
+    renderWithProviders(<AddMemberInput />, { preloadedState: {} });
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add/i })).toBeDisabled();
+  });
+});

--- a/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupMembersList/GroupMembersList.test.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupMembersList/GroupMembersList.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { GroupMembersList } from './GroupMembersList.tsx';
+
+describe('GroupMembersList', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<GroupMembersList />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupMembersList/UserDataField/UserDataField.test.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupMembersList/UserDataField/UserDataField.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { UserDataField } from './UserDataField.tsx';
+
+describe('UserDataField', () => {
+  it('renders the field name and value', () => {
+    renderWithMantine(
+      <UserDataField
+        fieldName="Email"
+        value="ada@example.com"
+      />,
+    );
+    expect(screen.getByText('Email:')).toBeInTheDocument();
+    expect(screen.getByText('ada@example.com')).toBeInTheDocument();
+  });
+
+  it('falls back to "Unavailable" when there is no value', () => {
+    renderWithMantine(<UserDataField fieldName="Email" />);
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupsDrawer.test.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsDrawer/GroupsDrawer.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { GroupsDrawer } from './GroupsDrawer.tsx';
+
+describe('GroupsDrawer', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<GroupsDrawer />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/groups/GroupsSidebar/GroupsDrawer/PermissionModal/PermissionModal.test.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsDrawer/PermissionModal/PermissionModal.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { PermissionsModal } from './PermissionModal.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = PermissionsModal as unknown as () => JSX.Element;
+
+describe('PermissionsModal', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/groups/GroupsSidebar/GroupsDrawer/RoleSelector/RoleSelector.test.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsDrawer/RoleSelector/RoleSelector.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { RoleSelector } from './RoleSelector.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = RoleSelector as unknown as () => JSX.Element;
+
+describe('RoleSelector', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/groups/GroupsSidebar/GroupsSidebar.test.tsx
+++ b/ui/src/features/groups/GroupsSidebar/GroupsSidebar.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { GroupsSidebar } from './GroupsSidebar.tsx';
+
+describe('GroupsSidebar', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<GroupsSidebar />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityDelete/ReactionEntityDelete.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityDelete/ReactionEntityDelete.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionEntityDelete } from './ReactionEntityDelete.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionEntityDelete as unknown as () => JSX.Element;
+
+describe('ReactionEntityDelete', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityPaste.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityPaste.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionEntityPaste } from './ReactionEntityPaste.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionEntityPaste as unknown as () => JSX.Element;
+
+describe('ReactionEntityPaste', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/AppDataDisplay.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/AppDataDisplay.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { AppDataDisplay } from './AppDataDisplay.tsx';
+import { AppDataType, type AppData } from 'store/entities/reactions/reactionData/reactionData.types.ts';
+
+const appData = (data: AppData['data'], name = 'field'): AppData => ({ id: 'x', name, data }) as AppData;
+
+describe('AppDataDisplay', () => {
+  it('renders a URL value as an external link', () => {
+    renderWithMantine(<AppDataDisplay appData={appData({ type: AppDataType.Url, value: 'https://example.com' })} />);
+    expect(screen.getByRole('link', { name: 'https://example.com' })).toBeInTheDocument();
+  });
+
+  it('renders a text value as plain text', () => {
+    renderWithMantine(<AppDataDisplay appData={appData({ type: AppDataType.Text, value: 'hello' })} />);
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('renders an uploaded file as a download link, or "No file" when empty', () => {
+    const { unmount } = renderWithMantine(
+      <AppDataDisplay appData={appData({ type: AppDataType.Upload, value: 'YWJj', format: 'pb' }, 'mol')} />,
+    );
+    expect(screen.getByRole('link', { name: 'mol.pb' })).toBeInTheDocument();
+    unmount();
+
+    renderWithMantine(
+      <AppDataDisplay appData={appData({ type: AppDataType.Upload, value: '', format: 'pb' }, 'mol')} />,
+    );
+    expect(screen.getByText('No file')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsLookup/ComponentsLookup.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsLookup/ComponentsLookup.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ComponentsLookup } from './ComponentsLookup.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ComponentsLookup as unknown as () => JSX.Element;
+
+describe('ComponentsLookup', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/AuthenticStandard/AuthenticStandard.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/AuthenticStandard/AuthenticStandard.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { AuthenticStandard } from './AuthenticStandard.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = AuthenticStandard as unknown as () => JSX.Element;
+
+describe('AuthenticStandard', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementsDivider.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementsDivider.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { MeasurementsDivider } from './MeasurementsDivider.tsx';
+
+describe('MeasurementsDivider', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<MeasurementsDivider />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/workups/WorkupInput.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/workups/WorkupInput.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { WorkupInput } from './WorkupInput.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = WorkupInput as unknown as () => JSX.Element;
+
+describe('WorkupInput', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityBlock/ReactionEntityBlock.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityBlock/ReactionEntityBlock.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionEntityBlock } from './ReactionEntityBlock.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionEntityBlock as unknown as () => JSX.Element;
+
+describe('ReactionEntityBlock', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityLabel/ReactionEntityLabel.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityLabel/ReactionEntityLabel.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionEntityLabel } from './ReactionEntityLabel.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionEntityLabel as unknown as () => JSX.Element;
+
+describe('ReactionEntityLabel', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationBadge.test.tsx
+++ b/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationBadge.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionValidationBadge } from './ReactionValidationBadge.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionValidationBadge as unknown as () => JSX.Element;
+
+describe('ReactionValidationBadge', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionInteractions/ReactionValueLabel/TemplateReactionValueLabel.test.tsx
+++ b/ui/src/features/reactions/ReactionInteractions/ReactionValueLabel/TemplateReactionValueLabel.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { TemplateReactionValueLabelWrapper } from './TemplateReactionValueLabel.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = TemplateReactionValueLabelWrapper as unknown as () => JSX.Element;
+
+describe('TemplateReactionValueLabelWrapper', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionInteractions/ReactionViewDeleteButtons/ReactionEditDeleteButtons.test.tsx
+++ b/ui/src/features/reactions/ReactionInteractions/ReactionViewDeleteButtons/ReactionEditDeleteButtons.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionEditDeleteButtons } from './ReactionEditDeleteButtons.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionEditDeleteButtons as unknown as () => JSX.Element;
+
+describe('ReactionEditDeleteButtons', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionInteractions/ReactionViewDeleteButtons/ReactionSetVariablesButton.test.tsx
+++ b/ui/src/features/reactions/ReactionInteractions/ReactionViewDeleteButtons/ReactionSetVariablesButton.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionSetVariablesButton } from './ReactionSetVariablesButton.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionSetVariablesButton as unknown as () => JSX.Element;
+
+describe('ReactionSetVariablesButton', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionInteractions/ReactionViewDeleteButtons/ReactionViewButton.test.tsx
+++ b/ui/src/features/reactions/ReactionInteractions/ReactionViewDeleteButtons/ReactionViewButton.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionViewButton } from './ReactionViewButton.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ReactionViewButton as unknown as () => JSX.Element;
+
+describe('ReactionViewButton', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionList/CreateReactionMenu/CreateReactionFromFile/CreateReactionFromFile.test.tsx
+++ b/ui/src/features/reactions/ReactionList/CreateReactionMenu/CreateReactionFromFile/CreateReactionFromFile.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { CreateReactionFromFile } from './CreateReactionFromFile.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = CreateReactionFromFile as unknown as () => JSX.Element;
+
+describe('CreateReactionFromFile', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionList/CreateReactionMenu/CreateReactionMenu.test.tsx
+++ b/ui/src/features/reactions/ReactionList/CreateReactionMenu/CreateReactionMenu.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { CreateReactionMenu } from './CreateReactionMenu.tsx';
+
+describe('CreateReactionMenu', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<CreateReactionMenu />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionList/ReactionList.test.tsx
+++ b/ui/src/features/reactions/ReactionList/ReactionList.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionList } from './ReactionList.tsx';
+
+describe('ReactionList', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<ReactionList />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/ComponentsList/ComponentsList.test.tsx
+++ b/ui/src/features/reactions/ReactionView/ComponentsList/ComponentsList.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ComponentsListHeader } from './ComponentsList.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ComponentsListHeader as unknown as () => JSX.Element;
+
+describe('ComponentsListHeader', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/OpenSingleEntityButton/OpenSingleEntityButton.test.tsx
+++ b/ui/src/features/reactions/ReactionView/OpenSingleEntityButton/OpenSingleEntityButton.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { OpenSingleEntityButton } from './OpenSingleEntityButton.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = OpenSingleEntityButton as unknown as () => JSX.Element;
+
+describe('OpenSingleEntityButton', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/RemoveReaction/RemoveReaction.test.tsx
+++ b/ui/src/features/reactions/RemoveReaction/RemoveReaction.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { RemoveReaction } from './RemoveReaction.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = RemoveReaction as unknown as () => JSX.Element;
+
+describe('RemoveReaction', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/templates/EntitiesMenu/EntitiesMenu.test.tsx
+++ b/ui/src/features/templates/EntitiesMenu/EntitiesMenu.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { EntitiesMenu } from './EntitiesMenu.tsx';
+
+describe('EntitiesMenu', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<EntitiesMenu />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/templates/ImportFromJSON/ImportFromJSON.test.tsx
+++ b/ui/src/features/templates/ImportFromJSON/ImportFromJSON.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ImportFromJSON } from './ImportFromJSON.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = ImportFromJSON as unknown as () => JSX.Element;
+
+describe('ImportFromJSON', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.test.tsx
+++ b/ui/src/features/templates/SaveAsTemplate/SaveAsTemplate.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { SaveAsTemplate } from './SaveAsTemplate.tsx';
+
+// Smoke test: the component mounts inside the store/Mantine providers without throwing.
+const Component = SaveAsTemplate as unknown as () => JSX.Element;
+
+describe('SaveAsTemplate', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderWithProviders(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/test/renderWithProviders.tsx
+++ b/ui/src/test/renderWithProviders.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, type RenderOptions } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { rootReducer } from 'store/rootReducer.ts';
+import type { AppState } from 'store/configureAppStore.ts';
+import type { ReactElement, ReactNode } from 'react';
+
+interface ProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  preloadedState?: Partial<AppState>;
+}
+
+/**
+ * Renders a store-connected component inside a fresh Redux store + MantineProvider. Seed only the
+ * slices the component reads via `preloadedState`; the rest fall back to their reducer defaults.
+ */
+export function renderWithProviders(ui: ReactElement, { preloadedState, ...options }: ProvidersOptions = {}) {
+  const store = configureStore({ reducer: rootReducer, preloadedState: preloadedState as AppState });
+  function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
+    return (
+      <Provider store={store}>
+        <MantineProvider>{children}</MantineProvider>
+      </Provider>
+    );
+  }
+  return { store, ...render(ui, { wrapper: Wrapper, ...options }) };
+}


### PR DESCRIPTION
## Summary

Large component-backfill batch — **~53 new component test files** plus two reusable render helpers, spanning `common/components` and `features/*`.

**Helpers** (`src/test/`): `renderWithMantine` (MantineProvider) and `renderWithProviders` (fresh Redux store seeded via `preloadedState` + MantineProvider).

**Assertion-rich tests (~20)** — render output / interactions:
- Prop-driven: `FormModal`, `ConfirmPopover`, `DataTable`, `FileControl`, `InputModal`, `ValuePrecisionUnitControl`, `UserDataField`, `AppDataDisplay`, `EnumerationProgress`, `DownloadMenu`.
- Store-connected: `GroupsListWithRoles`, `GroupSelector`, `GroupsList`, `AddMemberInput`, `EnumerateButton` (dispatch → store), `CreateNewDataset`, `CreateDatasetFromFile`.

**Mount-safety smoke tests (~33)** — each mounts a store-connected component inside the real Redux store + Mantine and asserts it renders without throwing (regression guard against undefined-selector / bad-context crashes): datasets, groups, reaction list/header/validation, templates, and reaction-entity-node components.

Deeply context-dependent components (`ReactionView/*`, nested entity nodes needing reaction/entity context) are deferred to a follow-up PR with targeted fixtures.

**Small a11y fix**: `FileControl`'s remove button gained an `aria-label="Remove file"`.

## Gates

- `vitest run`: 403/403 pass.
- `tsc -b`, `eslint`, `prettier --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds ~20 component test files plus a `renderWithProviders` helper (Redux store + MantineProvider) to complement the existing `renderWithMantine` helper, completing a backfill batch for both prop-driven and store-connected components. The only production change is a one-line a11y fix adding `aria-label="Remove file"` to `FileControl`'s remove `ActionIcon`.

- **`renderWithProviders`**: creates a fresh `configureStore` per call so each test gets isolated state; seeds slices via `preloadedState` and returns the `store` alongside the RTL handle for post-dispatch state assertions.
- **Prop-driven tests** (`FormModal`, `ConfirmPopover`, `DataTable`, `FileControl`, `InputModal`, `ValuePrecisionUnitControl`, `UserDataField`, `AppDataDisplay`, `EnumerationProgress`, `DownloadMenu`): exercise rendering and user-interaction callbacks.
- **Store-connected tests** (`GroupsListWithRoles`, `GroupSelector`, `GroupsList`, `AddMemberInput`, `EnumerateButton`, `CreateNewDataset`, `CreateDatasetFromFile`): verify store reads and dispatch side-effects via preloaded state; ~15 heavier components are covered as documented smoke tests using `as unknown as () => JSX.Element` to bypass required-prop TypeScript checks.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are test files plus a one-line a11y addition to FileControl; no production logic is modified.

The only production file touched is FileControl.tsx, where a single aria-label attribute is added to an existing ActionIcon with no behavioral change. All other files are new test files. The renderWithProviders helper correctly isolates store state per call, and all 370 tests pass.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/test/renderWithProviders.tsx | New test helper that wires a fresh Redux store seeded via preloadedState + MantineProvider; store is returned alongside RTL render result for state assertions |
| ui/src/common/components/inputs/FileControl/FileControl.tsx | Single-line a11y fix: aria-label="Remove file" added to the ActionIcon so screen readers and tests can identify it |
| ui/src/common/components/GroupsListWithRoles/GroupsListWithRoles.test.tsx | Three-case suite: empty data, IDs absent from store, and priority-ordering + counter; previously addressed feedback incorporated |
| ui/src/features/enumeration/EnumerateButton.test.tsx | Two cases: smoke render and dispatch-to-store; click test uses getByRole('button') without a name — currently safe since PaperButton renders exactly one button |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/AppDataDisplay.test.tsx | Three display modes (URL, text, upload) tested; the upload case combines two sub-scenarios in one it block with unmount() between them rather than splitting into separate it calls |
| ui/src/common/components/FormModal/FormModal.test.tsx | Title/body/label rendering and Cancel/Submit callbacks verified; custom submitTitle case added |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/AuthenticStandard/AuthenticStandard.test.tsx | Smoke-only test using as unknown as () => JSX.Element cast to bypass required-props checking; mounting without crashing is the sole assertion |
| ui/src/features/groups/GroupsList/GroupsList.test.tsx | Store-seeded test that verifies a group name from preloadedState appears in the rendered list |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Helpers["Test Helpers (src/test/)"]
        RWM["renderWithMantine\n(MantineProvider only)"]
        RWP["renderWithProviders\n(configureStore + MantineProvider)\nreturns { store, ...rtl }"]
    end

    subgraph PropDriven["Prop-driven Tests (~10)"]
        FM["FormModal"]
        CP["ConfirmPopover"]
        DT["DataTable"]
        FC["FileControl"]
        IM["InputModal"]
        VP["ValuePrecisionUnitControl"]
        UDF["UserDataField"]
        ADD["AppDataDisplay"]
        EP["EnumerationProgress"]
        DM["DownloadMenu"]
    end

    subgraph Connected["Store-connected Tests (~7 full + ~15 smoke)"]
        GLR["GroupsListWithRoles"]
        GS["GroupSelector"]
        GL["GroupsList"]
        AMI["AddMemberInput"]
        EB["EnumerateButton\n(dispatch → store assertion)"]
        CND["CreateNewDataset"]
        CDF["CreateDatasetFromFile"]
        SMOKE["Smoke tests\n(as unknown as JSX.Element)"]
    end

    RWM --> PropDriven
    RWP --> Connected
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(ui): mount-safety smoke tests for c..."](https://github.com/open-reaction-database/ord-app/commit/4b30b70939264cfec44b3f0cd4f6664964af94af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35050300)</sub>

<!-- /greptile_comment -->