### PR TITLE
Add project CLAUDE.md + UI-testing skill/rule, and pytest-xdist with per-worker DB isolation

### DIFF
--- a/.claude/rules/ui-testing.md
+++ b/.claude/rules/ui-testing.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "ui/**/*"
+---
+
+# UI testing & type-checking (ord-app `ui/`)
+
+Two silent-failure traps when working in `ui/`:
+
+- **Type-check with `tsc -b`, not `tsc --noEmit`.** CI's `npm run build` runs `tsc -b`, which type-checks the test files too. Bare `tsc --noEmit` against the root config skips them → false green, then the `lint_and_build_ui` CI job fails. Run `cd ui && npx tsc -b --force`.
+- **Booting the dev/E2E UI needs BOTH `VITE_E2E_NO_AUTH=TRUE` and `VITE_API_ENDPOINT="http://127.0.0.1:8000/service_api/api/v1"`.** `VITE_E2E_NO_AUTH` only skips Auth0; without the endpoint the app calls the **production** API and hangs on "Loading…". (Backend is mounted under `/service_api`.)
+
+For the full playbook — Vitest mocking patterns (overloaded-axios `vi.mocked`, the Ketcher/d3 barrel stub, protobuf partial-mocks), the render helpers, the thunk-test harness, and the E2E stack-boot recipe — use the **`ord-app-ui-testing` skill**.

