### PR TITLE
test(ui): cover web-worker plumbing (previews worker + both middlewares) (#662)

### DIFF
--- a/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
+++ b/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
@@ -18,23 +18,9 @@ import type { MiddlewareAPI } from '@reduxjs/toolkit';
 import { enumerationWorkerMiddleware } from './enumerationWorkerMiddleware.ts';
 import { enumerateBatchActions } from 'store/entities/enumeration/enumeration.actions.ts';
 import type { EnumerationBatchResult } from 'store/entities/enumeration/enumeration.types.ts';
-
-interface CapturedWorker {
-  postMessage: ReturnType<typeof vi.fn>;
-  onmessage: ((event: { data: unknown }) => void) | null;
-  onerror: ((error: unknown) => void) | null;
-}
+import { type CapturedWorker, stubWorker } from 'test/workerStub.ts';
 
 let workers: Array<CapturedWorker>;
-
-class MockWorker {
-  postMessage = vi.fn();
-  onmessage: ((event: { data: unknown }) => void) | null = null;
-  onerror: ((error: unknown) => void) | null = null;
-  constructor() {
-    workers.push(this);
-  }
-}
 
 function setup() {
   const dispatch = vi.fn((action: unknown) => action);
@@ -47,8 +33,7 @@ function setup() {
 const batchRequest = { index: 0, data: {}, variables: [], matching: [], templateCSV: { headers: [], content: [] } };
 
 beforeEach(() => {
-  workers = [];
-  vi.stubGlobal('Worker', MockWorker);
+  workers = stubWorker();
 });
 
 afterEach(() => {

--- a/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
+++ b/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
@@ -16,8 +16,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { enumerationWorkerMiddleware } from './enumerationWorkerMiddleware.ts';
 import { enumerateBatchActions } from 'store/entities/enumeration/enumeration.actions.ts';
+import { enumerateBatchResult } from 'store/entities/enumeration/enumeration.thunks.ts';
 import type { EnumerationBatchResult } from 'store/entities/enumeration/enumeration.types.ts';
 import { createWorkerHarness, itForwardsNonWorkerActions } from 'test/workerStub.ts';
+
+// enumerateBatchResult is a thunk creator (new function per call, so no
+// reference equality); stub it to a plain action so the dispatch assertion can
+// check both the data it was built from and that exact value reaching dispatch.
+vi.mock('store/entities/enumeration/enumeration.thunks.ts', () => ({
+  enumerateBatchResult: vi.fn((batch: unknown) => ({ type: 'enumeration/batch-result', payload: batch })),
+}));
 
 function setup() {
   const { workers, dispatch, next, api } = createWorkerHarness();
@@ -44,11 +52,12 @@ describe('enumerationWorkerMiddleware', () => {
     expect(next).toHaveBeenCalledWith(action);
   });
 
-  it('dispatches the batch result when the worker posts a message back', () => {
+  it('dispatches enumerateBatchResult built from the posted batch when the worker replies', () => {
     const { dispatch, worker } = setup();
     const result: EnumerationBatchResult = { reactions: ['enc'], errors: [] };
     worker.onmessage?.({ data: result });
-    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(enumerateBatchResult).toHaveBeenCalledWith(result);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'enumeration/batch-result', payload: result });
   });
 
   it('logs worker errors without throwing', () => {

--- a/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
+++ b/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
@@ -13,41 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MiddlewareAPI } from '@reduxjs/toolkit';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { enumerationWorkerMiddleware } from './enumerationWorkerMiddleware.ts';
 import { enumerateBatchActions } from 'store/entities/enumeration/enumeration.actions.ts';
 import type { EnumerationBatchResult } from 'store/entities/enumeration/enumeration.types.ts';
-import { type CapturedWorker, stubWorker } from 'test/workerStub.ts';
-
-let workers: Array<CapturedWorker>;
+import { createWorkerHarness, itForwardsNonWorkerActions } from 'test/workerStub.ts';
 
 function setup() {
-  const dispatch = vi.fn((action: unknown) => action);
-  const api = { dispatch, getState: vi.fn() } as unknown as MiddlewareAPI;
-  const next = vi.fn((action: unknown) => action);
+  const { workers, dispatch, next, api } = createWorkerHarness();
   const invoke = enumerationWorkerMiddleware(api)(next) as (action: unknown) => unknown;
   return { dispatch, next, invoke, worker: workers[0] };
 }
 
 const batchRequest = { index: 0, data: {}, variables: [], matching: [], templateCSV: { headers: [], content: [] } };
 
-beforeEach(() => {
-  workers = stubWorker();
-});
-
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe('enumerationWorkerMiddleware', () => {
-  it('passes thunk (function) actions straight through without posting to the worker', () => {
-    const { invoke, next, worker } = setup();
-    const thunk = () => undefined;
-    invoke(thunk);
-    expect(next).toHaveBeenCalledWith(thunk);
-    expect(worker.postMessage).not.toHaveBeenCalled();
-  });
+  itForwardsNonWorkerActions(setup);
 
   it('posts the payload to the worker for a batch-request action and forwards it', () => {
     const { invoke, next, worker } = setup();
@@ -56,14 +41,6 @@ describe('enumerationWorkerMiddleware', () => {
     const action = { type: enumerateBatchActions.request.type, payload: batchRequest };
     invoke(action);
     expect(worker.postMessage).toHaveBeenCalledWith(batchRequest);
-    expect(next).toHaveBeenCalledWith(action);
-  });
-
-  it('does not post unrelated actions but still forwards them', () => {
-    const { invoke, next, worker } = setup();
-    const action = { type: 'something/unrelated' };
-    invoke(action);
-    expect(worker.postMessage).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledWith(action);
   });
 

--- a/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
+++ b/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MiddlewareAPI, UnknownAction } from '@reduxjs/toolkit';
+import type { MiddlewareAPI } from '@reduxjs/toolkit';
 import { enumerationWorkerMiddleware } from './enumerationWorkerMiddleware.ts';
 import { enumerateBatchActions } from 'store/entities/enumeration/enumeration.actions.ts';
-import type { EnumerationBatchRequest, EnumerationBatchResult } from 'store/entities/enumeration/enumeration.types.ts';
+import type { EnumerationBatchResult } from 'store/entities/enumeration/enumeration.types.ts';
 
 interface CapturedWorker {
   postMessage: ReturnType<typeof vi.fn>;
@@ -66,15 +66,17 @@ describe('enumerationWorkerMiddleware', () => {
 
   it('posts the payload to the worker for a batch-request action and forwards it', () => {
     const { invoke, next, worker } = setup();
-    const action = enumerateBatchActions.request(batchRequest as unknown as EnumerationBatchRequest);
-    invoke(action as unknown as UnknownAction);
+    // The middleware matches by action.type and forwards payload verbatim, so a
+    // plain {type, payload} literal exercises it without a full request payload.
+    const action = { type: enumerateBatchActions.request.type, payload: batchRequest };
+    invoke(action);
     expect(worker.postMessage).toHaveBeenCalledWith(batchRequest);
     expect(next).toHaveBeenCalledWith(action);
   });
 
   it('does not post unrelated actions but still forwards them', () => {
     const { invoke, next, worker } = setup();
-    const action = { type: 'something/unrelated' } as UnknownAction;
+    const action = { type: 'something/unrelated' };
     invoke(action);
     expect(worker.postMessage).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledWith(action);

--- a/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
+++ b/ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MiddlewareAPI, UnknownAction } from '@reduxjs/toolkit';
+import { enumerationWorkerMiddleware } from './enumerationWorkerMiddleware.ts';
+import { enumerateBatchActions } from 'store/entities/enumeration/enumeration.actions.ts';
+import type { EnumerationBatchRequest, EnumerationBatchResult } from 'store/entities/enumeration/enumeration.types.ts';
+
+interface CapturedWorker {
+  postMessage: ReturnType<typeof vi.fn>;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onerror: ((error: unknown) => void) | null;
+}
+
+let workers: Array<CapturedWorker>;
+
+class MockWorker {
+  postMessage = vi.fn();
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((error: unknown) => void) | null = null;
+  constructor() {
+    workers.push(this);
+  }
+}
+
+function setup() {
+  const dispatch = vi.fn((action: unknown) => action);
+  const api = { dispatch, getState: vi.fn() } as unknown as MiddlewareAPI;
+  const next = vi.fn((action: unknown) => action);
+  const invoke = enumerationWorkerMiddleware(api)(next) as (action: unknown) => unknown;
+  return { dispatch, next, invoke, worker: workers[0] };
+}
+
+const batchRequest = { index: 0, data: {}, variables: [], matching: [], templateCSV: { headers: [], content: [] } };
+
+beforeEach(() => {
+  workers = [];
+  vi.stubGlobal('Worker', MockWorker);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('enumerationWorkerMiddleware', () => {
+  it('passes thunk (function) actions straight through without posting to the worker', () => {
+    const { invoke, next, worker } = setup();
+    const thunk = () => undefined;
+    invoke(thunk);
+    expect(next).toHaveBeenCalledWith(thunk);
+    expect(worker.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('posts the payload to the worker for a batch-request action and forwards it', () => {
+    const { invoke, next, worker } = setup();
+    const action = enumerateBatchActions.request(batchRequest as unknown as EnumerationBatchRequest);
+    invoke(action as unknown as UnknownAction);
+    expect(worker.postMessage).toHaveBeenCalledWith(batchRequest);
+    expect(next).toHaveBeenCalledWith(action);
+  });
+
+  it('does not post unrelated actions but still forwards them', () => {
+    const { invoke, next, worker } = setup();
+    const action = { type: 'something/unrelated' } as UnknownAction;
+    invoke(action);
+    expect(worker.postMessage).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(action);
+  });
+
+  it('dispatches the batch result when the worker posts a message back', () => {
+    const { dispatch, worker } = setup();
+    const result: EnumerationBatchResult = { reactions: ['enc'], errors: [] };
+    worker.onmessage?.({ data: result });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs worker errors without throwing', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const { worker } = setup();
+    expect(() => worker.onerror?.(new Error('boom'))).not.toThrow();
+    expect(infoSpy).toHaveBeenCalledWith('Error in WebWorker', expect.any(Error));
+    infoSpy.mockRestore();
+  });
+});

--- a/ui/src/store/features/previewsWorker/previewsWorkerMiddleware.test.ts
+++ b/ui/src/store/features/previewsWorker/previewsWorkerMiddleware.test.ts
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MiddlewareAPI } from '@reduxjs/toolkit';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { previewsWorkerMiddleware } from './previewsWorkerMiddleware.ts';
 import {
   getReactionActions,
@@ -23,14 +22,10 @@ import {
 } from 'store/entities/reactions/reactions.actions.ts';
 import { getAllTemplatesActions } from 'store/entities/templates/templates.actions.ts';
 import { setPreviewsByIds } from 'store/entities/reactions/reactionsPreviews/reactionsPreviews.actions.ts';
-import { type CapturedWorker, stubWorker } from 'test/workerStub.ts';
-
-let workers: Array<CapturedWorker>;
+import { createWorkerHarness, itForwardsNonWorkerActions } from 'test/workerStub.ts';
 
 function setup() {
-  const dispatch = vi.fn((action: unknown) => action);
-  const api = { dispatch, getState: vi.fn() } as unknown as MiddlewareAPI;
-  const next = vi.fn((action: unknown) => action);
+  const { workers, dispatch, next, api } = createWorkerHarness();
   const invoke = previewsWorkerMiddleware(api)(next) as (action: unknown) => unknown;
   return { dispatch, next, invoke, worker: workers[0] };
 }
@@ -40,22 +35,12 @@ function setup() {
 // without fabricating full DatasetReaction/Pages payloads.
 const action = (type: string, payload: unknown) => ({ type, payload });
 
-beforeEach(() => {
-  workers = stubWorker();
-});
-
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe('previewsWorkerMiddleware', () => {
-  it('passes thunk (function) actions straight through without posting to the worker', () => {
-    const { invoke, next, worker } = setup();
-    const thunk = () => undefined;
-    invoke(thunk);
-    expect(next).toHaveBeenCalledWith(thunk);
-    expect(worker.postMessage).not.toHaveBeenCalled();
-  });
+  itForwardsNonWorkerActions(setup);
 
   it("posts a single reaction action's previews to the worker and forwards the action", () => {
     const { invoke, next, worker } = setup();
@@ -84,14 +69,6 @@ describe('previewsWorkerMiddleware', () => {
     const { invoke, worker } = setup();
     invoke(action(getAllTemplatesActions.success.type, [{ previews: { t1: 'x' } }, { previews: { t2: 'y' } }]));
     expect(worker.postMessage).toHaveBeenCalledWith({ t1: 'x', t2: 'y' });
-  });
-
-  it('does not post unrelated actions but still forwards them', () => {
-    const { invoke, next, worker } = setup();
-    const unrelated = action('something/unrelated', undefined);
-    invoke(unrelated);
-    expect(worker.postMessage).not.toHaveBeenCalled();
-    expect(next).toHaveBeenCalledWith(unrelated);
   });
 
   it('dispatches setPreviewsByIds when the worker posts a result back', () => {

--- a/ui/src/store/features/previewsWorker/previewsWorkerMiddleware.test.ts
+++ b/ui/src/store/features/previewsWorker/previewsWorkerMiddleware.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MiddlewareAPI, UnknownAction } from '@reduxjs/toolkit';
+import { previewsWorkerMiddleware } from './previewsWorkerMiddleware.ts';
+import {
+  getReactionActions,
+  getReactionPageActions,
+  getReactionsListActions,
+} from 'store/entities/reactions/reactions.actions.ts';
+import { getAllTemplatesActions } from 'store/entities/templates/templates.actions.ts';
+import { setPreviewsByIds } from 'store/entities/reactions/reactionsPreviews/reactionsPreviews.actions.ts';
+
+interface CapturedWorker {
+  postMessage: ReturnType<typeof vi.fn>;
+  onmessage: ((event: { data: unknown }) => void) | null;
+}
+
+let workers: Array<CapturedWorker>;
+
+class MockWorker {
+  postMessage = vi.fn();
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  constructor() {
+    workers.push(this);
+  }
+}
+
+function setup() {
+  const dispatch = vi.fn((action: unknown) => action);
+  const api = { dispatch, getState: vi.fn() } as unknown as MiddlewareAPI;
+  const next = vi.fn((action: unknown) => action);
+  const invoke = previewsWorkerMiddleware(api)(next) as (action: unknown) => unknown;
+  return { dispatch, next, invoke, worker: workers[0] };
+}
+
+beforeEach(() => {
+  workers = [];
+  vi.stubGlobal('Worker', MockWorker);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('previewsWorkerMiddleware', () => {
+  it('passes thunk (function) actions straight through without posting to the worker', () => {
+    const { invoke, next, worker } = setup();
+    const thunk = () => undefined;
+    invoke(thunk);
+    expect(next).toHaveBeenCalledWith(thunk);
+    expect(worker.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("posts a single reaction action's previews to the worker and forwards the action", () => {
+    const { invoke, next, worker } = setup();
+    const previews = { r1: 'svgA' };
+    const action = getReactionActions.success({ previews } as unknown as Parameters<
+      typeof getReactionActions.success
+    >[0]);
+    invoke(action as unknown as UnknownAction);
+    expect(worker.postMessage).toHaveBeenCalledWith(previews);
+    expect(next).toHaveBeenCalledWith(action);
+  });
+
+  it('merges previews across items for a reactions-list action', () => {
+    const { invoke, worker } = setup();
+    const action = getReactionsListActions.success({
+      items: [{ previews: { a: '1' } }, { previews: { b: '2' } }],
+    } as unknown as Parameters<typeof getReactionsListActions.success>[0]);
+    invoke(action as unknown as UnknownAction);
+    expect(worker.postMessage).toHaveBeenCalledWith({ a: '1', b: '2' });
+  });
+
+  it('merges previews across items for a reaction-page action', () => {
+    const { invoke, worker } = setup();
+    const action = getReactionPageActions.success({
+      items: [{ previews: { p: '9' } }],
+    } as unknown as Parameters<typeof getReactionPageActions.success>[0]);
+    invoke(action as unknown as UnknownAction);
+    expect(worker.postMessage).toHaveBeenCalledWith({ p: '9' });
+  });
+
+  it('merges previews across templates for a get-all-templates action', () => {
+    const { invoke, worker } = setup();
+    const action = getAllTemplatesActions.success([
+      { previews: { t1: 'x' } },
+      { previews: { t2: 'y' } },
+    ] as unknown as Parameters<typeof getAllTemplatesActions.success>[0]);
+    invoke(action as unknown as UnknownAction);
+    expect(worker.postMessage).toHaveBeenCalledWith({ t1: 'x', t2: 'y' });
+  });
+
+  it('does not post unrelated actions but still forwards them', () => {
+    const { invoke, next, worker } = setup();
+    const action = { type: 'something/unrelated' } as UnknownAction;
+    invoke(action);
+    expect(worker.postMessage).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(action);
+  });
+
+  it('dispatches setPreviewsByIds when the worker posts a result back', () => {
+    const { dispatch, worker } = setup();
+    const previews = { r1: 'rendered' };
+    worker.onmessage?.({ data: previews });
+    expect(dispatch).toHaveBeenCalledWith(setPreviewsByIds(previews));
+  });
+});

--- a/ui/src/store/features/previewsWorker/previewsWorkerMiddleware.test.ts
+++ b/ui/src/store/features/previewsWorker/previewsWorkerMiddleware.test.ts
@@ -23,21 +23,9 @@ import {
 } from 'store/entities/reactions/reactions.actions.ts';
 import { getAllTemplatesActions } from 'store/entities/templates/templates.actions.ts';
 import { setPreviewsByIds } from 'store/entities/reactions/reactionsPreviews/reactionsPreviews.actions.ts';
-
-interface CapturedWorker {
-  postMessage: ReturnType<typeof vi.fn>;
-  onmessage: ((event: { data: unknown }) => void) | null;
-}
+import { type CapturedWorker, stubWorker } from 'test/workerStub.ts';
 
 let workers: Array<CapturedWorker>;
-
-class MockWorker {
-  postMessage = vi.fn();
-  onmessage: ((event: { data: unknown }) => void) | null = null;
-  constructor() {
-    workers.push(this);
-  }
-}
 
 function setup() {
   const dispatch = vi.fn((action: unknown) => action);
@@ -53,8 +41,7 @@ function setup() {
 const action = (type: string, payload: unknown) => ({ type, payload });
 
 beforeEach(() => {
-  workers = [];
-  vi.stubGlobal('Worker', MockWorker);
+  workers = stubWorker();
 });
 
 afterEach(() => {

--- a/ui/src/store/features/previewsWorker/previewsWorkerMiddleware.test.ts
+++ b/ui/src/store/features/previewsWorker/previewsWorkerMiddleware.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MiddlewareAPI, UnknownAction } from '@reduxjs/toolkit';
+import type { MiddlewareAPI } from '@reduxjs/toolkit';
 import { previewsWorkerMiddleware } from './previewsWorkerMiddleware.ts';
 import {
   getReactionActions,
@@ -47,6 +47,11 @@ function setup() {
   return { dispatch, next, invoke, worker: workers[0] };
 }
 
+// The middleware matches by action.type and only reads payload.previews /
+// payload.items, so plain {type, payload} literals exercise it faithfully
+// without fabricating full DatasetReaction/Pages payloads.
+const action = (type: string, payload: unknown) => ({ type, payload });
+
 beforeEach(() => {
   workers = [];
   vi.stubGlobal('Worker', MockWorker);
@@ -68,48 +73,38 @@ describe('previewsWorkerMiddleware', () => {
   it("posts a single reaction action's previews to the worker and forwards the action", () => {
     const { invoke, next, worker } = setup();
     const previews = { r1: 'svgA' };
-    const action = getReactionActions.success({ previews } as unknown as Parameters<
-      typeof getReactionActions.success
-    >[0]);
-    invoke(action as unknown as UnknownAction);
+    const single = action(getReactionActions.success.type, { previews });
+    invoke(single);
     expect(worker.postMessage).toHaveBeenCalledWith(previews);
-    expect(next).toHaveBeenCalledWith(action);
+    expect(next).toHaveBeenCalledWith(single);
   });
 
   it('merges previews across items for a reactions-list action', () => {
     const { invoke, worker } = setup();
-    const action = getReactionsListActions.success({
-      items: [{ previews: { a: '1' } }, { previews: { b: '2' } }],
-    } as unknown as Parameters<typeof getReactionsListActions.success>[0]);
-    invoke(action as unknown as UnknownAction);
+    invoke(
+      action(getReactionsListActions.success.type, { items: [{ previews: { a: '1' } }, { previews: { b: '2' } }] }),
+    );
     expect(worker.postMessage).toHaveBeenCalledWith({ a: '1', b: '2' });
   });
 
   it('merges previews across items for a reaction-page action', () => {
     const { invoke, worker } = setup();
-    const action = getReactionPageActions.success({
-      items: [{ previews: { p: '9' } }],
-    } as unknown as Parameters<typeof getReactionPageActions.success>[0]);
-    invoke(action as unknown as UnknownAction);
+    invoke(action(getReactionPageActions.success.type, { items: [{ previews: { p: '9' } }] }));
     expect(worker.postMessage).toHaveBeenCalledWith({ p: '9' });
   });
 
   it('merges previews across templates for a get-all-templates action', () => {
     const { invoke, worker } = setup();
-    const action = getAllTemplatesActions.success([
-      { previews: { t1: 'x' } },
-      { previews: { t2: 'y' } },
-    ] as unknown as Parameters<typeof getAllTemplatesActions.success>[0]);
-    invoke(action as unknown as UnknownAction);
+    invoke(action(getAllTemplatesActions.success.type, [{ previews: { t1: 'x' } }, { previews: { t2: 'y' } }]));
     expect(worker.postMessage).toHaveBeenCalledWith({ t1: 'x', t2: 'y' });
   });
 
   it('does not post unrelated actions but still forwards them', () => {
     const { invoke, next, worker } = setup();
-    const action = { type: 'something/unrelated' } as UnknownAction;
-    invoke(action);
+    const unrelated = action('something/unrelated', undefined);
+    invoke(unrelated);
     expect(worker.postMessage).not.toHaveBeenCalled();
-    expect(next).toHaveBeenCalledWith(action);
+    expect(next).toHaveBeenCalledWith(unrelated);
   });
 
   it('dispatches setPreviewsByIds when the worker posts a result back', () => {

--- a/ui/src/store/features/previewsWorker/worker.test.ts
+++ b/ui/src/store/features/previewsWorker/worker.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// indigo wraps a WASM structure renderer that can't load under vitest; stub it
+// so the worker's reduce-and-render path runs against predictable output. The
+// real initIndigo() is also a no-op-at-import side effect we don't want here.
+const { initIndigoMock, waitForIndigoMock, renderSvgMock } = vi.hoisted(() => ({
+  initIndigoMock: vi.fn(),
+  waitForIndigoMock: vi.fn(() => Promise.resolve()),
+  renderSvgMock: vi.fn((component: unknown) => `<svg>${String(component)}</svg>`),
+}));
+vi.mock('common/utils/indigo.ts', () => ({
+  initIndigo: initIndigoMock,
+  waitForIndigo: waitForIndigoMock,
+  renderSvg: renderSvgMock,
+}));
+
+// Importing the module calls initIndigo() and assigns the global onmessage handler.
+import './worker.ts';
+
+const handler = globalThis.onmessage as unknown as (event: { data: unknown }) => void;
+
+let postMessageMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  postMessageMock = vi.fn();
+  vi.stubGlobal('postMessage', postMessageMock);
+  renderSvgMock.mockClear();
+  waitForIndigoMock.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('previews worker', () => {
+  it('calls initIndigo once at module load', () => {
+    expect(initIndigoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a message whose data is not an object', () => {
+    handler({ data: 42 });
+    expect(waitForIndigoMock).not.toHaveBeenCalled();
+    expect(postMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('renders every preview to SVG and posts the keyed result', async () => {
+    handler({ data: { a: 'molA', b: 'molB' } });
+    await vi.waitFor(() => expect(postMessageMock).toHaveBeenCalledTimes(1));
+    expect(renderSvgMock).toHaveBeenCalledWith('molA');
+    expect(renderSvgMock).toHaveBeenCalledWith('molB');
+    expect(postMessageMock).toHaveBeenCalledWith({ a: '<svg>molA</svg>', b: '<svg>molB</svg>' });
+  });
+
+  it('posts an empty object for an empty preview map', async () => {
+    handler({ data: {} });
+    await vi.waitFor(() => expect(postMessageMock).toHaveBeenCalledTimes(1));
+    expect(renderSvgMock).not.toHaveBeenCalled();
+    expect(postMessageMock).toHaveBeenCalledWith({});
+  });
+});

--- a/ui/src/test/workerStub.ts
+++ b/ui/src/test/workerStub.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { vi } from 'vitest';
+
+/** A recorded Worker instance: posted messages plus the handlers the middleware assigns. */
+export interface CapturedWorker {
+  postMessage: ReturnType<typeof vi.fn>;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onerror: ((error: unknown) => void) | null;
+}
+
+/**
+ * Replace the global Worker constructor with a recorder for worker-middleware tests.
+ *
+ * Worker (and module workers via `new URL(..., import.meta.url)`) can't run under
+ * vitest, so the stub records each instance the code under test constructs and
+ * exposes its postMessage spy plus the onmessage/onerror handlers the middleware
+ * assigns. Pair with `vi.unstubAllGlobals()` in afterEach to restore the global.
+ *
+ * Returns:
+ *   The array that captures Worker instances in construction order.
+ */
+export function stubWorker(): Array<CapturedWorker> {
+  const workers: Array<CapturedWorker> = [];
+  class MockWorker {
+    postMessage = vi.fn();
+    onmessage: CapturedWorker['onmessage'] = null;
+    onerror: CapturedWorker['onerror'] = null;
+    constructor() {
+      workers.push(this);
+    }
+  }
+  vi.stubGlobal('Worker', MockWorker);
+  return workers;
+}

--- a/ui/src/test/workerStub.ts
+++ b/ui/src/test/workerStub.ts
@@ -13,13 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { vi } from 'vitest';
+import { expect, it, vi } from 'vitest';
+import type { MiddlewareAPI } from '@reduxjs/toolkit';
 
 /** A recorded Worker instance: posted messages plus the handlers the middleware assigns. */
 export interface CapturedWorker {
   postMessage: ReturnType<typeof vi.fn>;
   onmessage: ((event: { data: unknown }) => void) | null;
   onerror: ((error: unknown) => void) | null;
+}
+
+/** Handles a worker-middleware test drives: the recorded worker plus the dispatch/next spies. */
+export interface WorkerMiddlewareHandles {
+  dispatch: ReturnType<typeof vi.fn>;
+  next: ReturnType<typeof vi.fn>;
+  invoke: (action: unknown) => unknown;
+  worker: CapturedWorker;
 }
 
 /**
@@ -45,4 +54,55 @@ export function stubWorker(): Array<CapturedWorker> {
   }
   vi.stubGlobal('Worker', MockWorker);
   return workers;
+}
+
+/**
+ * Stub the Worker global and build the api/next/dispatch spies a worker middleware needs.
+ *
+ * The caller applies its own middleware to the returned ``api``/``next`` so the
+ * middleware's specific dispatch type is preserved. Restore the global with
+ * ``vi.unstubAllGlobals()`` in afterEach.
+ *
+ * Returns:
+ *   The captured-worker array plus the dispatch/next spies and a MiddlewareAPI.
+ */
+export function createWorkerHarness(): {
+  workers: Array<CapturedWorker>;
+  dispatch: ReturnType<typeof vi.fn>;
+  next: ReturnType<typeof vi.fn>;
+  api: MiddlewareAPI;
+} {
+  const workers = stubWorker();
+  const dispatch = vi.fn((action: unknown) => action);
+  const next = vi.fn((action: unknown) => action);
+  const api = { dispatch, getState: vi.fn() } as unknown as MiddlewareAPI;
+  return { workers, dispatch, next, api };
+}
+
+/**
+ * Register the passthrough behavior every worker middleware shares.
+ *
+ * Both worker middlewares forward thunk (function) actions and unrelated actions
+ * to ``next`` without posting to the worker; this declares those two ``it`` cases
+ * once. Call it inside the middleware's ``describe`` block.
+ *
+ * Args:
+ *     setup: Builds fresh handles (stubbed worker + applied middleware) per test.
+ */
+export function itForwardsNonWorkerActions(setup: () => WorkerMiddlewareHandles): void {
+  it('passes thunk (function) actions straight through without posting to the worker', () => {
+    const { invoke, next, worker } = setup();
+    const thunk = () => undefined;
+    invoke(thunk);
+    expect(next).toHaveBeenCalledWith(thunk);
+    expect(worker.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not post unrelated actions but still forwards them', () => {
+    const { invoke, next, worker } = setup();
+    const unrelated = { type: 'unrelated/action' };
+    invoke(unrelated);
+    expect(worker.postMessage).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(unrelated);
+  });
 }


### PR DESCRIPTION
## Summary

Brings the remaining 0%-coverage web-worker infrastructure to **100%** (#662):

- **`previewsWorker/worker.ts`** — drives `onmessage` with `indigo` stubbed: `initIndigo` runs once at load, non-object messages are ignored, every preview is rendered to SVG and posted under its key, and the empty-map case posts `{}`.
- **`previewsWorkerMiddleware.ts`** — with a stubbed `Worker`: thunk passthrough, single-reaction previews post, the list/page item-merge branch, the get-all-templates merge branch, unrelated-action passthrough, and the worker → `setPreviewsByIds` dispatch on message.
- **`enumerationWorkerMiddleware.ts`** — thunk passthrough, batch-request post, unrelated-action passthrough, worker → `enumerateBatchResult` dispatch, and the `onerror` logging path.

All worker/middleware I/O is exercised against mock `Worker`/`postMessage` globals; the indigo WASM renderer and the protobuf-heavy thunks are stubbed so the plumbing logic is tested without their runtime.

## Test plan
- [x] `vitest run` — 16/16 new tests pass; full suite 489/489 green
- [x] All four files (`previewsWorker/worker.ts`, both `*Middleware.ts`) at 100% coverage
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean
- [ ] CI green

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds tests bringing four previously-uncovered worker files to 100% coverage: `previewsWorker/worker.ts`, `previewsWorkerMiddleware.ts`, and `enumerationWorkerMiddleware.ts`, plus a new shared `workerStub.ts` utility.

- **`workerStub.ts`** introduces `stubWorker`, `createWorkerHarness`, and `itForwardsNonWorkerActions` — reusable helpers that capture `MockWorker` instances and register shared passthrough assertions, keeping the per-middleware test files concise.
- **`worker.test.ts`** stubs the WASM indigo renderer via `vi.hoisted` + `vi.mock`, captures `globalThis.onmessage` after import, and verifies the init-once, type-guard, SVG-render, and empty-map paths.
- **Both middleware tests** use `createWorkerHarness` with `vi.unstubAllGlobals()` cleanup; the enumeration middleware test mocks `enumerateBatchResult` to a stable plain action so both the thunk factory call-site and the dispatched value can be asserted precisely.

<h3>Confidence Score: 5/5</h3>

Test-only change; no production code is modified and the new tests pass cleanly against the existing worker implementations.

All four files are new test infrastructure that exercises previously uncovered worker plumbing without touching production code. The dispatch assertions are specific (both call-site and dispatched value verified), mock cleanup is consistent, and the shared harness is used correctly across both middleware tests.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/test/workerStub.ts | New shared test utility: `stubWorker` captures MockWorker instances, `createWorkerHarness` builds dispatch/next spies, and `itForwardsNonWorkerActions` registers reusable passthrough `it` cases. Clean abstractions with correct cleanup via `vi.unstubAllGlobals()`. |
| ui/src/store/features/previewsWorker/worker.test.ts | New tests covering `initIndigo` at module load, non-object message guard, SVG rendering per key, and empty-map case. Correctly stubs `postMessage`/WASM indigo before each test and captures `globalThis.onmessage` at import time. |
| ui/src/store/features/previewsWorker/previewsWorkerMiddleware.test.ts | New middleware tests cover thunk passthrough, single-reaction preview posting, list/page item merge, get-all-templates merge, and worker→`setPreviewsByIds` dispatch round-trip. Assertions are specific and the branching logic is fully exercised. |
| ui/src/store/features/enumerationWorker/enumerationWorkerMiddleware.test.ts | New middleware tests cover thunk passthrough, batch-request post, unrelated-action passthrough, onerror logging, and worker→dispatch round-trip. Addresses the previously flagged weak dispatch assertion by mocking `enumerateBatchResult` to a stable plain action, allowing both the call-site and the dispatched value to be asserted precisely. |

</details>

</details>

<sub>Reviews (5): Last reviewed commit: ["test(ui): assert dispatched batch-result..."](https://github.com/open-reaction-database/ord-app/commit/0bc8e4ce06063483890e92e6e029384eee34e567) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35529376)</sub>

<!-- /greptile_comment -->