### PR TITLE
fix(ui): submit filtered values on Paste Chunk (#601, #592)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.paste.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.paste.test.tsx
@@ -35,7 +35,7 @@ vi.mock('./reactionEntityForm.utils.ts', async importActual => ({
   pasteReactionPart: (...args: Array<unknown>) => pasteReactionPartMock(...args),
 }));
 
-const addUpdateReactionFieldMock = vi.fn(() => ({ type: 'test/noop' }));
+const addUpdateReactionFieldMock = vi.fn((_arg: unknown) => ({ type: 'test/noop' }));
 vi.mock('store/entities/reactions/reactions.thunks.ts', async importActual => ({
   ...((await importActual()) as Record<string, unknown>),
   addUpdateReactionField: (arg: unknown) => addUpdateReactionFieldMock(arg),

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.paste.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.paste.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntityForm } from './ReactionEntityForm.tsx';
+import { reactionSidebarInfo } from 'features/reactions/ReactionEntities/sidebarInfo/sidebarInfo.models.ts';
+import { ReactionNodeEntity } from 'store/entities/reactions/reactions.types.ts';
+
+// The real form registry eagerly imports every node form, including the Ketcher/d3 structure
+// editor (a CJS/ESM break under vitest). Stub the registry to an empty form — the field nodes
+// aren't what's under test here; the paste-submit wiring is.
+vi.mock('features/reactions/ReactionEntities', () => ({
+  ReactionEntityBaseNode: () => null,
+  reactionEntityToForm: new Proxy({}, { get: () => [] }),
+}));
+
+// Drive the paste flow through a stubbed clipboard read and capture what the form dispatches.
+const pasteReactionPartMock = vi.fn();
+vi.mock('./reactionEntityForm.utils.ts', async importActual => ({
+  ...((await importActual()) as Record<string, unknown>),
+  pasteReactionPart: (...args: Array<unknown>) => pasteReactionPartMock(...args),
+}));
+
+const addUpdateReactionFieldMock = vi.fn(() => ({ type: 'test/noop' }));
+vi.mock('store/entities/reactions/reactions.thunks.ts', async importActual => ({
+  ...((await importActual()) as Record<string, unknown>),
+  addUpdateReactionField: (arg: unknown) => addUpdateReactionFieldMock(arg),
+}));
+
+const provenanceSidebarInfo = reactionSidebarInfo.find(info => info.entityName === ReactionNodeEntity.Provenance)!;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ReactionEntityForm — Paste Chunk filtering', () => {
+  it('submits the filtered chunk, dropping fields the sidebar excludes (e.g. recordModified)', async () => {
+    // A clipboard chunk that includes recordModified — which the Provenance sidebar filters out
+    // (it is edited in its own sidebar) — plus an ordinary field that must survive the paste.
+    pasteReactionPartMock.mockResolvedValue([
+      { doi: '10.0000/paste-test', recordModified: { time: { value: 'leaked' } } },
+      'clipboard-text',
+    ]);
+
+    renderInReactionView(
+      <ReactionEntityForm
+        isHidden={false}
+        reactionPathComponents={provenanceSidebarInfo.pathComponents}
+        sidebarInfo={provenanceSidebarInfo}
+        onFormClose={() => {}}
+        onSetFormDirty={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Paste Chunk' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Paste' }));
+
+    await waitFor(() => expect(addUpdateReactionFieldMock).toHaveBeenCalled());
+
+    const { newValue } = addUpdateReactionFieldMock.mock.calls[0][0] as { newValue: Record<string, unknown> };
+    // The bug submitted the raw chunk, leaking recordModified into the merge; the fix submits filtered values.
+    expect(newValue).not.toHaveProperty('recordModified');
+    expect(newValue).toHaveProperty('doi', '10.0000/paste-test');
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.tsx
@@ -110,9 +110,12 @@ export function ReactionEntityForm({
   const onPasteChunk = useCallback(
     (reactionPart: object) => {
       try {
+        // Submit the filtered values, not the raw clipboard chunk: fields the sidebar excludes
+        // (e.g. setup.automationCode, provenance.recordModified, product.measurements) are edited
+        // in their own sidebars and must not be merged in here, or they get duplicated/retained.
         const formValues = filterValues(reactionPart);
         form.setValues(formValues);
-        onSubmit(reactionPart);
+        onSubmit(formValues);
         setFormKey(crypto.randomUUID());
       } catch (_e: unknown) {
         showNotification({

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/reactionEntityForm.utils.test.ts
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/reactionEntityForm.utils.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { copyReactionPart, pasteReactionPart } from './reactionEntityForm.utils.ts';
+import { ReactionNodeEntity } from 'store/entities/reactions/reactions.types.ts';
+import { ordNotesToReaction } from 'store/entities/reactions/reactionNotes/reactionNotes.converters.ts';
+
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
+
+/** Backs navigator.clipboard with an in-memory string so write/read round-trip in tests. */
+function stubClipboard() {
+  let stored = '';
+  const writeText = vi.fn((text: string) => {
+    stored = text;
+    return Promise.resolve();
+  });
+  const readText = vi.fn(() => Promise.resolve(stored));
+  vi.stubGlobal('navigator', { clipboard: { writeText, readText } });
+  return { writeText, readText, setStored: (text: string) => (stored = text) };
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('copyReactionPart', () => {
+  it('writes a JSON envelope tagging the entity type to the clipboard', async () => {
+    const { writeText } = stubClipboard();
+    await copyReactionPart(ReactionNodeEntity.Notes, ordNotesToReaction(null));
+    expect(writeText).toHaveBeenCalledOnce();
+    const envelope = JSON.parse(writeText.mock.calls[0][0]);
+    expect(envelope.type).toBe(ReactionNodeEntity.Notes);
+    expect(envelope).toHaveProperty('value');
+  });
+
+  it('swallows clipboard write failures instead of throwing', async () => {
+    vi.stubGlobal('navigator', { clipboard: { writeText: vi.fn(() => Promise.reject(new Error('denied'))) } });
+    await expect(copyReactionPart(ReactionNodeEntity.Notes, ordNotesToReaction(null))).resolves.toBeUndefined();
+  });
+});
+
+describe('pasteReactionPart', () => {
+  it('round-trips a copied chunk back into a reaction part', async () => {
+    stubClipboard();
+    await copyReactionPart(ReactionNodeEntity.Notes, ordNotesToReaction(null));
+    const [result, text] = await pasteReactionPart(ReactionNodeEntity.Notes);
+    expect(result).not.toBeNull();
+    expect(text).not.toBe('');
+    // id/name are stripped by the paste so they don't overwrite the target entity's identity.
+    expect(result).not.toHaveProperty('id');
+    expect(result).not.toHaveProperty('name');
+  });
+
+  it('rejects a chunk whose entity type does not match the target field', async () => {
+    const clipboard = stubClipboard();
+    clipboard.setStored(JSON.stringify({ type: ReactionNodeEntity.Conditions, value: {} }));
+    expect(await pasteReactionPart(ReactionNodeEntity.Notes)).toEqual([null, '']);
+  });
+
+  it('returns a null result for invalid clipboard JSON', async () => {
+    const clipboard = stubClipboard();
+    clipboard.setStored('not valid json');
+    expect(await pasteReactionPart(ReactionNodeEntity.Notes)).toEqual([null, '']);
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/reactionEntityForm.utils.test.ts
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/reactionEntityForm.utils.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { copyReactionPart, pasteReactionPart } from './reactionEntityForm.utils.ts';
 import { ReactionNodeEntity } from 'store/entities/reactions/reactions.types.ts';
 import { ordNotesToReaction } from 'store/entities/reactions/reactionNotes/reactionNotes.converters.ts';
@@ -32,7 +32,7 @@ function stubClipboard() {
   return { writeText, readText, setStored: (text: string) => (stored = text) };
 }
 
-beforeEach(() => {
+afterEach(() => {
   vi.unstubAllGlobals();
 });
 

--- a/ui/src/store/entities/reactions/reactions.utils.test.ts
+++ b/ui/src/store/entities/reactions/reactions.utils.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   convertObjectToNullIfEmpty,
+  deepMergeWithArrayMerge,
   generateDeepPartialReactionByPath,
   getDeepReactionPart,
   removeDeepReactionPart,
@@ -87,5 +88,33 @@ describe('convertObjectToNullIfEmpty', () => {
   it('keeps a 0-valued key that is not declared as an enum key', () => {
     const object = { type: 0 };
     expect(convertObjectToNullIfEmpty(object)).toBe(object);
+  });
+});
+
+describe('deepMergeWithArrayMerge', () => {
+  it('deep-merges nested objects, keeping keys from both sides', () => {
+    expect(deepMergeWithArrayMerge({ a: { x: 1 }, b: 1 }, { a: { y: 2 } })).toEqual({ a: { x: 1, y: 2 }, b: 1 });
+  });
+
+  it('merges arrays element-wise by index rather than concatenating', () => {
+    expect(deepMergeWithArrayMerge([{ a: 1 }, { a: 2 }], [{ b: 9 }])).toEqual([{ a: 1, b: 9 }, { a: 2 }]);
+  });
+
+  it('replaces a primitive array element at the same index', () => {
+    expect(deepMergeWithArrayMerge([1, 2, 3], [9])).toEqual([9, 2, 3]);
+  });
+
+  it('skips falsy source items, preserving the target element at that index', () => {
+    expect(deepMergeWithArrayMerge([{ a: 1 }, { a: 2 }], [null, { b: 9 }])).toEqual([{ a: 1 }, { a: 2, b: 9 }]);
+  });
+
+  it('appends a new element when the target has no value at that index', () => {
+    expect(deepMergeWithArrayMerge([], [{ x: 1 }])).toEqual([{ x: 1 }]);
+  });
+
+  it('does not mutate the target operand', () => {
+    const target = { a: { x: 1 }, list: [{ k: 1 }] };
+    deepMergeWithArrayMerge(target, { a: { y: 2 }, list: [{ j: 2 }] });
+    expect(target).toEqual({ a: { x: 1 }, list: [{ k: 1 }] });
   });
 });


### PR DESCRIPTION
## Summary

The **Paste Chunk** flow had a wiring bug: it computed the *filtered* clipboard value (dropping fields that belong to other sidebars), set the form to those filtered values — but then **submitted the unfiltered chunk**. The excluded fields were merged back into the reaction, which is the root cause of two open bugs.

In [`ReactionEntityForm.tsx`](https://github.com/open-reaction-database/ord-app/blob/main/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.tsx) `onPasteChunk`:

```diff
 const formValues = filterValues(reactionPart);
 form.setValues(formValues);
-onSubmit(reactionPart);   // ❌ submits the raw clipboard chunk
+onSubmit(formValues);     // ✅ submits what the form is actually set to
```

Each sidebar's `filterInitialValues` deliberately strips fields edited in their own sidebars (`setup.automationCode`, `provenance.recordModified`, `product.measurements`/`identifiers`/…). Submitting the raw chunk re-merged them:

- **#601** — automation codes duplicated: the excluded `automationCode` array was re-merged onto the existing one via the element-wise array merge.
- **#592** — measurements / record-modifications retained even when excluded.

## Tests

This previously-untested layer now has coverage that locks the regression:

- **`ReactionEntityForm.paste.test.tsx`** — drives the Paste Chunk flow (stubbed clipboard) and asserts the dispatched `newValue` drops the excluded field (`recordModified`) while preserving included fields. Verified it **fails** against the old `onSubmit(reactionPart)` and **passes** with the fix.
- **`reactionEntityForm.utils.test.ts`** — `copyReactionPart`/`pasteReactionPart` clipboard round-trip, entity-type-mismatch and invalid-JSON rejection, and id/name stripping.
- **`reactions.utils.test.ts`** — `deepMergeWithArrayMerge`: element-wise array merge, primitive replacement, falsy-source skipping, no target mutation (the merge semantics behind the duplication).

Full vitest suite: **423 passing** (was 411). `tsc`, eslint, prettier clean.

## Out of scope

**#589** (structure not deleted on paste) is a *separate* problem — the reducer's `deepMergeWithArrayMerge` only adds/merges and never removes, so an absent structure can't clear an existing one. That's a merge-semantics change with broader blast radius and is intentionally **not** addressed here.

## Verification note

Per the plan's DoD for FE bugs, this is held for review rather than auto-merged — a before/after on the live Paste Chunk UI (automation codes / measurements no longer duplicated) would confirm the user-visible behavior; the regression tests cover the dispatch-level contract.

Closes #601
Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a wiring bug in the Paste Chunk flow where the raw (unfiltered) clipboard chunk was submitted to the store instead of the sidebar-filtered values, causing excluded fields (`automationCode`, `recordModified`, `measurements`) to be re-merged and duplicated (#601, #592).

- **`ReactionEntityForm.tsx`**: Single-line fix — `onSubmit(reactionPart)` → `onSubmit(formValues)` — with a comment explaining the filtering contract.
- **`ReactionEntityForm.paste.test.tsx`**: New integration test that stubs the clipboard and Redux dispatch, confirming the dispatched `newValue` drops `recordModified` while preserving included fields.
- **`reactionEntityForm.utils.test.ts` / `reactions.utils.test.ts`**: New unit tests covering the clipboard round-trip, entity-type mismatch rejection, invalid-JSON rejection, and `deepMergeWithArrayMerge` semantics.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-targeted correction to a clearly identified wiring bug, backed by a regression test that fails against the old code and passes with the fix.

The fix is a single-line swap of the argument passed to `onSubmit` inside `onPasteChunk`. The corrected code path is consistent with how `filterValues` and `form.setValues` are already used immediately above it. The new test directly exercises the dispatch contract and would catch a revert. No existing behavior outside the paste flow is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.tsx | One-line fix: `onSubmit(reactionPart)` → `onSubmit(formValues)` so the paste path submits only sidebar-filtered values, with a clear explanatory comment. |
| ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.paste.test.tsx | New integration-level test that stubs the clipboard and dispatch, asserts filtered submit drops excluded fields (recordModified) while preserving included ones (doi). |
| ui/src/features/reactions/ReactionEntities/ReactionEntityForm/reactionEntityForm.utils.test.ts | New unit tests for clipboard copy/paste round-trip, entity-type mismatch rejection, invalid-JSON rejection, and id/name stripping; uses afterEach for global stub teardown. |
| ui/src/store/entities/reactions/reactions.utils.test.ts | Adds deepMergeWithArrayMerge tests covering element-wise merge, primitive replacement, falsy-source skipping, new-element appending, and no-mutation guarantee. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["test(ui): tear down the clipboard stub i..."](https://github.com/open-reaction-database/ord-app/commit/f77be2c96fdb21486046296b274826fcd42b2228) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35057594)</sub>

<!-- /greptile_comment -->