### PR TITLE
test(ui): async-thunk tests (datasets/reactions/groups) + S6582 optional-chain cleanup

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/useReactionEntityLabel.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/useReactionEntityLabel.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { isValidElement } from 'react';
+import { useReactionEntityLabel } from './useReactionEntityLabel.tsx';
+import type { ReactionFormStandaloneField } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const field = (label: unknown): ReactionFormStandaloneField => ({ label }) as ReactionFormStandaloneField;
+
+describe('useReactionEntityLabel', () => {
+  it('returns null when no config is provided', () => {
+    expect(useReactionEntityLabel(undefined)).toBeNull();
+  });
+
+  it('returns null when the config has no label', () => {
+    expect(useReactionEntityLabel(field(undefined))).toBeNull();
+  });
+
+  it('renders a label element when a label is present', () => {
+    const result = useReactionEntityLabel(field('Yield'));
+    expect(isValidElement(result)).toBe(true);
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/useReactionEntityLabel.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/useReactionEntityLabel.tsx
@@ -18,7 +18,7 @@ import type { ReactNode } from 'react';
 import { ReactionEntityLabel } from './ReactionEntityLabel/ReactionEntityLabel.tsx';
 
 export function useReactionEntityLabel(wrapperConfig?: ReactionFormStandaloneField): ReactNode {
-  if (!wrapperConfig || !wrapperConfig.label) {
+  if (!wrapperConfig?.label) {
     return null;
   }
   return <ReactionEntityLabel wrapperConfig={wrapperConfig} />;

--- a/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItemHeader.tsx
+++ b/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItemHeader.tsx
@@ -53,7 +53,7 @@ export function OutcomeListItemHeader({ outcome, pathComponents }: Readonly<Outc
           amount={outcome.products.length}
         />
       </Flex>
-      {outcome.reactionTime && outcome.reactionTime.value && (
+      {outcome.reactionTime?.value && (
         <Flex
           align="center"
           gap="xs"
@@ -63,7 +63,7 @@ export function OutcomeListItemHeader({ outcome, pathComponents }: Readonly<Outc
           <Text className={classes.shortInfoText}>{renderValuePrecisionUnit(outcome.reactionTime)}</Text>
         </Flex>
       )}
-      {outcome.conversion && outcome.conversion.value && (
+      {outcome.conversion?.value && (
         <Flex
           align="center"
           gap="xs"

--- a/ui/src/store/entities/datasets/datasets.thunks.test.ts
+++ b/ui/src/store/entities/datasets/datasets.thunks.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { configureStore, type UnknownAction } from '@reduxjs/toolkit';
+import { rootReducer } from 'store/rootReducer.ts';
+import axiosInstance from 'store/axiosInstance.ts';
+import { navigate } from 'wouter/use-browser-location';
+import {
+  createEmptyDataset,
+  getDataset,
+  getDatasetGroups,
+  getDatasetsPage,
+  removeDataset,
+  shareDatasetWithGroup,
+  unshareDatasetWithGroup,
+} from './datasets.thunks.ts';
+import {
+  createNewDatasetActions,
+  getDatasetActions,
+  getDatasetGroupsActions,
+  getDatasetPageActions,
+  removeDatasetActions,
+  shareDatasetWithGroupActions,
+  unshareDatasetWithGroupActions,
+} from './datasets.actions.ts';
+
+vi.mock('store/axiosInstance.ts', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('wouter/use-browser-location', () => ({ navigate: vi.fn() }));
+
+const axiosMock = vi.mocked(axiosInstance);
+
+/** A store that records every dispatched action so follow-up refetches can be asserted by type. */
+function makeStore() {
+  const actions: Array<UnknownAction> = [];
+  const recorder = () => (next: (action: unknown) => unknown) => (action: unknown) => {
+    actions.push(action as UnknownAction);
+    return next(action);
+  };
+  const store = configureStore({
+    reducer: rootReducer,
+    middleware: getDefault => getDefault().concat(recorder),
+  });
+  return { store, types: () => actions.map(action => action.type) };
+}
+
+const dataset = { id: 1, name: 'd1', description: '', groups: [] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  axiosMock.get.mockResolvedValue({ data: dataset });
+  axiosMock.post.mockResolvedValue({ data: dataset });
+  axiosMock.patch.mockResolvedValue({ data: dataset });
+  axiosMock.delete.mockResolvedValue({ data: {} });
+});
+
+describe('getDataset', () => {
+  it('fetches the dataset and dispatches success', async () => {
+    const { store, types } = makeStore();
+    await store.dispatch(getDataset(1) as unknown as UnknownAction);
+    expect(axiosMock.get).toHaveBeenCalledWith('/datasets/1');
+    expect(types()).toContain(getDatasetActions.success.type);
+  });
+
+  it('dispatches failure when the request rejects', async () => {
+    axiosMock.get.mockRejectedValueOnce(new Error('boom'));
+    const { store, types } = makeStore();
+    await store.dispatch(getDataset(1) as unknown as UnknownAction);
+    expect(types()).toContain(getDatasetActions.failure.type);
+  });
+});
+
+describe('getDatasetsPage', () => {
+  it('requests the unscoped datasets list when no active group is set', async () => {
+    axiosMock.get.mockResolvedValueOnce({ data: { items: [], page: 1, size: 10, total: 0, pages: 0 } });
+    const { store, types } = makeStore();
+    await store.dispatch(getDatasetsPage() as unknown as UnknownAction);
+    expect(axiosMock.get).toHaveBeenCalledWith('/datasets', expect.objectContaining({ params: expect.any(Object) }));
+    expect(types()).toContain(getDatasetPageActions.success.type);
+  });
+});
+
+describe('createEmptyDataset', () => {
+  it('creates the dataset and navigates to it', async () => {
+    const { store, types } = makeStore();
+    await store.dispatch(createEmptyDataset({ groupId: 7, name: 'n', description: '' }) as unknown as UnknownAction);
+    expect(axiosMock.post).toHaveBeenCalledWith('/groups/7/datasets', { name: 'n', description: '' });
+    expect(types()).toContain(createNewDatasetActions.success.type);
+    expect(navigate).toHaveBeenCalledWith('/datasets/1');
+  });
+});
+
+describe('removeDataset', () => {
+  it('deletes the dataset and navigates home', async () => {
+    const { store, types } = makeStore();
+    await store.dispatch(removeDataset(1) as unknown as UnknownAction);
+    expect(axiosMock.delete).toHaveBeenCalledWith('/datasets/1');
+    expect(types()).toContain(removeDatasetActions.success.type);
+    expect(navigate).toHaveBeenCalledWith('/');
+  });
+});
+
+describe('getDatasetGroups', () => {
+  it('fetches the groups a dataset is shared with', async () => {
+    axiosMock.get.mockResolvedValueOnce({ data: [] });
+    const { store, types } = makeStore();
+    await store.dispatch(getDatasetGroups(1) as unknown as UnknownAction);
+    expect(axiosMock.get).toHaveBeenCalledWith('/datasets/1/groups');
+    expect(types()).toContain(getDatasetGroupsActions.success.type);
+  });
+});
+
+describe('shareDatasetWithGroup', () => {
+  it('shares then refetches the dataset and its groups', async () => {
+    axiosMock.get.mockResolvedValue({ data: [] });
+    const { store, types } = makeStore();
+    await store.dispatch(
+      shareDatasetWithGroup({ groupId: 2, datasetId: 1, primaryGroupId: 9 }) as unknown as UnknownAction,
+    );
+    expect(axiosMock.post).toHaveBeenCalledWith('/groups/9/datasets/1/share', { secondary_group_id: 2 });
+    // The follow-up refetch is the cache-invalidation contract: success then both getters re-run.
+    expect(types()).toEqual(
+      expect.arrayContaining([
+        shareDatasetWithGroupActions.success.type,
+        getDatasetActions.request.type,
+        getDatasetGroupsActions.request.type,
+      ]),
+    );
+  });
+});
+
+describe('unshareDatasetWithGroup', () => {
+  it('unshares then refetches the dataset', async () => {
+    const { store, types } = makeStore();
+    await store.dispatch(
+      unshareDatasetWithGroup({ groupId: 2, datasetId: 1, primaryGroupId: 9 }) as unknown as UnknownAction,
+    );
+    expect(axiosMock.post).toHaveBeenCalledWith('/groups/9/datasets/1/unshare', { secondary_group_id: 2 });
+    expect(types()).toEqual(
+      expect.arrayContaining([unshareDatasetWithGroupActions.success.type, getDatasetActions.request.type]),
+    );
+  });
+});

--- a/ui/src/store/entities/datasets/datasets.thunks.test.ts
+++ b/ui/src/store/entities/datasets/datasets.thunks.test.ts
@@ -42,7 +42,9 @@ vi.mock('store/axiosInstance.ts', () => ({
 }));
 vi.mock('wouter/use-browser-location', () => ({ navigate: vi.fn() }));
 
-const axiosMock = vi.mocked(axiosInstance);
+// axios methods are overloaded, so vi.mocked() doesn't surface the mock helpers under tsc;
+// cast to a plain record of mock fns instead.
+const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
 
 /** A store that records every dispatched action so follow-up refetches can be asserted by type. */
 function makeStore() {
@@ -88,7 +90,7 @@ describe('getDatasetsPage', () => {
   it('requests the unscoped datasets list when no active group is set', async () => {
     axiosMock.get.mockResolvedValueOnce({ data: { items: [], page: 1, size: 10, total: 0, pages: 0 } });
     const { store, types } = makeStore();
-    await store.dispatch(getDatasetsPage() as unknown as UnknownAction);
+    await store.dispatch(getDatasetsPage({ page: 1, size: 10 }) as unknown as UnknownAction);
     expect(axiosMock.get).toHaveBeenCalledWith('/datasets', expect.objectContaining({ params: expect.any(Object) }));
     expect(types()).toContain(getDatasetPageActions.success.type);
   });

--- a/ui/src/store/entities/groups/groups.thunks.test.ts
+++ b/ui/src/store/entities/groups/groups.thunks.test.ts
@@ -34,7 +34,9 @@ vi.mock('store/axiosInstance.ts', () => ({
 }));
 vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
 
-const axiosMock = vi.mocked(axiosInstance);
+// axios methods are overloaded, so vi.mocked() doesn't surface the mock helpers under tsc;
+// cast to a plain record of mock fns instead.
+const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
 
 function makeStore() {
   const actions: Array<UnknownAction> = [];
@@ -81,8 +83,8 @@ describe('updateGroupMembers', () => {
   it('patches the member, refetches the list, and dispatches success', async () => {
     const { store, types } = makeStore();
     store.dispatch(setEditingGroupIdAction(3));
-    await store.dispatch(updateGroupMembers({ userId: 8, role: 'EDITOR' }) as unknown as UnknownAction);
-    expect(axiosMock.patch).toHaveBeenCalledWith('/groups/3/members', { userId: 8, role: 'EDITOR' });
+    await store.dispatch(updateGroupMembers({ user_id: 8, role: USER_ROLES.EDITOR }) as unknown as UnknownAction);
+    expect(axiosMock.patch).toHaveBeenCalledWith('/groups/3/members', { user_id: 8, role: USER_ROLES.EDITOR });
     expect(types()).toEqual(
       expect.arrayContaining([getGroupListActions.request.type, updateGroupMembersActions.success.type]),
     );
@@ -121,9 +123,9 @@ describe('addGroupMember', () => {
     const { store, actions } = makeStore();
     store.dispatch(setEditingGroupIdAction(3));
     await store.dispatch(addGroupMember('ann@example.com') as unknown as UnknownAction);
-    const failure = actions.find(action => action.type === addGroupMemberActions.failure.type) as {
-      payload: string;
-    };
+    const failure = actions.find(action => action.type === addGroupMemberActions.failure.type) as unknown as
+      | { payload: string }
+      | undefined;
     expect(failure?.payload).toBe(expected);
   });
 });

--- a/ui/src/store/entities/groups/groups.thunks.test.ts
+++ b/ui/src/store/entities/groups/groups.thunks.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { configureStore, type UnknownAction } from '@reduxjs/toolkit';
+import { rootReducer } from 'store/rootReducer.ts';
+import axiosInstance from 'store/axiosInstance.ts';
+import { addGroupMember, createGroup, getGroupList, removeGroupMembers, updateGroupMembers } from './groups.thunks.ts';
+import {
+  addGroupMemberActions,
+  createGroupActions,
+  getGroupListActions,
+  removeGroupMembersActions,
+  updateGroupMembersActions,
+} from './groups.actions.ts';
+import { setEditingGroupIdAction } from 'store/features/groups/groups.actions.ts';
+import { ADD_MEMBER_ERROR } from './groups.types.ts';
+import { USER_ROLES } from 'common/types';
+
+vi.mock('store/axiosInstance.ts', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
+
+const axiosMock = vi.mocked(axiosInstance);
+
+function makeStore() {
+  const actions: Array<UnknownAction> = [];
+  const recorder = () => (next: (action: unknown) => unknown) => (action: unknown) => {
+    actions.push(action as UnknownAction);
+    return next(action);
+  };
+  const store = configureStore({ reducer: rootReducer, middleware: getDefault => getDefault().concat(recorder) });
+  return { store, actions, types: () => actions.map(action => action.type) };
+}
+
+/** Rejects the way axios does so the thunk's `isAxiosError` status branches are exercised. */
+const axiosError = (status: number) => ({ isAxiosError: true, response: { status } });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  axiosMock.get.mockResolvedValue({ data: [] });
+  axiosMock.post.mockResolvedValue({ data: { user: { name: 'Ann' } } });
+  axiosMock.patch.mockResolvedValue({ data: { user: { name: 'Ann' } } });
+});
+
+describe('getGroupList', () => {
+  it('fetches the group list and dispatches success', async () => {
+    const { store, types } = makeStore();
+    await store.dispatch(getGroupList() as unknown as UnknownAction);
+    expect(axiosMock.get).toHaveBeenCalledWith('/groups');
+    expect(types()).toContain(getGroupListActions.success.type);
+  });
+});
+
+describe('createGroup', () => {
+  it('creates the group then refetches the list', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: { id: 5 } });
+    const { store, types } = makeStore();
+    await store.dispatch(createGroup('My group') as unknown as UnknownAction);
+    expect(axiosMock.post).toHaveBeenCalledWith('/groups', { name: 'My group' });
+    expect(types()).toEqual(
+      expect.arrayContaining([getGroupListActions.request.type, createGroupActions.success.type]),
+    );
+  });
+});
+
+describe('updateGroupMembers', () => {
+  it('patches the member, refetches the list, and dispatches success', async () => {
+    const { store, types } = makeStore();
+    store.dispatch(setEditingGroupIdAction(3));
+    await store.dispatch(updateGroupMembers({ userId: 8, role: 'EDITOR' }) as unknown as UnknownAction);
+    expect(axiosMock.patch).toHaveBeenCalledWith('/groups/3/members', { userId: 8, role: 'EDITOR' });
+    expect(types()).toEqual(
+      expect.arrayContaining([getGroupListActions.request.type, updateGroupMembersActions.success.type]),
+    );
+  });
+});
+
+describe('removeGroupMembers', () => {
+  it('posts the removal scoped to the editing group and dispatches success', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: {} });
+    const { store, types } = makeStore();
+    store.dispatch(setEditingGroupIdAction(3));
+    await store.dispatch(removeGroupMembers([8]) as unknown as UnknownAction);
+    expect(axiosMock.post).toHaveBeenCalledWith('/groups/3/members/remove', [8]);
+    expect(types()).toContain(removeGroupMembersActions.success.type);
+  });
+});
+
+describe('addGroupMember', () => {
+  it('adds the member and dispatches success on the happy path', async () => {
+    const { store, actions } = makeStore();
+    store.dispatch(setEditingGroupIdAction(3));
+    await store.dispatch(addGroupMember('ann@example.com') as unknown as UnknownAction);
+    expect(axiosMock.post).toHaveBeenCalledWith('/groups/3/members', {
+      identity: 'ann@example.com',
+      role: USER_ROLES.VIEWER,
+    });
+    expect(actions.some(action => action.type === addGroupMemberActions.success.type)).toBe(true);
+  });
+
+  it.each([
+    [409, ADD_MEMBER_ERROR.ALREADY_MEMBER],
+    [404, ADD_MEMBER_ERROR.NOT_FOUND],
+    [500, ADD_MEMBER_ERROR.GENERIC],
+  ])('maps HTTP %i to the %s failure', async (status, expected) => {
+    axiosMock.post.mockRejectedValueOnce(axiosError(status));
+    const { store, actions } = makeStore();
+    store.dispatch(setEditingGroupIdAction(3));
+    await store.dispatch(addGroupMember('ann@example.com') as unknown as UnknownAction);
+    const failure = actions.find(action => action.type === addGroupMemberActions.failure.type) as {
+      payload: string;
+    };
+    expect(failure?.payload).toBe(expected);
+  });
+});

--- a/ui/src/store/entities/reactions/reactions.thunks.test.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { configureStore, type UnknownAction } from '@reduxjs/toolkit';
+import { rootReducer } from 'store/rootReducer.ts';
+import axiosInstance from 'store/axiosInstance.ts';
+import { navigate } from 'wouter/use-browser-location';
+import { createEmptyReaction, getReactionsList, getReactionsPage, removeReaction } from './reactions.thunks.ts';
+import {
+  createEmptyReactionActions,
+  getReactionPageActions,
+  getReactionsListActions,
+  removeReactionActions,
+} from './reactions.actions.ts';
+
+vi.mock('store/axiosInstance.ts', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('wouter/use-browser-location', () => ({ navigate: vi.fn() }));
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
+// Reaction responses carry base64-encoded protobufs; stub the parse so tests need no real binpb,
+// and keep the rest of the module (merge helpers used by the reducer) intact.
+vi.mock('./reactions.utils.ts', async importActual => ({
+  ...((await importActual()) as Record<string, unknown>),
+  parseReaction: () => ({ id: 99, pb_reaction_id: 'pb-99', data: {}, previews: {}, validation: null }),
+  parseReactionList: (pages: unknown) => pages,
+}));
+vi.mock('./reactions.converters.ts', async importActual => ({
+  ...((await importActual()) as Record<string, unknown>),
+  linkReactionEntities: (data: unknown) => data,
+}));
+
+const axiosMock = vi.mocked(axiosInstance);
+const emptyPage = { items: [], page: 1, size: 10, total: 0, pages: 0 };
+
+function makeStore() {
+  const actions: Array<UnknownAction> = [];
+  const recorder = () => (next: (action: unknown) => unknown) => (action: unknown) => {
+    actions.push(action as UnknownAction);
+    return next(action);
+  };
+  const store = configureStore({ reducer: rootReducer, middleware: getDefault => getDefault().concat(recorder) });
+  return { store, types: () => actions.map(action => action.type) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  axiosMock.get.mockResolvedValue({ data: emptyPage });
+  axiosMock.post.mockResolvedValue({ data: {} });
+  axiosMock.delete.mockResolvedValue({ data: {} });
+});
+
+describe('getReactionsList', () => {
+  it('fetches the dataset reactions and dispatches success', async () => {
+    const { store, types } = makeStore();
+    await store.dispatch(getReactionsList(5) as unknown as UnknownAction);
+    expect(axiosMock.get).toHaveBeenCalledWith(
+      '/datasets/5/reactions',
+      expect.objectContaining({ params: expect.any(Object) }),
+    );
+    expect(types()).toContain(getReactionsListActions.success.type);
+  });
+
+  it('dispatches failure when the request rejects', async () => {
+    axiosMock.get.mockRejectedValueOnce(new Error('boom'));
+    const { store, types } = makeStore();
+    await store.dispatch(getReactionsList(5) as unknown as UnknownAction);
+    expect(types()).toContain(getReactionsListActions.failure.type);
+  });
+});
+
+describe('getReactionsPage', () => {
+  it('fetches the active dataset using the current pagination', async () => {
+    const { store, types } = makeStore();
+    // Seed the active dataset id (set by a prior list request) so the page URL is scoped.
+    store.dispatch(getReactionsListActions.request(5));
+    await store.dispatch(getReactionsPage({ page: 2 }) as unknown as UnknownAction);
+    expect(axiosMock.get).toHaveBeenCalledWith(
+      '/datasets/5/reactions',
+      expect.objectContaining({ params: expect.any(Object) }),
+    );
+    expect(types()).toContain(getReactionPageActions.success.type);
+  });
+});
+
+describe('removeReaction', () => {
+  it('deletes the reaction, dispatches success, and navigates back to the dataset', async () => {
+    const { store, types } = makeStore();
+    store.dispatch(getReactionsListActions.request(5));
+    await store.dispatch(removeReaction(42) as unknown as UnknownAction);
+    expect(axiosMock.delete).toHaveBeenCalledWith('/datasets/5/reactions/42');
+    expect(types()).toContain(removeReactionActions.success.type);
+    expect(navigate).toHaveBeenCalledWith('/datasets/5');
+    // Characterization: removal updates the store optimistically (reducer prunes order + total) and
+    // does NOT trigger a list refetch — no getReactionPage/List request follows the success.
+    expect(types()).not.toContain(getReactionPageActions.request.type);
+  });
+});
+
+describe('createEmptyReaction', () => {
+  it('creates a reaction and navigates to it without refetching the list', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: { binpb: '', molblocks: {}, validation: null } });
+    const { store, types } = makeStore();
+    store.dispatch(getReactionsListActions.request(5));
+    await store.dispatch(createEmptyReaction() as unknown as UnknownAction);
+    expect(axiosMock.post).toHaveBeenCalledWith('/datasets/5/reactions/from-scratch');
+    expect(types()).toContain(createEmptyReactionActions.success.type);
+    expect(navigate).toHaveBeenCalledWith('/datasets/5/reactions/99');
+    expect(types()).not.toContain(getReactionPageActions.request.type);
+  });
+});

--- a/ui/src/store/entities/reactions/reactions.thunks.test.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.test.ts
@@ -43,7 +43,9 @@ vi.mock('./reactions.converters.ts', async importActual => ({
   linkReactionEntities: (data: unknown) => data,
 }));
 
-const axiosMock = vi.mocked(axiosInstance);
+// axios methods are overloaded, so vi.mocked() doesn't surface the mock helpers under tsc;
+// cast to a plain record of mock fns instead.
+const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
 const emptyPage = { items: [], page: 1, size: 10, total: 0, pages: 0 };
 
 function makeStore() {


### PR DESCRIPTION
## Summary

Two coherent store/UI quality changes, bundled to conserve review:

### 1. Async-thunk test coverage (mocked axios)

First **thunk-level** coverage for the Redux store. A small reusable harness — mocked `axiosInstance` + `navigate` + `showNotification`, and a real store with an action-recording middleware — drives each thunk and asserts the HTTP call, dispatched lifecycle actions, follow-up refetches, and navigation. This backfills the biggest remaining coverage gap (thunks were untested) and *characterizes* current mutation/refetch behavior as a baseline for any future stale-data work.

- **`datasets.thunks.test.ts`** — `getDataset` (+ failure), `getDatasetsPage`, `createEmptyDataset`/`removeDataset` (+ navigate), `getDatasetGroups`, and the **share/unshare refetch contract**.
- **`groups.thunks.test.ts`** — `getGroupList`, `createGroup`/`updateGroupMembers` (+ list refetch), `removeGroupMembers`, and `addGroupMember` incl. the **#659 status mapping** (`409 → ALREADY_MEMBER`, `404 → NOT_FOUND`, else `→ GENERIC`).
- **`reactions.thunks.test.ts`** — `getReactionsList`/`getReactionsPage` (+ failure), `removeReaction` (delete + navigate), `createEmptyReaction` (parse stubbed, no real protobuf needed); documents that remove/create update the store optimistically and don't refetch the list.

`parseReaction`/`parseReactionList`/`linkReactionEntities` are stubbed via partial mocks (the reducer's merge helpers stay intact). Enumeration's `finishEnumeration` is left as a follow-up (needs heavy progress-state seeding).

### 2. SonarCloud S6582 — optional chaining (3)

Semantics-preserving optional chains clearing the three `typescript:S6582` issues:
- `OutcomeListItemHeader`: `outcome.reactionTime?.value` / `outcome.conversion?.value`
- `useReactionEntityLabel`: `!wrapperConfig?.label` (+ a unit test for its three branches)

**On the rest of the §10 logic tail (intentionally not touched):** the five `S2486` "handle this exception" hits all *do* handle their condition (dispatch failure / show a notification / return a fallback) and merely don't inspect the error object — the textbook false-positive. The eleven `S7735` negated-condition flips are MINOR readability-only with branch-swap risk and no behavior change. Both read as won't-fix (mark in #671) rather than churn working code; neither blocks the gate (already green).

Full vitest suite: **435 passing** (was 411). `tsc`, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers two orthogonal improvements: first-ever thunk-level test coverage for the Redux store (datasets, groups, and reactions), and three SonarCloud S6582 optional-chain cleanups in production code.

- **Thunk tests** use a shared harness (mocked `axiosInstance`, action-recorder middleware, real store) to verify HTTP calls, action lifecycle types, navigate side-effects, and refetch contracts. Protobuf-dependent paths are cleanly isolated via partial mocks of `reactions.utils.ts` and `reactions.converters.ts`.
- **S6582 fixes** replace double-guard conditions (`x && x.prop`) with optional chains (`x?.prop`) in `OutcomeListItemHeader` and `useReactionEntityLabel`; semantics are identical in all cases.
- A matching unit test is added for `useReactionEntityLabel` covering the three branches (undefined config, config with no label, config with label).

<h3>Confidence Score: 5/5</h3>

Safe to merge — all production code changes are semantics-preserving optional-chain rewrites with no behavior difference.

The production changes are mechanical refactors verified by the existing test suite and the new tests added in this PR. The three optional-chain substitutions are equivalent to the original double-guard conditions in all cases. New test files add meaningful coverage without altering any runtime behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/useReactionEntityLabel.tsx | S6582 optional-chain fix: `!wrapperConfig || !wrapperConfig.label` → `!wrapperConfig?.label`; semantically identical, no behavior change. |
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/useReactionEntityLabel.test.tsx | New unit test covering the three branches (undefined config, config with no label, config with label). Calls the function directly without `renderHook`; safe today because the implementation holds no React hook calls internally. |
| ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItemHeader.tsx | S6582 optional-chain fix for `reactionTime` and `conversion` guards; semantically equivalent to the prior double-check pattern. |
| ui/src/store/entities/datasets/datasets.thunks.test.ts | Comprehensive thunk-level tests for all dataset operations; action-recorder pattern correctly validates HTTP calls, lifecycle action types, and share/unshare refetch contracts. |
| ui/src/store/entities/groups/groups.thunks.test.ts | New thunk tests covering group CRUD and the `addGroupMember` HTTP-status-to-error-enum mapping; `axiosError` helper correctly simulates `isAxiosError`-compatible objects. |
| ui/src/store/entities/reactions/reactions.thunks.test.ts | New thunk tests for reactions list/page/remove/create; partial mocks of `reactions.utils.ts` and `reactions.converters.ts` avoid protobuf dependency while keeping reducer helpers intact. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph "Test Harness (shared pattern)"
        A[vi.mock axiosInstance] --> B[makeStore with action-recorder]
        B --> C[dispatch thunk]
        C --> D{Axios call}
    end

    subgraph "datasets.thunks.test.ts"
        D1[getDataset] -->|GET /datasets/:id| S1[getDatasetActions.success]
        D2[getDatasetsPage] -->|GET /datasets| S2[getDatasetPageActions.success]
        D3[createEmptyDataset] -->|POST /groups/:gid/datasets| S3[createNewDatasetActions.success + navigate]
        D4[removeDataset] -->|DELETE /datasets/:id| S4[removeDatasetActions.success + navigate /]
        D5[shareDatasetWithGroup] -->|POST .../share| S5[shareDatasetWithGroupActions.success + refetch dataset + groups]
        D6[unshareDatasetWithGroup] -->|POST .../unshare| S6[unshareDatasetWithGroupActions.success + refetch dataset]
    end

    subgraph "groups.thunks.test.ts"
        G1[getGroupList] -->|GET /groups| GS1[getGroupListActions.success]
        G2[createGroup] -->|POST /groups| GS2[createGroupActions.success + refetch list]
        G3[updateGroupMembers] -->|PATCH /groups/:id/members| GS3[updateGroupMembersActions.success + refetch list]
        G4[removeGroupMembers] -->|POST /groups/:id/members/remove| GS4[removeGroupMembersActions.success]
        G5[addGroupMember] -->|POST /groups/:id/members| GS5{status?}
        GS5 -->|200| OK[addGroupMemberActions.success]
        GS5 -->|409| E1[ALREADY_MEMBER]
        GS5 -->|404| E2[NOT_FOUND]
        GS5 -->|5xx| E3[GENERIC]
    end

    subgraph "reactions.thunks.test.ts"
        R1[getReactionsList] -->|GET /datasets/:id/reactions| RS1[getReactionsListActions.success]
        R2[getReactionsPage] -->|GET /datasets/:id/reactions| RS2[getReactionPageActions.success]
        R3[removeReaction] -->|DELETE /datasets/:id/reactions/:rid| RS3[removeReactionActions.success + navigate]
        R4[createEmptyReaction] -->|POST /datasets/:id/reactions/from-scratch| RS4[createEmptyReactionActions.success + navigate]
    end

    D --> D1
    D --> D2
    D --> D3
    D --> D4
    D --> D5
    D --> D6
    D --> G1
    D --> G2
    D --> G3
    D --> G4
    D --> G5
    D --> R1
    D --> R2
    D --> R3
    D --> R4
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): type the axios mock + thunk pay..."](https://github.com/open-reaction-database/ord-app/commit/dcd6a2be425d34dbc6facbe2d56e4caeaea987c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35141569)</sub>

<!-- /greptile_comment -->