### PR TITLE
test(ui): reaction-view render helper + ReactionView section tests

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityTitle/ReactionEntityTitle.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityTitle/ReactionEntityTitle.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntityTitle } from './ReactionEntityTitle.tsx';
+
+// Smoke test: mounts within seeded reaction/entity contexts + store without throwing.
+const Component = ReactionEntityTitle as unknown as () => JSX.Element;
+
+describe('ReactionEntityTitle', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderInReactionView(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/ComponentPreview/ComponentPreview.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/ComponentPreview/ComponentPreview.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ComponentPreview } from './ComponentPreview.tsx';
+
+// Smoke test: mounts within seeded reaction/entity contexts + store without throwing.
+const Component = ComponentPreview as unknown as () => JSX.Element;
+
+describe('ComponentPreview', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderInReactionView(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionValueLabelWrapper.test.tsx
+++ b/ui/src/features/reactions/ReactionValueLabelWrapper.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionValueLabelWrapper } from './ReactionValueLabelWrapper.tsx';
+
+// Smoke test: mounts within seeded reaction/entity contexts + store without throwing.
+const Component = ReactionValueLabelWrapper as unknown as () => JSX.Element;
+
+describe('ReactionValueLabelWrapper', () => {
+  it('mounts without crashing', () => {
+    const { container } = renderInReactionView(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Inputs/Inputs.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Inputs/Inputs.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { Inputs } from './Inputs.tsx';
+
+const Component = Inputs as unknown as () => JSX.Element;
+
+describe('Inputs', () => {
+  it('mounts within the reaction view without crashing', () => {
+    const { container } = renderInReactionView(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Inputs/Inputs.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Inputs/Inputs.test.tsx
@@ -17,6 +17,7 @@ import { describe, it, expect } from 'vitest';
 import { renderInReactionView } from 'test/renderInReactionView.tsx';
 import { Inputs } from './Inputs.tsx';
 
+// Smoke test: mounts within seeded reaction/entity contexts + store without throwing.
 const Component = Inputs as unknown as () => JSX.Element;
 
 describe('Inputs', () => {

--- a/ui/src/features/reactions/ReactionView/Notes/Notes.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Notes/Notes.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { Notes } from './Notes.tsx';
+
+const Component = Notes as unknown as () => JSX.Element;
+
+describe('Notes', () => {
+  it('mounts within the reaction view without crashing', () => {
+    const { container } = renderInReactionView(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Notes/Notes.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Notes/Notes.test.tsx
@@ -17,6 +17,7 @@ import { describe, it, expect } from 'vitest';
 import { renderInReactionView } from 'test/renderInReactionView.tsx';
 import { Notes } from './Notes.tsx';
 
+// Smoke test: mounts within seeded reaction/entity contexts + store without throwing.
 const Component = Notes as unknown as () => JSX.Element;
 
 describe('Notes', () => {

--- a/ui/src/features/reactions/ReactionView/Outcomes/Outcomes.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Outcomes/Outcomes.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { Outcomes } from './Outcomes.tsx';
+
+const Component = Outcomes as unknown as () => JSX.Element;
+
+describe('Outcomes', () => {
+  it('mounts within the reaction view without crashing', () => {
+    const { container } = renderInReactionView(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Outcomes/Outcomes.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Outcomes/Outcomes.test.tsx
@@ -17,6 +17,7 @@ import { describe, it, expect } from 'vitest';
 import { renderInReactionView } from 'test/renderInReactionView.tsx';
 import { Outcomes } from './Outcomes.tsx';
 
+// Smoke test: mounts within seeded reaction/entity contexts + store without throwing.
 const Component = Outcomes as unknown as () => JSX.Element;
 
 describe('Outcomes', () => {

--- a/ui/src/features/reactions/ReactionView/Provenance/Provenance.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Provenance/Provenance.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { Provenance } from './Provenance.tsx';
+
+const Component = Provenance as unknown as () => JSX.Element;
+
+describe('Provenance', () => {
+  it('mounts within the reaction view without crashing', () => {
+    const { container } = renderInReactionView(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Provenance/Provenance.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Provenance/Provenance.test.tsx
@@ -17,6 +17,7 @@ import { describe, it, expect } from 'vitest';
 import { renderInReactionView } from 'test/renderInReactionView.tsx';
 import { Provenance } from './Provenance.tsx';
 
+// Smoke test: mounts within seeded reaction/entity contexts + store without throwing.
 const Component = Provenance as unknown as () => JSX.Element;
 
 describe('Provenance', () => {

--- a/ui/src/features/reactions/ReactionView/Workups/Workups.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Workups/Workups.test.tsx
@@ -17,6 +17,7 @@ import { describe, it, expect } from 'vitest';
 import { renderInReactionView } from 'test/renderInReactionView.tsx';
 import { Workups } from './Workups.tsx';
 
+// Smoke test: mounts within seeded reaction/entity contexts + store without throwing.
 const Component = Workups as unknown as () => JSX.Element;
 
 describe('Workups', () => {

--- a/ui/src/features/reactions/ReactionView/Workups/Workups.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Workups/Workups.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { Workups } from './Workups.tsx';
+
+const Component = Workups as unknown as () => JSX.Element;
+
+describe('Workups', () => {
+  it('mounts within the reaction view without crashing', () => {
+    const { container } = renderInReactionView(<Component />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/src/test/renderInReactionView.tsx
+++ b/ui/src/test/renderInReactionView.tsx
@@ -50,11 +50,13 @@ export function emptyReactionData(): AppReaction {
   } as unknown as AppReaction;
 }
 
+// Only the dataset-reaction shape is modelled here (isTemplate: false). The template variant of
+// ReactionsContext additionally requires a string reactionId + isViewOnly: true; if a template
+// smoke test is ever needed, add a dedicated helper rather than loosening these options.
 interface ReactionViewOptions extends Omit<RenderOptions, 'wrapper'> {
-  reactionId?: number | string;
+  reactionId?: number;
   pathComponents?: ReactionPathComponents;
   reaction?: AppReaction;
-  isTemplate?: boolean;
   isViewOnly?: boolean;
 }
 
@@ -63,14 +65,7 @@ interface ReactionViewOptions extends Omit<RenderOptions, 'wrapper'> {
  * the store, so components that read `reactionContext`/`reactionEntityContext` mount correctly.
  */
 export function renderInReactionView(ui: ReactElement, options: ReactionViewOptions = {}) {
-  const {
-    reactionId = 1,
-    pathComponents = [],
-    reaction,
-    isTemplate = false,
-    isViewOnly = false,
-    ...renderOptions
-  } = options;
+  const { reactionId = 1, pathComponents = [], reaction, isViewOnly = false, ...renderOptions } = options;
   const store = configureStore({
     reducer: rootReducer,
     preloadedState: {
@@ -81,7 +76,7 @@ export function renderInReactionView(ui: ReactElement, options: ReactionViewOpti
   });
   const reactionCtxValue = {
     reactionId,
-    isTemplate,
+    isTemplate: false,
     isViewOnly,
     ViewDeleteButtonsComponent: Dummy,
     ValueLabelComponent: Dummy,

--- a/ui/src/test/renderInReactionView.tsx
+++ b/ui/src/test/renderInReactionView.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Test-only render helper (exports a fixture factory + a Dummy context component), not an HMR boundary.
+/* eslint-disable react-refresh/only-export-components */
+import { render, type RenderOptions } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { rootReducer } from 'store/rootReducer.ts';
+import type { AppState } from 'store/configureAppStore.ts';
+import { reactionContext } from 'features/reactions/reactions.context.ts';
+import { reactionEntityContext } from 'features/reactions/ReactionEntities/reactionEntity.context.ts';
+import { ordSetupToReactionSetup } from 'store/entities/reactions/reactionSetup/reactionSetup.converter.ts';
+import { ordConditionsToReaction } from 'store/entities/reactions/reactionConditions/reactionConditions.converter.ts';
+import { ordNotesToReaction } from 'store/entities/reactions/reactionNotes/reactionNotes.converters.ts';
+import { ordProvenanceToReaction } from 'store/entities/reactions/reactionProvenance/reactionProvenance.converters.ts';
+import type { AppReaction } from 'store/entities/reactions/reactions.types.ts';
+import type { ReactionsContext } from 'features/reactions/reactions.types.ts';
+import type { ReactionPathComponents } from 'common/types/reaction/reactionPathComponents.ts';
+import type { ReactElement, ReactNode } from 'react';
+
+const Dummy = () => null;
+
+/** A structurally-valid empty reaction, built from the same default converters the app uses. */
+export function emptyReactionData(): AppReaction {
+  return {
+    reactionId: '',
+    inputs: {},
+    outcomes: [],
+    identifiers: [],
+    setup: ordSetupToReactionSetup(null),
+    observations: [],
+    conditions: ordConditionsToReaction(null),
+    notes: ordNotesToReaction(null),
+    provenance: ordProvenanceToReaction(null),
+    workups: [],
+  } as unknown as AppReaction;
+}
+
+interface ReactionViewOptions extends Omit<RenderOptions, 'wrapper'> {
+  reactionId?: number | string;
+  pathComponents?: ReactionPathComponents;
+  reaction?: AppReaction;
+  isTemplate?: boolean;
+  isViewOnly?: boolean;
+}
+
+/**
+ * Renders a ReactionView-tree component with the reaction/entity contexts and a seeded reaction in
+ * the store, so components that read `reactionContext`/`reactionEntityContext` mount correctly.
+ */
+export function renderInReactionView(ui: ReactElement, options: ReactionViewOptions = {}) {
+  const {
+    reactionId = 1,
+    pathComponents = [],
+    reaction,
+    isTemplate = false,
+    isViewOnly = false,
+    ...renderOptions
+  } = options;
+  const store = configureStore({
+    reducer: rootReducer,
+    preloadedState: {
+      entities: {
+        reactions: { reactionsById: { [reactionId]: { id: reactionId, data: reaction ?? emptyReactionData() } } },
+      },
+    } as unknown as AppState,
+  });
+  const reactionCtxValue = {
+    reactionId,
+    isTemplate,
+    isViewOnly,
+    ViewDeleteButtonsComponent: Dummy,
+    ValueLabelComponent: Dummy,
+    ViewOnlyLabelComponent: Dummy,
+  } as unknown as ReactionsContext;
+  function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
+    return (
+      <Provider store={store}>
+        <MantineProvider>
+          <reactionContext.Provider value={reactionCtxValue}>
+            <reactionEntityContext.Provider value={{ reactionId, pathComponents }}>
+              {children}
+            </reactionEntityContext.Provider>
+          </reactionContext.Provider>
+        </MantineProvider>
+      </Provider>
+    );
+  }
+  return { store, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
+}


### PR DESCRIPTION
## Summary

Adds **`src/test/renderInReactionView.tsx`** — a render helper that wraps a component in the Redux store + Mantine + the `reactionContext`/`reactionEntityContext` and seeds a structurally-valid reaction (built from the same default converters the app uses). This unlocks the `ReactionView` tree, which the previous batch couldn't mount.

Mount-safety smoke tests for the components it recovers: `ReactionView` Inputs / Notes / Provenance / Workups / Outcomes, plus `ReactionEntityTitle`, `ComponentPreview`, `ReactionValueLabelWrapper`.

## Note on scope

This is intentionally a **smaller, foundational PR**: the bulk-generatable component surface is now covered (prior batches). The remaining ~50 `ReactionView`/entity-node components are thin wrappers that each need **bespoke fixtures** (specific reaction-data shapes, props, router context, or Ketcher/wasm mocks) — not bulk-generatable. The new helper is the groundwork for tackling them in focused follow-ups.

## Gates

- `vitest run`: 411/411 pass.
- `tsc -b`, `eslint`, `prettier --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `renderInReactionView`, a test render helper that wraps components in the Redux store, Mantine, `reactionContext`, and `reactionEntityContext` with a structurally-valid seeded reaction, enabling smoke tests for the `ReactionView` subtree.

- **`src/test/renderInReactionView.tsx`**: New helper that configures a fresh store from `rootReducer` with a minimal preloaded reaction state, seeds both reaction contexts, and exposes `emptyReactionData()` for callers who need a valid `AppReaction` fixture.
- **8 new `.test.tsx` files**: Mount-safety smoke tests for `ReactionView` sections (Inputs, Notes, Outcomes, Provenance, Workups) plus `ReactionEntityTitle`, `ComponentPreview`, and `ReactionValueLabelWrapper`; each casts props away with `as unknown as () => JSX.Element` to keep the fixture minimal.
- The helper intentionally only models the `DatasetReactionContext` branch (documented in an inline comment), deferring any template-variant tests to a dedicated follow-up helper.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no changes to production code; all 411 tests pass and the helper is scoped correctly to the dataset-reaction context branch.

The entire diff is new test files and a test render helper. No production logic is touched, the helper seeds the store using the same converters the app uses, and the discriminated-union constraint for template reactions is correctly documented and excluded.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/test/renderInReactionView.tsx | New render helper correctly scopes context to DatasetReactionContext, seeds the store via the same converters the app uses, and documents the template-variant limitation inline. |
| ui/src/features/reactions/ReactionView/Inputs/Inputs.test.tsx | Smoke test verifying Inputs mounts in the seeded reaction tree without throwing. |
| ui/src/features/reactions/ReactionView/Notes/Notes.test.tsx | Smoke test verifying Notes mounts in the seeded reaction tree without throwing. |
| ui/src/features/reactions/ReactionView/Outcomes/Outcomes.test.tsx | Smoke test verifying Outcomes mounts in the seeded reaction tree without throwing. |
| ui/src/features/reactions/ReactionView/Provenance/Provenance.test.tsx | Smoke test verifying Provenance mounts in the seeded reaction tree without throwing. |
| ui/src/features/reactions/ReactionView/Workups/Workups.test.tsx | Smoke test verifying Workups mounts in the seeded reaction tree without throwing. |
| ui/src/features/reactions/ReactionEntities/ReactionEntityTitle/ReactionEntityTitle.test.tsx | Smoke test for ReactionEntityTitle using the new renderInReactionView helper. |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/ComponentPreview/ComponentPreview.test.tsx | Smoke test for ComponentPreview using the new renderInReactionView helper. |
| ui/src/features/reactions/ReactionValueLabelWrapper.test.tsx | Smoke test for ReactionValueLabelWrapper using the new renderInReactionView helper. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[renderInReactionView helper] --> B[configureStore\nrootReducer + preloaded reaction]
    A --> C[emptyReactionData\nfrom real converters]
    C --> B
    B --> D[Provider\nRedux store]
    D --> E[MantineProvider]
    E --> F[reactionContext.Provider\nDatasetReactionContext]
    F --> G[reactionEntityContext.Provider\nreactionId + pathComponents]
    G --> H[Component under test]

    subgraph Smoke Tests
        I[Inputs.test]
        J[Notes.test]
        K[Outcomes.test]
        L[Provenance.test]
        M[Workups.test]
        N[ReactionEntityTitle.test]
        O[ComponentPreview.test]
        P[ReactionValueLabelWrapper.test]
    end

    H --> I & J & K & L & M & N & O & P
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): address Greptile feedback on t..."](https://github.com/open-reaction-database/ord-app/commit/0812be44e63898125f0f8b529a3429b71178c53b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35054473)</sub>

<!-- /greptile_comment -->