### PR TITLE
test(ui): cover enumeration worker value coercion (#662)

### DIFF
--- a/ui/src/store/features/enumerationWorker/worker.test.ts
+++ b/ui/src/store/features/enumerationWorker/worker.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  EnumerationBatchRequest,
+  EnumerationBatchResult,
+  TemplateCSVRow,
+  VariableMatch,
+} from 'store/entities/enumeration/enumeration.types.ts';
+import type { AppReaction } from 'store/entities/reactions/reactions.types.ts';
+import { type Variable, VariableType } from 'store/entities/templates/templates.types.ts';
+
+// reactionToOrdReaction (and the protobuf encode it feeds) is the heavy tail of
+// enumerateReaction; mocking it lets us capture the *coerced & merged* template
+// without standing up a full, encodable reaction. ordBooleanToReaction and the
+// reactions.utils merge helpers are left real so the coercion logic is exercised.
+const { reactionToOrdReactionMock } = vi.hoisted(() => ({
+  reactionToOrdReactionMock: vi.fn((_template: unknown) => ({})),
+}));
+vi.mock('store/entities/reactions/reactions.converters.ts', () => ({
+  reactionToOrdReaction: reactionToOrdReactionMock,
+}));
+
+// Importing the module assigns the global onmessage handler as a side effect.
+import './worker.ts';
+
+const handler = globalThis.onmessage as unknown as (event: { data: unknown }) => void;
+
+function makeVariable(type: VariableType, overrides: Partial<Variable> = {}): Variable {
+  return { name: 'v1', field: 'f1', type, path: ['valueField'], ...overrides };
+}
+
+interface RunOptions {
+  variables?: Array<Variable>;
+  matching?: Array<VariableMatch>;
+  rows?: Array<TemplateCSVRow>;
+  index?: number;
+}
+
+/** Drive the worker's onmessage handler for one batch and return its posted result. */
+function run({
+  variables = [makeVariable(VariableType.String)],
+  matching = [{ variable: 'v1', csvColumn: 'col1' }],
+  rows = [{ col1: 'value' }],
+  index = 0,
+}: RunOptions = {}): EnumerationBatchResult {
+  const request: EnumerationBatchRequest = {
+    data: {} as unknown as AppReaction,
+    variables,
+    matching: matching as Array<Required<VariableMatch>>,
+    templateCSV: { headers: ['col1'], content: rows },
+    index,
+  };
+  handler({ data: request });
+  return postMessageMock.mock.calls.at(-1)?.[0] as EnumerationBatchResult;
+}
+
+/** The merged template handed to reactionToOrdReaction for the most recent reaction. */
+function lastMergedTemplate(): Record<string, unknown> {
+  return reactionToOrdReactionMock.mock.calls.at(-1)?.[0] as unknown as Record<string, unknown>;
+}
+
+let postMessageMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  postMessageMock = vi.fn();
+  vi.stubGlobal('postMessage', postMessageMock);
+  reactionToOrdReactionMock.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('enumeration worker onmessage', () => {
+  it('ignores a message whose data is not an object', () => {
+    handler({ data: 'not-an-object' });
+    expect(postMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the template reactionId and coerces a value onto the variable path', () => {
+    const result = run({
+      variables: [makeVariable(VariableType.String, { path: ['valueField'] })],
+      rows: [{ col1: 'abc' }],
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.reactions).toHaveLength(1);
+    const merged = lastMergedTemplate();
+    expect(merged.reactionId).toBeNull();
+    expect(merged.valueField).toBe('abc');
+  });
+
+  it('reports one error per failing row, leaving successful rows intact', () => {
+    const result = run({
+      variables: [makeVariable(VariableType.Number)],
+      rows: [{ col1: 5 }, { col1: 'oops' }],
+      index: 10,
+    });
+    expect(result.reactions).toHaveLength(1);
+    // baseIndex (10) + row index (1) + 2 (1-based + header row) = 13.
+    expect(result.errors).toEqual([{ line: 13, message: 'Expected number value for variable v1' }]);
+  });
+});
+
+describe('value coercion by VariableType', () => {
+  it('stringifies a non-string value for a String variable', () => {
+    run({ variables: [makeVariable(VariableType.String)], rows: [{ col1: 42 }] });
+    expect(lastMergedTemplate().valueField).toBe('42');
+  });
+
+  it('passes a number through for a Number variable', () => {
+    run({ variables: [makeVariable(VariableType.Number)], rows: [{ col1: 7 }] });
+    expect(lastMergedTemplate().valueField).toBe(7);
+  });
+
+  it('throws for a Number variable given a non-number', () => {
+    const result = run({ variables: [makeVariable(VariableType.Number)], rows: [{ col1: 'x' }] });
+    expect(result.reactions).toEqual([]);
+    expect(result.errors[0].message).toBe('Expected number value for variable v1');
+  });
+
+  it('upper-cases a string option for a Select variable', () => {
+    run({ variables: [makeVariable(VariableType.Select)], rows: [{ col1: 'aqueous' }] });
+    expect(lastMergedTemplate().valueField).toBe('AQUEOUS');
+  });
+
+  it('maps a boolean to the ORD boolean enum for a Select variable', () => {
+    run({ variables: [makeVariable(VariableType.Select)], rows: [{ col1: true }] });
+    expect(lastMergedTemplate().valueField).toBe('True');
+  });
+
+  it('rejects a numeric Select value', () => {
+    const result = run({ variables: [makeVariable(VariableType.Select)], rows: [{ col1: 3 }] });
+    expect(result.errors[0].message).toBe('Expected string option value for variable v1');
+  });
+
+  it('formats a Date variable to YYYY-MM-DD', () => {
+    run({ variables: [makeVariable(VariableType.Date)], rows: [{ col1: '2024-01-15T08:30:00' }] });
+    expect(lastMergedTemplate().valueField).toBe('2024-01-15');
+  });
+
+  it('formats a DateTime variable with the time component', () => {
+    run({ variables: [makeVariable(VariableType.DateTime)], rows: [{ col1: '2024-01-15T08:30:00' }] });
+    expect(lastMergedTemplate().valueField).toBe('2024-01-15T08:30:00');
+  });
+
+  it('rejects an invalid date', () => {
+    const result = run({ variables: [makeVariable(VariableType.Date)], rows: [{ col1: 'not-a-date' }] });
+    expect(result.errors[0].message).toBe('Expected date value for variable v1');
+  });
+
+  it('rejects a non-string date value', () => {
+    const result = run({ variables: [makeVariable(VariableType.Date)], rows: [{ col1: 123 }] });
+    expect(result.errors[0].message).toBe('Expected date value for variable v1');
+  });
+
+  it('wraps a single number in an array for a NumberArray variable', () => {
+    run({ variables: [makeVariable(VariableType.NumberArray)], rows: [{ col1: 9 }] });
+    expect(lastMergedTemplate().valueField).toEqual([9]);
+  });
+
+  it('splits a comma-separated string for a NumberArray variable', () => {
+    run({ variables: [makeVariable(VariableType.NumberArray)], rows: [{ col1: '1.5,2,3' }] });
+    expect(lastMergedTemplate().valueField).toEqual([1.5, 2, 3]);
+  });
+
+  it('rejects a NumberArray string with a non-numeric entry', () => {
+    const result = run({ variables: [makeVariable(VariableType.NumberArray)], rows: [{ col1: '1,x,3' }] });
+    expect(result.errors[0].message).toBe('Expected number array value for variable v1');
+  });
+
+  it('rejects a non-string, non-number NumberArray value', () => {
+    const result = run({ variables: [makeVariable(VariableType.NumberArray)], rows: [{ col1: true }] });
+    expect(result.errors[0].message).toBe('Expected number array value for variable v1');
+  });
+});


### PR DESCRIPTION
## Summary

Brings `store/features/enumerationWorker/worker.ts` from **0% → 100%** line/branch coverage (#662). This module holds the CSV-variable → reaction coercion logic for template enumeration, previously untested.

The test drives the worker's `onmessage` handler directly (stubbing `postMessage`) and covers:
- non-object messages are ignored (no `postMessage`);
- the template `reactionId` is cleared and the coerced value lands on the variable `path`;
- one error per failing row, with the correct 1-based line number (`baseIndex + rowIndex + 2`), while successful rows still post;
- **every `VariableType` branch** — String stringify, Number passthrough/reject, Select upper-case / boolean→ORD-enum / reject, Date & DateTime formatting + invalid/non-string rejection, NumberArray single-number / CSV-split / non-numeric / non-string rejection.

`reactionToOrdReaction` (and the protobuf encode it feeds) is mocked so we can capture the **coerced & merged** template without a fully encodable reaction; `ordBooleanToReaction` and the `reactions.utils` merge helpers are left real so the coercion logic is genuinely exercised.

## Test plan
- [x] `vitest run` — 17/17 new tests pass; full suite 473/473 green
- [x] `worker.ts` coverage 100% statements/branches/functions/lines
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean
- [ ] CI green

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new test file `worker.test.ts` that brings the enumeration worker module from 0% to 100% line/branch coverage by driving the `onmessage` handler directly and stubbing `postMessage`.

- `reactionToOrdReaction` (and its downstream protobuf encode) is mocked via `vi.hoisted` so the tests capture coerced/merged template state without requiring a fully encodable reaction; all other helpers (`ordBooleanToReaction`, `deepMergeWithArrayMerge`, `generateDeepPartialReactionByPath`) are exercised for real.
- Every `VariableType` branch is covered: String, Number, Select (string/boolean/numeric-reject), Date & DateTime (round-trip and invalid-input rejection), and NumberArray (single number, CSV-split, non-numeric entry, and non-string rejection).
- The error-line-number formula (`baseIndex + rowIndex + 2`) is explicitly verified with a parameterised batch offset.

<h3>Confidence Score: 5/5</h3>

Purely additive test file with no changes to production code; safe to merge.

The change is a single new test file. The mock setup uses the correct vi.hoisted + vi.mock hoisting pattern, beforeEach/afterEach guards properly isolate global stubs, and the run helper always exercises the full handler path so postMessage is guaranteed to fire. No production code is touched and the test design is sound.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/features/enumerationWorker/worker.test.ts | New test file with 17 tests that bring worker.ts from 0% to 100% coverage; well-structured mock setup and complete VariableType branch coverage |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover enumeration worker value..."](https://github.com/open-reaction-database/ord-app/commit/115af767ce99a5b717cefdae9e725f9795b587cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35528483)</sub>

<!-- /greptile_comment -->