### PR TITLE
test(ui): cover useAuth hook — Auth0 flow + no-auth bypass (#662)

### DIFF
--- a/ui/src/common/hooks/useAuth.test.ts
+++ b/ui/src/common/hooks/useAuth.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// noAuth is a module-level constant the hook branches on; expose it through a
+// getter backed by hoisted state so each test can flip the dev/prod path via a
+// live binding (no module reload, which would duplicate React and break hooks).
+const env = vi.hoisted(() => ({ noAuth: false }));
+vi.mock('common/noAuth.constants.ts', () => ({
+  get noAuth() {
+    return env.noAuth;
+  },
+  e2eDevToken: 'dev-token',
+}));
+
+const auth0 = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
+vi.mock('@auth0/auth0-react', () => ({ useAuth0: () => auth0.value }));
+
+// useSelector is wired only to selectSelf here; return the controlled self value
+// directly so no store/Provider is needed.
+const redux = vi.hoisted(() => ({ self: null as unknown }));
+vi.mock('react-redux', () => ({ useSelector: () => redux.self }));
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  setAccessTokenGetter: vi.fn(),
+  createUser: vi.fn((arg: unknown) => ({ type: 'users/createUser', payload: arg })),
+}));
+vi.mock('store/useAppDispatch', () => ({ useAppDispatch: () => mocks.dispatch }));
+vi.mock('store/axiosInstance.ts', () => ({
+  default: {},
+  setAccessTokenGetter: mocks.setAccessTokenGetter,
+  getAccessToken: undefined,
+}));
+vi.mock('store/entities/users/users.thunks', () => ({ createUser: mocks.createUser }));
+
+import { useAuth } from './useAuth.ts';
+
+let loginWithRedirect: ReturnType<typeof vi.fn>;
+let getAccessTokenSilently: ReturnType<typeof vi.fn>;
+let getIdTokenClaims: ReturnType<typeof vi.fn>;
+
+function setAuth0(overrides: Record<string, unknown> = {}): void {
+  auth0.value = {
+    isAuthenticated: false,
+    isLoading: false,
+    user: undefined,
+    loginWithRedirect,
+    getAccessTokenSilently,
+    getIdTokenClaims,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  env.noAuth = false;
+  redux.self = null;
+  loginWithRedirect = vi.fn();
+  getAccessTokenSilently = vi.fn().mockResolvedValue('access-tok');
+  getIdTokenClaims = vi.fn().mockResolvedValue({ __raw: 'id-raw' });
+  mocks.dispatch.mockClear();
+  mocks.setAccessTokenGetter.mockClear();
+  mocks.createUser.mockClear();
+  setAuth0();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useAuth — no-auth dev/E2E bypass', () => {
+  beforeEach(() => {
+    env.noAuth = true;
+  });
+
+  it('registers a dev-token getter and provisions the mock user without redirecting', async () => {
+    await act(async () => {
+      renderHook(() => useAuth());
+    });
+    expect(mocks.setAccessTokenGetter).toHaveBeenCalledTimes(1);
+    const getter = mocks.setAccessTokenGetter.mock.calls[0][0] as () => Promise<string>;
+    await expect(getter()).resolves.toBe('dev-token');
+    expect(mocks.createUser).toHaveBeenCalledWith({ access_token: 'dev-token', id_token: 'dev-token' });
+    expect(mocks.dispatch).toHaveBeenCalledWith({
+      type: 'users/createUser',
+      payload: { access_token: 'dev-token', id_token: 'dev-token' },
+    });
+    expect(loginWithRedirect).not.toHaveBeenCalled();
+  });
+
+  it('reports app-loading until the current user is populated', async () => {
+    const { result, rerender } = renderHook(() => useAuth());
+    expect(result.current).toBe(true);
+    redux.self = { id: 1 };
+    rerender();
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useAuth — Auth0 flow', () => {
+  it('redirects to Auth0 when unauthenticated and not loading', () => {
+    setAuth0({ isAuthenticated: false, isLoading: false });
+    renderHook(() => useAuth());
+    expect(loginWithRedirect).toHaveBeenCalledWith(
+      expect.objectContaining({ appState: expect.objectContaining({ returnTo: expect.any(String) }) }),
+    );
+  });
+
+  it('does not redirect while Auth0 is still loading', () => {
+    setAuth0({ isAuthenticated: false, isLoading: true });
+    renderHook(() => useAuth());
+    expect(loginWithRedirect).not.toHaveBeenCalled();
+  });
+
+  it('registers the silent token getter once authenticated', () => {
+    setAuth0({ isAuthenticated: true });
+    renderHook(() => useAuth());
+    expect(mocks.setAccessTokenGetter).toHaveBeenCalledWith(getAccessTokenSilently);
+  });
+
+  it('provisions the user from the id/access tokens when a user is present', async () => {
+    setAuth0({ isAuthenticated: true, user: { sub: 'auth0|1' } });
+    await act(async () => {
+      renderHook(() => useAuth());
+    });
+    expect(mocks.createUser).toHaveBeenCalledWith({ access_token: 'access-tok', id_token: 'id-raw' });
+    expect(mocks.dispatch).toHaveBeenCalled();
+    expect(loginWithRedirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects when token provisioning throws', async () => {
+    getAccessTokenSilently.mockRejectedValue(new Error('token failure'));
+    setAuth0({ isAuthenticated: true, user: { sub: 'auth0|1' } });
+    await act(async () => {
+      renderHook(() => useAuth());
+    });
+    expect(mocks.createUser).not.toHaveBeenCalled();
+    expect(loginWithRedirect).toHaveBeenCalledWith(
+      expect.objectContaining({ appState: expect.objectContaining({ returnTo: expect.any(String) }) }),
+    );
+  });
+});

--- a/ui/src/common/hooks/useAuth.test.ts
+++ b/ui/src/common/hooks/useAuth.test.ts
@@ -30,10 +30,14 @@ vi.mock('common/noAuth.constants.ts', () => ({
 const auth0 = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
 vi.mock('@auth0/auth0-react', () => ({ useAuth0: () => auth0.value }));
 
-// useSelector is wired only to selectSelf here; return the controlled self value
-// directly so no store/Provider is needed.
+// useSelector runs the real selector against a minimal state shaped to the path
+// selectSelf reads (state.entities.users.self), so the mock honors the selector
+// argument — and would catch a selector-path regression — without a Provider.
 const redux = vi.hoisted(() => ({ self: null as unknown }));
-vi.mock('react-redux', () => ({ useSelector: () => redux.self }));
+vi.mock('react-redux', () => ({
+  useSelector: (selector: (state: { entities: { users: { self: unknown } } }) => unknown) =>
+    selector({ entities: { users: { self: redux.self } } }),
+}));
 
 const mocks = vi.hoisted(() => ({
   dispatch: vi.fn(),
@@ -72,12 +76,12 @@ beforeEach(() => {
   loginWithRedirect = vi.fn();
   getAccessTokenSilently = vi.fn().mockResolvedValue('access-tok');
   getIdTokenClaims = vi.fn().mockResolvedValue({ __raw: 'id-raw' });
-  mocks.dispatch.mockClear();
-  mocks.setAccessTokenGetter.mockClear();
-  mocks.createUser.mockClear();
   setAuth0();
 });
 
+// vi.clearAllMocks() resets the persistent hoisted mocks' call history between
+// tests (their vi.fn implementations are preserved); the per-test Auth0 spies
+// are rebuilt fresh in beforeEach.
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -138,7 +142,10 @@ describe('useAuth — Auth0 flow', () => {
       renderHook(() => useAuth());
     });
     expect(mocks.createUser).toHaveBeenCalledWith({ access_token: 'access-tok', id_token: 'id-raw' });
-    expect(mocks.dispatch).toHaveBeenCalled();
+    expect(mocks.dispatch).toHaveBeenCalledWith({
+      type: 'users/createUser',
+      payload: { access_token: 'access-tok', id_token: 'id-raw' },
+    });
     expect(loginWithRedirect).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Brings `common/hooks/useAuth.ts` from **0% → 100%** coverage (#662). The hook wires up Auth0 login/redirect, the axios silent-token getter, and user provisioning across four effects, branching throughout on the module-level `noAuth` dev/E2E bypass constant.

The test drives it with `renderHook` and controlled mocks for `@auth0/auth0-react`, the redux hooks, the axios token-getter setter, and the `createUser` thunk. `noAuth` is mocked through a **getter backed by hoisted state**, so each test flips the dev/prod path via the live binding — no module reload (which would duplicate React and break the hooks).

Covers both paths:
- **No-auth bypass**: registers a dev-token getter, provisions the mock user, never redirects; and reports app-loading until the current user is populated.
- **Auth0 flow**: redirects when unauthenticated and not loading, stays put while loading, registers the silent token getter once authenticated, provisions the user from the id/access tokens, and redirects when provisioning throws.

## Test plan
- [x] `vitest run` — 7/7 new tests pass; full suite 496/496 green
- [x] `useAuth.ts` at 100% statements/branches/functions/lines
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean
- [ ] CI green

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file covering `useAuth.ts` from 0% to 100%, exercising both the no-auth dev/E2E bypass and the full Auth0 login flow across 7 focused tests.

- The `useSelector` mock correctly executes the real `selectSelf` selector against a minimal state shape (`state.entities.users.self`), so selector-path regressions would surface rather than being silently swallowed.
- All three previous thread findings (weak dispatch assertion, ignoring selector argument, redundant `mockClear` in `beforeEach`) have been addressed in this revision.

<h3>Confidence Score: 5/5</h3>

A pure test addition with no production code changes — safe to merge.

Only useAuth.test.ts is added; no production code is touched. The mocks are carefully scoped, the useSelector stub runs the real selector against a correct minimal state shape, and all previously flagged gaps have been closed. The full suite is reported green at 496/496.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/hooks/useAuth.test.ts | New test file bringing useAuth.ts to 100% coverage across both the no-auth bypass and Auth0 flow paths, with well-structured mocks and selector-honoring useSelector stub. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): tighten useAuth test assertion..."](https://github.com/open-reaction-database/ord-app/commit/fdd5b98fcfbddc8eb56faf493c5959b0026133d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35533401)</sub>

<!-- /greptile_comment -->