### PR TITLE
test(ui): cover useAppUncontrolled hook + form util/schema gaps

### DIFF
--- a/ui/src/common/hooks/useAppUncontrolled.test.ts
+++ b/ui/src/common/hooks/useAppUncontrolled.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { ChangeEvent } from 'react';
+import { useAppUncontrolled } from 'common/hooks/useAppUncontrolled.ts';
+
+describe('useAppUncontrolled', () => {
+  it('is controlled when value is provided', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useAppUncontrolled<string>({ value: 'controlled', onChange }));
+    const [value, , isControlled] = result.current;
+    expect(value).toBe('controlled');
+    expect(isControlled).toBe(true);
+  });
+
+  it('falls back to defaultValue, then finalValue, when uncontrolled', () => {
+    const fromDefault = renderHook(() => useAppUncontrolled<string>({ defaultValue: 'd', finalValue: 'f' }));
+    expect(fromDefault.result.current[0]).toBe('d');
+    expect(fromDefault.result.current[2]).toBe(false);
+
+    const fromFinal = renderHook(() => useAppUncontrolled<string>({ finalValue: 'f' }));
+    expect(fromFinal.result.current[0]).toBe('f');
+  });
+
+  it('updates the uncontrolled value and calls onChange for a raw value', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useAppUncontrolled<string>({ defaultValue: 'a', onChange }));
+    act(() => result.current[1]('b'));
+    expect(result.current[0]).toBe('b');
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('reads value from a ChangeEvent target', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useAppUncontrolled<string>({ defaultValue: 'a', onChange }));
+    const setValue = result.current[1] as unknown as (event: ChangeEvent<HTMLInputElement>) => void;
+    act(() => setValue({ target: { value: 'from-event' } } as ChangeEvent<HTMLInputElement>));
+    expect(result.current[0]).toBe('from-event');
+    expect(onChange).toHaveBeenCalledWith('from-event');
+  });
+});

--- a/ui/src/features/datasets/DatasetHeader/EditDataset/editDataset.schema.test.ts
+++ b/ui/src/features/datasets/DatasetHeader/EditDataset/editDataset.schema.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { editDatasetSchema } from 'features/datasets/DatasetHeader/EditDataset/editDataset.schema.ts';
+
+describe('editDatasetSchema', () => {
+  it('accepts a name and description', async () => {
+    await expect(editDatasetSchema.validate({ name: 'My dataset', description: 'notes' })).resolves.toEqual({
+      name: 'My dataset',
+      description: 'notes',
+    });
+  });
+
+  it('requires the name', async () => {
+    await expect(editDatasetSchema.validate({ name: '', description: 'notes' })).rejects.toThrow(
+      'Dataset name should not be empty',
+    );
+  });
+
+  it('requires the description', async () => {
+    await expect(editDatasetSchema.validate({ name: 'My dataset', description: '   ' })).rejects.toThrow(
+      'Description should not be empty',
+    );
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntities.utils.test.ts
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntities.utils.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { createConditionFactory } from 'features/reactions/ReactionEntities/reactionEntities.utils.ts';
+
+describe('createConditionFactory', () => {
+  it('builds a "type" condition that hides when the value is not in the allowed set', () => {
+    const condition = createConditionFactory<string>()(['a', 'b']);
+    expect(condition?.name).toBe('type');
+    expect(condition?.isHidden('a')).toBe(false);
+    expect(condition?.isHidden('b')).toBe(false);
+    expect(condition?.isHidden('c')).toBe(true);
+  });
+
+  it('hides everything for an empty allowed set', () => {
+    const condition = createConditionFactory<number>()([]);
+    expect(condition?.isHidden(1)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fills three previously 0%-coverage pure units (#662):
- **`useAppUncontrolled`** — controlled vs. uncontrolled (the `defaultValue` → `finalValue` fallback), raw-value change updating state + calling `onChange`, and the `ChangeEvent.target.value` branch.
- **`createConditionFactory`** — the `"type"` condition's `isHidden` for values in/out of the allowed set, plus the empty-set case.
- **`editDatasetSchema`** — accepts `{name, description}`, requires each (composes `requiredTextField`).

## Test plan
- [x] `vitest run` — 9/9 new tests pass
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean
- [ ] CI green

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 9 new unit tests across three previously uncovered modules (`useAppUncontrolled`, `editDatasetSchema`, and `createConditionFactory`) as part of the ongoing coverage work tracked in #662. All assertions were verified against the source implementations — error messages, return shapes, and state transitions are accurate.

- **`useAppUncontrolled.test.ts`**: Covers controlled vs. uncontrolled fallback (`defaultValue` → `finalValue`), raw-value state update + `onChange` forwarding, and the `ChangeEvent.target.value` extraction branch.
- **`editDataset.schema.test.ts`**: Validates that the yup schema accepts a valid `{name, description}` pair and rejects both an empty name and a whitespace-only description, matching the `requiredTextField` error messages exactly.
- **`reactionEntities.utils.test.ts`**: Confirms `createConditionFactory` names its condition `"type"`, correctly includes/excludes values from the allowed set, and hides everything for an empty set.

<h3>Confidence Score: 5/5</h3>

Pure test additions with no changes to production code — safe to merge.

All three test files add only new test cases with no modifications to source code. Each assertion was verified against the corresponding implementation: error messages match requiredTextField output exactly, the ChangeEvent branch in useAppUncontrolled is exercised correctly, and the createConditionFactory include/exclude logic is accurately reflected in the tests.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/hooks/useAppUncontrolled.test.ts | Adds 4 tests for useAppUncontrolled covering controlled/uncontrolled fallback, raw-value updates, and ChangeEvent branch — all assertions match the implementation. |
| ui/src/features/datasets/DatasetHeader/EditDataset/editDataset.schema.test.ts | Adds 3 tests for editDatasetSchema; error messages align exactly with requiredTextField output, including the whitespace-only rejection for description. |
| ui/src/features/reactions/ReactionEntities/reactionEntities.utils.test.ts | Adds 2 tests for createConditionFactory covering in-set/out-of-set and empty-set cases; logic matches the implementation correctly. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover useAppUncontrolled hook ..."](https://github.com/open-reaction-database/ord-app/commit/e9b6f66ff7d5261731eecc6977abe47f3ddc7e76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35527499)</sub>

<!-- /greptile_comment -->