--- a/.claude/skills/ord-app-ui-testing/SKILL.md
+++ b/.claude/skills/ord-app-ui-testing/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: ord-app-ui-testing
+description: Use when writing, debugging, or running tests for the ord-app `ui/` package — Vitest unit/integration tests (components, thunks, reducers, converters), mocking patterns (axios, Ketcher, protobuf), or Playwright E2E against the live no-auth stack. Covers the CI gotchas that cause "passes locally, fails in CI".
+version: 0.1.0
+---
+
+# ORD-App UI Testing
+
+Stack: React 19 / Vite 6 / Vitest 3 / happy-dom / @testing-library/react / Mantine v7 / Redux Toolkit / wouter. Playwright for E2E. Imports use `baseUrl: ./src` (vite-tsconfig-paths), so write `store/…`, `common/…`, `features/…`, `test/…` — not relative `../../`.
+
+## Pre-flight: match CI or get a false green
+
+- **Type-check with `tsc -b`, never bare `tsc --noEmit`.** CI's `npm run build` = `tsc -b && vite build`, and `tsc -b` type-checks the **test files**. Bare `tsc --noEmit` against the root config skips them → false green, then `lint_and_build_ui` fails in CI. Always: `cd ui && npx tsc -b --force`.
+- **Lint/format** exactly as CI (`lint:check` = `prettier --check . && eslint && stylelint`): run `npx prettier --write <files>` and `npx eslint <files>` before committing. Pre-commit also runs these.
+- **zsh word-splitting**: a `$VAR` holding a space-separated file list does NOT split. Use `${=FILES}` (e.g. `npx eslint ${=FILES}`).
+- ESLint rules that bite tests: `no-duplicate-imports`; use `Array<string>` not `string[]`; `react-refresh/only-export-components` fires on files that export both a component and helpers (add a file-level `/* eslint-disable react-refresh/only-export-components */` to test-only render helpers); forbids inline `import()` type annotations (`@typescript-eslint/consistent-type-imports`) — see the partial-mock note below.
+
+## Running tests
+
+```
+cd ui
+npx vitest run                         # whole suite (~20s)
+npx vitest run <path-or-substring>     # subset
+```
+Vitest is scoped to `src/**`; Playwright specs live in `e2e/` and run via `npm run test:e2e` (not vitest). The license header for new test files is Apache 2.0 with the current year.
+
+## Render helpers (in `src/test/`)
+
+- `renderWithMantine(ui)` — wraps in `MantineProvider` (Mantine components throw without it).
+- `renderWithProviders(ui, { preloadedState })` — fresh `configureStore({ reducer: rootReducer, preloadedState })` + Mantine. Returns `{ store, ...renderResult }`. Seed only the slices the component reads.
+- `renderInReactionView(ui, { reactionId, reaction, isViewOnly, pathComponents })` — also seeds `reactionContext` + `reactionEntityContext` and a reaction in the store (`emptyReactionData()` by default). Use for components under `ReactionView/` / `reactionEntityNode/`.
+
+## Mocking patterns (the ones that cost time)
+
+**Typed axios mock.** `vi.mocked(axiosInstance)` does NOT surface `mockResolvedValue` under `tsc -b` because axios methods are overloaded. Cast instead:
+```ts
+vi.mock('store/axiosInstance.ts', () => ({ default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() } }));
+const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
+```
+
+**`vi.fn` arity.** `vi.fn(() => …)` is typed with **0 args**; calling it with one fails `tsc -b` and makes `mock.calls[0]` an empty tuple. Declare the arg: `vi.fn((_arg: unknown) => …)`.
+
+**Partial mocks without inline `import()` types** (eslint forbids them):
+```ts
+vi.mock('./reactions.utils.ts', async importActual => ({
+  ...((await importActual()) as Record<string, unknown>),
+  parseReaction: () => ({ id: 99, data: {}, previews: {}, validation: null }),
+}));
+```
+
+**Ketcher / d3 CJS break.** Rendering most `ReactionView/` editor components pulls in `reactionEntityToForm`, which eagerly imports every node form including the Ketcher/d3 structure editor → `require() of ES Module d3 … not supported` under vitest. If the field nodes aren't what you're testing, stub the registry barrel:
+```ts
+vi.mock('features/reactions/ReactionEntities', () => ({
+  ReactionEntityBaseNode: () => null,
+  reactionEntityToForm: new Proxy({}, { get: () => [] }),
+}));
+```
+
+**Reaction protobufs.** Reaction API responses carry base64 `binpb`; don't fabricate them. Partial-mock `parseReaction`/`parseReactionList` (in `reactions.utils.ts`) and `linkReactionEntities` (in `reactions.converters.ts`) to plain objects, keeping the reducer's merge helpers intact.
+
+## Thunk test harness (mocked axios + action recorder)
+
+The store uses RTK `createThunk`/`createThunkWithExplicitResult` (not RTK Query) + a plain axios instance. To test a thunk: mock the I/O, dispatch against a **real** store with a recording middleware, assert HTTP calls + dispatched action *types* (this catches follow-up refetches).
+
+```ts
+vi.mock('store/axiosInstance.ts', () => ({ default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() } }));
+vi.mock('wouter/use-browser-location', () => ({ navigate: vi.fn() }));
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
+
+function makeStore() {
+  const actions: Array<UnknownAction> = [];
+  const recorder = () => (next: (a: unknown) => unknown) => (a: unknown) => { actions.push(a as UnknownAction); return next(a); };
+  const store = configureStore({ reducer: rootReducer, middleware: d => d().concat(recorder) });
+  return { store, actions, types: () => actions.map(a => a.type) };
+}
+// dispatch with: store.dispatch(thunk(arg) as unknown as UnknownAction)
+```
+
+- **Seed selector state by dispatching, not by hand-building preloadedState**: `store.dispatch(getReactionsListActions.request(5))` sets `activeDatasetId`; `store.dispatch(setEditingGroupIdAction(3))` sets the editing group. `arrayContaining`/`toContain` tolerate the extra setup action.
+- Watch payload field names/enums: e.g. `updateGroupMembers` takes `{ user_id, role: USER_ROLES }` (snake_case, enum is `USER_ROLES.VIEWER` = `'viewer'`). `getDatasetsPage` requires its `Partial<CurrentPage>` arg.
+- Teardown belongs in `afterEach`, not `beforeEach` (else the last test's global stub — e.g. `vi.unstubAllGlobals()` / clipboard stub — is never torn down).
+
+## Playwright E2E against the live no-auth stack
+
+Boot the full stack with the dev/test Auth0 bypass, then drive Chromium. The **critical, easy-to-miss** env var is `VITE_API_ENDPOINT` — without it the UI calls the *production* API and hangs on "Loading…".
+
+```bash
+# 1) Postgres (docker-compose maps it to host :5400; user/db = ord, empty password)
+docker compose up -d db   # wait for healthy
+
+# 2) migrations + backend (host), under /service_api
+export PG_DSN="postgresql+asyncpg://ord@localhost:5400/ord"
+export PG_ALEMBIC_DSN="postgresql+psycopg://ord@localhost:5400/ord"
+export PG_TEST_DSN="postgresql+psycopg://ord@localhost:5400/test"
+export APP_ENV=localhost ORD_APP_E2E=true CORS_ORIGINS='["http://127.0.0.1:5173"]'
+uv run alembic upgrade head
+uv run uvicorn ord_app.service_api.main:app --host 127.0.0.1 --port 8000 &   # docs: /service_api/docs
+
+# 3) UI — BOTH env vars are required
+cd ui && VITE_E2E_NO_AUTH=TRUE VITE_API_ENDPOINT="http://127.0.0.1:8000/service_api/api/v1" \
+  npm run dev -- --host 127.0.0.1 --port 5173 &
+
+# 4) Playwright (config baseURL is http://127.0.0.1:5173)
+npx playwright install chromium   # first time only
+npx playwright test e2e/<spec>
+```
+Teardown: kill the :5173/:8000 listeners, then `docker compose down`.
+
+E2E driving tips (the app is WASM/Ketcher-heavy and slow):
+- Grant clipboard for copy/paste flows: `test.use({ permissions: ['clipboard-read', 'clipboard-write'] })`; `127.0.0.1` is a secure context so the clipboard API works.
+- Generous `test.setTimeout(120000)` + `page.setDefaultTimeout(10000)` so a bad selector fails fast instead of hanging 120s. Log each step to find the hang.
+- Scope selectors to the dialog (`page.getByRole('dialog').getByLabel(…)`) — table headers collide with form labels. Prefer `getByRole('button', { name })` over `getByText` (the latter matches hidden icon `aria-label`s and hangs on click).
+- Create-reaction lives on the **dataset** page (`/datasets/:id` → "Reaction" button → "From Scratch"), not the reaction editor.
+- **Before/after on a one-line change**: edit the source file while the dev server runs — Vite HMR reloads it live — capture the buggy screenshot, revert, capture the fixed one. Verify the working tree is clean afterward.
+
+## SonarCloud issues (public API, no token)
+
+```bash
+curl -s "https://sonarcloud.io/api/issues/search?componentKeys=open-reaction-database_ord-app&rules=typescript:S6582&resolved=false&ps=50"
+```
+The gate is part of CI; a PR isn't green over a red Sonar check. Many TS rules in this repo are documented false-positives/won't-fix (tracked in #671) — don't churn working code (e.g. `S2486` catches that already handle their condition, `S7735` readability-only branch flips). Avoid bare `Array.sort()` in tests (S-rule, needs a `localeCompare` comparator).
+
+## Merge gate (when authorized to merge)
+
+Test/no-behavior PRs auto-merge at **Greptile 5/5 + all checks green + 0 unresolved threads**. Greptile posts its score into the PR **body** (`<!-- greptile_comment -->` block, "Confidence Score: N/5"), not always a review — read it there. `test_e2e` flakes on network (`ECONNRESET` during install); re-run rather than treating as a real failure. Merge with `gh pr merge --squash --admin --delete-branch` (admin overrides the review-required ruleset).

--- a/.claude/skills/ord-app-ui-testing/SKILL.md
+++ b/.claude/skills/ord-app-ui-testing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ord-app-ui-testing
 description: Use when writing, debugging, or running tests for the ord-app `ui/` package — Vitest unit/integration tests (components, thunks, reducers, converters), mocking patterns (axios, Ketcher, protobuf), or Playwright E2E against the live no-auth stack. Covers the CI gotchas that cause "passes locally, fails in CI".
-version: 0.1.0
 ---
 
 # ORD-App UI Testing
@@ -11,7 +10,7 @@ Stack: React 19 / Vite 6 / Vitest 3 / happy-dom / @testing-library/react / Manti
 ## Pre-flight: match CI or get a false green
 
 - **Type-check with `tsc -b`, never bare `tsc --noEmit`.** CI's `npm run build` = `tsc -b && vite build`, and `tsc -b` type-checks the **test files**. Bare `tsc --noEmit` against the root config skips them → false green, then `lint_and_build_ui` fails in CI. Always: `cd ui && npx tsc -b --force`.
-- **Lint/format** exactly as CI (`lint:check` = `prettier --check . && eslint && stylelint`): run `npx prettier --write <files>` and `npx eslint <files>` before committing. Pre-commit also runs these.
+- **Lint/format** exactly as CI: `npm run lint:check` = `prettier --check . && npm run lint && npm run lint:css` (where `lint` is `eslint src *.ts *.cjs *.mjs` and `lint:css` is `stylelint '**/*.[s]css'`). Run `npx prettier --write <files>` and `npx eslint <files>` before committing. Pre-commit also runs these.
 - **zsh word-splitting**: a `$VAR` holding a space-separated file list does NOT split. Use `${=FILES}` (e.g. `npx eslint ${=FILES}`).
 - ESLint rules that bite tests: `no-duplicate-imports`; use `Array<string>` not `string[]`; `react-refresh/only-export-components` fires on files that export both a component and helpers (add a file-level `/* eslint-disable react-refresh/only-export-components */` to test-only render helpers); forbids inline `import()` type annotations (`@typescript-eslint/consistent-type-imports`) — see the partial-mock note below.
 
@@ -119,7 +118,3 @@ E2E driving tips (the app is WASM/Ketcher-heavy and slow):
 curl -s "https://sonarcloud.io/api/issues/search?componentKeys=open-reaction-database_ord-app&rules=typescript:S6582&resolved=false&ps=50"
 ```
 The gate is part of CI; a PR isn't green over a red Sonar check. Many TS rules in this repo are documented false-positives/won't-fix (tracked in #671) — don't churn working code (e.g. `S2486` catches that already handle their condition, `S7735` readability-only branch flips). Avoid bare `Array.sort()` in tests (S-rule, needs a `localeCompare` comparator).
-
-## Merge gate (when authorized to merge)
-
-Test/no-behavior PRs auto-merge at **Greptile 5/5 + all checks green + 0 unresolved threads**. Greptile posts its score into the PR **body** (`<!-- greptile_comment -->` block, "Confidence Score: N/5"), not always a review — read it there. `test_e2e` flakes on network (`ECONNRESET` during install); re-run rather than treating as a real failure. Merge with `gh pr merge --squash --admin --delete-branch` (admin overrides the review-required ruleset).

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ cython_debug/
 .idea/
 
 .vite/
+# personal, machine-local Claude rules (e.g. admin-merge workflow)
+.claude/rules/*.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# ord-app
+
+Web application for the [Open Reaction Database](https://open-reaction-database.org): browse, create, and edit reaction datasets. Python/FastAPI backend + React UI, Auth0-gated, backed by Postgres.
+
+## Layout
+
+- `ord_app/` — Python backend (Python 3.12).
+  - `service_api/` — FastAPI app (`service_api/main.py`), `repositories/`, `services/`, `domain/`, `schemas/`, `resources/`. Served under `/service_api`.
+  - `api/`, `visualization/` — supporting modules. `tests/` — pytest suite.
+- `ui/` — React 19 + Vite 6 frontend. Redux Toolkit store, Mantine v7, wouter routing, `ord-schema-protobufjs` for reaction protobufs. Imports use `baseUrl: ./src` (write `store/…`, `common/…`, `features/…`, not `../../`).
+- `migrations/` — Alembic. `scripts/` — dev/E2E helpers. `docker-compose.yml` — Postgres + backend.
+
+## Backend (Python, `uv`)
+
+- Deps: `uv sync --frozen` (pyproject.toml + uv.lock). **No lazy imports**; Google-style docstrings.
+- Postgres required, configured via `PG_DSN` / `PG_ALEMBIC_DSN` / `PG_TEST_DSN`. Migrate: `uv run alembic upgrade head`.
+- Run dev server: `cd ord_app/service_api && ORD_APP_TESTING=TRUE uv run fastapi dev main.py` → http://localhost:8000 (`/docs`).
+- Tests: `uv run pytest` (pytest-asyncio). Parallel runs are supported — `uv run pytest -n auto` — because the conftest gives each xdist worker its own isolated test database (DSN suffixed with `PYTEST_XDIST_WORKER`). Note: at the current suite size, per-worker DB setup makes `-n auto` roughly break-even with serial; the win grows as the suite does.
+- Lint/type: `ruff` + `ruff format`, `pytype` (migration to `ty` in progress — see #681).
+
+## Frontend (`ui/`)
+
+- Setup: `cd ui && npm ci`. Dev: `npm run dev`. Build: `npm run build` (= `tsc -b && vite build`).
+- Unit tests: `npx vitest run` (Vitest + happy-dom + Testing Library). E2E: `npm run test:e2e` (Playwright, specs in `e2e/`).
+- Lint/format: `npm run lint:check` (`prettier --check . && eslint && stylelint`).
+- **Type-check with `tsc -b`, not bare `tsc --noEmit`** (the latter skips test files → false green; CI runs `tsc -b`). See `.claude/rules/ui-testing.md` and the **`ord-app-ui-testing` skill** for the full testing playbook (mocking patterns, render helpers, thunk harness, E2E stack boot).
+
+## Formatting & pre-commit
+
+Run hooks via [pre-commit](https://pre-commit.com): `uv run pre-commit install` once (and `npm ci` in `ui/` so UI hooks find their tools). Hooks: `addlicense` (Apache header, current year for new files), `ruff` + `ruff-format` (scoped to `ord_app/`), and UI `prettier`/`eslint`/`stylelint`. Run all: `uv run pre-commit run --all-files`.
+
+## CI gates (a PR is not mergeable until these are green)
+
+- **Tests**: `test_python` (ubuntu + macos), `test_ui`, `test_e2e` (boots the full no-auth stack).
+- **Checks**: `check_python` (ruff / ruff-format / pytype), `check_javascript` (clang-format), `lint_and_build_ui` (`lint:check` + `npm run build`), `check_license_headers`.
+- **SonarCloud quality gate** and **Greptile review** also gate merges — never merge over a red Sonar check; address Greptile findings (and read its PR-body summary for sub-threshold notes) before merging.
+
+## Conventions
+
+- Every source file carries the Apache 2.0 license header (enforced by addlicense).
+- Coverage is reported to Codecov (`codecov.yml`); each `codecov-action` must set an explicit `slug`.
+- A living issue-triage plan lives in `ISSUE_TRIAGE_PLAN.md` (synced to issue #656) and epic #662.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Web application for the [Open Reaction Database](https://open-reaction-database.
 
 - Setup: `cd ui && npm ci`. Dev: `npm run dev`. Build: `npm run build` (= `tsc -b && vite build`).
 - Unit tests: `npx vitest run` (Vitest + happy-dom + Testing Library). E2E: `npm run test:e2e` (Playwright, specs in `e2e/`).
-- Lint/format: `npm run lint:check` (`prettier --check . && eslint && stylelint`).
+- Lint/format: `npm run lint:check` (= `prettier --check . && npm run lint && npm run lint:css`, i.e. `eslint src *.ts *.cjs *.mjs` + `stylelint '**/*.[s]css'`).
 - **Type-check with `tsc -b`, not bare `tsc --noEmit`** (the latter skips test files → false green; CI runs `tsc -b`). See `.claude/rules/ui-testing.md` and the **`ord-app-ui-testing` skill** for the full testing playbook (mocking patterns, render helpers, thunk harness, E2E stack boot).
 
 ## Formatting & pre-commit

--- a/ord_app/tests/conftest.py
+++ b/ord_app/tests/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import time
 
 import pytest
 from alembic import command
@@ -20,8 +21,8 @@ from faker import Faker
 from fastapi.testclient import TestClient
 from ord_schema.proto.reaction_pb2 import Reaction
 from sqlalchemy import create_engine, make_url, text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from ord_app.service_api.main import app
@@ -69,6 +70,8 @@ def _worker_test_dsn() -> str:
         The ``pg_test_dsn`` with the database name suffixed by ``PYTEST_XDIST_WORKER`` when set.
     """
     url = make_url(RuntimeSettings.pg_test_dsn)
+    if url.database is None:
+        raise RuntimeError(f"pg_test_dsn must name a database: {RuntimeSettings.pg_test_dsn!r}")
     worker = os.getenv("PYTEST_XDIST_WORKER")
     if worker:
         url = url.set(database=f"{url.database}_{worker}")
@@ -76,10 +79,45 @@ def _worker_test_dsn() -> str:
     return url.render_as_string(hide_password=False)
 
 
+def _recreate_test_database(dsn: str, attempts: int = 5, delay: float = 0.5) -> None:
+    """Create a fresh database for ``dsn``, dropping any leftover one first.
+
+    Dropping a database left behind by a crashed run avoids a stale/partial schema failing the
+    migration below. Concurrent xdist workers each issue ``CREATE DATABASE`` (which clones
+    ``template1``); Postgres rejects the clone while another worker is using ``template1``
+    (SQLSTATE 55006, raised as ``OperationalError``), so retry a few times.
+
+    Args:
+        dsn: Target database URL to (re)create.
+        attempts: Maximum create attempts before giving up.
+        delay: Seconds to wait between attempts.
+
+    Raises:
+        OperationalError: If every attempt fails (re-raised from the last attempt).
+    """
+    for attempt in range(attempts):
+        try:
+            if database_exists(dsn):
+                drop_database(dsn)
+            create_database(dsn)
+            return
+        except OperationalError:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(delay)
+
+
 TEST_DSN = _worker_test_dsn()
 
 pg_engine = create_async_engine(TEST_DSN)
 db_session_maker = async_sessionmaker(pg_engine, expire_on_commit=False, autocommit=False, autoflush=False)
+
+# Reused across every clear_database call instead of building a new engine per test.
+sync_engine = create_engine(TEST_DSN)
+# Single statement clears every table once per test; CASCADE handles FK order.
+_truncate_all_tables = text(
+    "TRUNCATE TABLE " + ", ".join(f'"{table.name}"' for table in BaseModel.metadata.sorted_tables) + " CASCADE"
+)
 
 
 async def _test_db_session():
@@ -120,10 +158,7 @@ def api_client():
 
 @pytest.fixture(scope="session", autouse=True)
 def create_test_database():
-    engine = create_engine(TEST_DSN)
-    if not database_exists(engine.url):
-        create_database(engine.url)
-    engine.dispose()
+    _recreate_test_database(TEST_DSN)
 
     alembic_cfg = Config(str(RuntimeSettings.base_dir.parent.parent / "alembic.ini"))
     alembic_cfg.set_main_option("script_location", str(RuntimeSettings.base_dir.parent.parent / "migrations"))
@@ -132,20 +167,15 @@ def create_test_database():
 
     yield
 
+    # Release pooled connections so drop_database isn't blocked by our own sessions.
+    sync_engine.dispose()
     drop_database(TEST_DSN)
 
 
 @pytest.fixture(autouse=True)
 def clear_database():
-    engine = create_engine(TEST_DSN)
-    db_session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-    with db_session() as session:
-        for table in reversed(BaseModel.metadata.sorted_tables):
-            session.execute(text(f'TRUNCATE TABLE "{table.name}" CASCADE;'))
-        session.commit()
-
-    engine.dispose()
+    with sync_engine.begin() as conn:
+        conn.execute(_truncate_all_tables)
 
     yield
 

--- a/ord_app/tests/conftest.py
+++ b/ord_app/tests/conftest.py
@@ -167,8 +167,9 @@ def create_test_database():
 
     yield
 
-    # Release pooled connections so drop_database isn't blocked by our own sessions.
-    sync_engine.dispose()
+    # drop_database() runs pg_terminate_backend on every other connection to this database
+    # (both sync_engine's pool and the async pg_engine's pool) before issuing DROP, so neither
+    # engine needs explicit disposal here.
     drop_database(TEST_DSN)
 
 

--- a/ord_app/tests/conftest.py
+++ b/ord_app/tests/conftest.py
@@ -11,13 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+
 import pytest
 from alembic import command
 from alembic.config import Config
 from faker import Faker
 from fastapi.testclient import TestClient
 from ord_schema.proto.reaction_pb2 import Reaction
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, make_url, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import create_database, database_exists, drop_database
@@ -55,7 +57,28 @@ def read_testdata_bytes(filename: str) -> bytes:
         return fd.read()
 
 
-pg_engine = create_async_engine(RuntimeSettings.pg_test_dsn)
+def _worker_test_dsn() -> str:
+    """Return a per-xdist-worker test database URL so parallel workers don't share state.
+
+    pytest-xdist runs each worker in its own process. The autouse ``clear_database`` fixture
+    TRUNCATEs every table before each test, so without isolation concurrent workers would wipe
+    each other's data mid-test. Suffix the database name with the worker id (``gw0``, ``gw1``,
+    …); a plain (non-``-n``) ``pytest`` run has no worker id and uses the base DSN unchanged.
+
+    Returns:
+        The ``pg_test_dsn`` with the database name suffixed by ``PYTEST_XDIST_WORKER`` when set.
+    """
+    url = make_url(RuntimeSettings.pg_test_dsn)
+    worker = os.getenv("PYTEST_XDIST_WORKER")
+    if worker:
+        url = url.set(database=f"{url.database}_{worker}")
+    # hide_password=False keeps the credential that str(url) would mask as "***".
+    return url.render_as_string(hide_password=False)
+
+
+TEST_DSN = _worker_test_dsn()
+
+pg_engine = create_async_engine(TEST_DSN)
 db_session_maker = async_sessionmaker(pg_engine, expire_on_commit=False, autocommit=False, autoflush=False)
 
 
@@ -97,24 +120,24 @@ def api_client():
 
 @pytest.fixture(scope="session", autouse=True)
 def create_test_database():
-    engine = create_engine(RuntimeSettings.pg_test_dsn)
+    engine = create_engine(TEST_DSN)
     if not database_exists(engine.url):
         create_database(engine.url)
     engine.dispose()
 
     alembic_cfg = Config(str(RuntimeSettings.base_dir.parent.parent / "alembic.ini"))
     alembic_cfg.set_main_option("script_location", str(RuntimeSettings.base_dir.parent.parent / "migrations"))
-    alembic_cfg.set_main_option("sqlalchemy.url", RuntimeSettings.pg_test_dsn)
+    alembic_cfg.set_main_option("sqlalchemy.url", TEST_DSN)
     command.upgrade(alembic_cfg, "head")
 
     yield
 
-    drop_database(RuntimeSettings.pg_test_dsn)
+    drop_database(TEST_DSN)
 
 
 @pytest.fixture(autouse=True)
 def clear_database():
-    engine = create_engine(RuntimeSettings.pg_test_dsn)
+    engine = create_engine(TEST_DSN)
     db_session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
     with db_session() as session:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pytest-cov>=6.0.0,<7",
     "pytype>=2024.10.11",
     "pytest-asyncio>=0.25.3,<0.26",
+    "pytest-xdist>=3.6,<4",
     "ruff>=0.9.9,<0.10",
     "pre-commit>=4.0,<5",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -265,6 +265,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "faker"
 version = "36.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -657,6 +666,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "pytype" },
     { name = "ruff" },
     { name = "sqlalchemy-utils" },
@@ -693,6 +703,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4,<9" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },
     { name = "pytest-cov", specifier = ">=6.0.0,<7" },
+    { name = "pytest-xdist", specifier = ">=3.6,<4" },
     { name = "pytype", specifier = ">=2024.10.11" },
     { name = "ruff", specifier = ">=0.9.9,<0.10" },
     { name = "sqlalchemy-utils", specifier = ">=0.41.2,<0.42" },
@@ -1099,6 +1110,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398, upload-time = "2025-09-06T15:40:14.361Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115, upload-time = "2025-09-06T15:40:12.44Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Improvements to the repo's dev/agent experience: parallel-capable Python tests, and native Claude Code memory files. (Commits 3–4 fold in the code review.)

## 1. `pytest-xdist` with per-worker DB isolation

Adds `pytest-xdist` so the Python suite can run in parallel (`uv run pytest -n auto`).

The autouse `clear_database` fixture `TRUNCATE`s every table before each test, so sharing one database across xdist workers would have them wipe each other's data mid-test. The conftest now derives a **per-worker** test database — the DSN's database name is suffixed with `PYTEST_XDIST_WORKER` (`test_gw0`, `test_gw1`, …). A plain serial run has no worker id and uses the base DSN unchanged.

Robustness (added in review, see §3): the per-worker DB is **dropped-and-recreated** at session start (so a crashed run can't leave a stale schema), `CREATE DATABASE` is **retried** (xdist workers race on cloning `template1`), and `clear_database` now reuses **one engine + a single multi-table `TRUNCATE`** instead of building an engine per test.

**Verified against Postgres:** serial and `-n auto` both **73 passed**, no leftover `test_gwN` databases, ruff/format clean. The `clear_database` refactor brought `-n auto` to ~3.95s (near serial's ~3.35s); **CI is left on serial** for now since the win only grows with the suite — flipping it is a one-line change.

## 2. Project `CLAUDE.md` + UI-testing skill and rule

Persistent project context for Claude Code (and useful to human contributors), structured by load behavior:

- **`CLAUDE.md`** (repo root, always-on) — overview, backend/UI build+test commands, CI gates, conventions. Flags `tsc -b` over bare `tsc --noEmit`, and the pytest parallelism nuance above.
- **`.claude/skills/ord-app-ui-testing/`** (on-demand) — the full UI-testing playbook: Vitest mocking patterns (overloaded-axios `vi.mocked`, the Ketcher/d3 barrel stub, protobuf partial-mocks), the render helpers, the thunk-test harness, and the Playwright no-auth stack-boot recipe.
- **`.claude/rules/ui-testing.md`** (`paths: ui/**`, loads only when working in `ui/`) — the two silent-failure tripwires (`tsc -b`; the E2E `VITE_API_ENDPOINT`), pointing to the skill for depth.

Uses native Claude Code memory mechanisms (no plugins): always-on CLAUDE.md, path-scoped rules, and an on-demand skill — so UI-testing detail loads only when relevant rather than bloating every session.

## 3. Code-review follow-ups (commits 3–4)

A `/code-review` pass surfaced five findings, all addressed:
- **conftest:** the `CREATE DATABASE` template1 retry, drop-and-recreate on a stale leftover DB, single-`TRUNCATE`/reused-engine in `clear_database` (the ~6.6s→~3.95s speedup), and a guard for a `pg_test_dsn` with no database name.
- **docs:** corrected the `lint:check` expansion in `CLAUDE.md` and the skill.

Also refined the skill itself: dropped the `version` frontmatter (only meaningful for marketplace-distributed skills), and moved the merge-gate guidance out of the shared skill into a **gitignored personal rule** (`.claude/rules/*.local.md`) since it described an admin `--admin`-bypass workflow that doesn't apply to other contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `pytest-xdist` support with per-worker database isolation so the Python test suite can run in parallel, and introduces native Claude Code memory files (`CLAUDE.md`, a path-scoped rule, and an on-demand skill) to document the project's build/test conventions and UI-testing playbook.

- **`conftest.py`**: derives a unique test database per xdist worker (`test_gw0`, `test_gw1`, …), drops and recreates it at session start to eliminate stale schemas from crashed runs, retries `CREATE DATABASE` to handle the Postgres template1 lock race, and replaces the per-test engine/sessionmaker with a shared `sync_engine` and a single multi-table `TRUNCATE` — cutting parallel-mode runtime from ~6.6 s to ~3.95 s.
- **Documentation**: `CLAUDE.md` is always-on project context; `.claude/rules/ui-testing.md` is path-scoped to `ui/**` and surfaces the two silent CI failure traps (`tsc -b` vs `tsc --noEmit`, missing `VITE_API_ENDPOINT`); the on-demand skill provides the full Vitest/Playwright testing playbook.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the parallel DB isolation is well-designed, the retry logic is sound, and the documentation additions are accurate.

The conftest rewrite is carefully structured: per-worker database names eliminate inter-worker TRUNCATE races, drop-and-recreate on stale leftovers is correct, the template1 lock retry is appropriate, and relying on sqlalchemy_utils' built-in pg_terminate_backend call inside drop_database to clear pooled connections before DROP is a sound approach. The documentation files are accurate against the actual codebase. No correctness issues found in any changed file.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_app/tests/conftest.py | Adds per-xdist-worker DB isolation via `_worker_test_dsn`, drop-and-recreate with retry logic, and a reused sync engine + single-TRUNCATE `clear_database`. Well-structured; the `drop_database` teardown relies on sqlalchemy_utils' built-in `pg_terminate_backend` to clear pooled connections before DROP. |
| pyproject.toml | Adds `pytest-xdist>=3.6,<4` to dev dependencies. Straightforward dependency addition. |
| CLAUDE.md | New always-on project context file covering backend/UI build and test commands, CI gates, and conventions. Content is accurate and well-organized. |
| .claude/rules/ui-testing.md | New path-scoped rule (active only for `ui/**/*`) surfacing the two silent-failure traps: `tsc -b` vs `tsc --noEmit`, and the missing `VITE_API_ENDPOINT` for E2E. Concise and accurate. |
| .claude/skills/ord-app-ui-testing/SKILL.md | New on-demand skill documenting Vitest mocking patterns, render helpers, thunk harness, and Playwright E2E boot recipe. Detail is precise and grounded in the actual stack. |
| .gitignore | Adds pattern to ignore personal/local Claude rule files (`*.local.md`) and a trailing newline fix. Correct glob scope. |
| uv.lock | Lock file update adding execnet 2.1.2 and pytest-xdist 3.8.0 entries. Expected companion to the pyproject.toml change. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["test(python): document that drop\_databas..."](https://github.com/open-reaction-database/ord-app/commit/23dae6a6f42396f0feabaa89b2edbf3f1a9e8b37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35302242)</sub>

<!-- /greptile_comment -->