### PR TITLE
test(ui): cover buildUseSelectItems hook factories (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseSelectItems.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseSelectItems.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { reactionEntityContext } from 'features/reactions/ReactionEntities/reactionEntity.context.ts';
+import { buildUseSelectItems, buildUseSelectItemsListFromMap } from './buildUseSelectItems.ts';
+
+// selectReactionPartByPath builds the parameterized selector; capture its args
+// to assert the path the hook resolves, and drive the hook's return value
+// through a useSelector mock that ignores the (mocked) selector identity.
+const selectReactionPartByPathMock = vi.hoisted(() =>
+  vi.fn((reactionId: number, path: unknown) => ({ reactionId, path })),
+);
+vi.mock('store/entities/reactions/reactions.selectors.ts', () => ({
+  selectReactionPartByPath: selectReactionPartByPathMock,
+}));
+
+let selectorReturn: unknown;
+vi.mock('react-redux', () => ({ useSelector: () => selectorReturn }));
+
+function contextWrapper(reactionId: number, pathComponents: Array<string | number>) {
+  const Wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
+    <reactionEntityContext.Provider value={{ reactionId, pathComponents }}>{children}</reactionEntityContext.Provider>
+  );
+  Wrapper.displayName = 'ContextWrapper';
+  return Wrapper;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  selectorReturn = undefined;
+});
+
+describe('buildUseSelectItems', () => {
+  it('wraps a string entityPath into a single path segment appended to the context path', () => {
+    selectorReturn = 'value-x';
+    const { result } = renderHook(() => buildUseSelectItems('amount')(), {
+      wrapper: contextWrapper(5, ['inputs', 0]),
+    });
+    expect(selectReactionPartByPathMock).toHaveBeenCalledWith(5, ['inputs', 0, 'amount']);
+    expect(result.current).toBe('value-x');
+  });
+
+  it('appends an array entityPath verbatim to the context path', () => {
+    selectorReturn = { some: 'object' };
+    renderHook(() => buildUseSelectItems(['conditions', 'temperature'])(), {
+      wrapper: contextWrapper(5, ['setup']),
+    });
+    expect(selectReactionPartByPathMock).toHaveBeenCalledWith(5, ['setup', 'conditions', 'temperature']);
+  });
+});
+
+interface OrderedItem {
+  id: string;
+  order: number;
+}
+
+describe('buildUseSelectItemsListFromMap', () => {
+  const byOrder = (a: OrderedItem, b: OrderedItem) => a.order - b.order;
+
+  it('resolves the entity map under the context path and returns its values sorted', () => {
+    selectorReturn = { x: { id: 'x', order: 2 }, y: { id: 'y', order: 1 } };
+    const { result } = renderHook(() => buildUseSelectItemsListFromMap<OrderedItem>('components', byOrder)(), {
+      wrapper: contextWrapper(5, ['inputs']),
+    });
+    expect(selectReactionPartByPathMock).toHaveBeenCalledWith(5, ['inputs', 'components']);
+    expect(result.current).toEqual([
+      { id: 'y', order: 1 },
+      { id: 'x', order: 2 },
+    ]);
+  });
+
+  it('memoizes the sorted list while the underlying map reference is unchanged', () => {
+    selectorReturn = { a: { id: 'a', order: 1 } };
+    const { result, rerender } = renderHook(
+      () => buildUseSelectItemsListFromMap<OrderedItem>('components', byOrder)(),
+      {
+        wrapper: contextWrapper(5, ['inputs']),
+      },
+    );
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary

Brings `entityFormConfiguration/buildUseSelectItems.ts` from **0% → 100%** (#662). Both exports are hook factories over `reactionEntityContext` + a parameterized selector.

Renders the produced hooks with a `reactionEntityContext` Provider and a mocked `useSelector`, asserting:
- **`buildUseSelectItems`** wraps a string `entityPath` into one segment and appends an array `entityPath` verbatim, both onto the context `pathComponents`, and returns the selected value.
- **`buildUseSelectItemsListFromMap`** resolves the entity map under the context path, returns `Object.values` sorted by the supplied comparator, and memoizes the sorted list while the underlying map reference is unchanged.

## Test plan
- [x] `vitest run` — 4/4 new tests pass; full suite 500/500 green
- [x] `buildUseSelectItems.ts` at 100% coverage
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean
- [ ] CI green

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file for `buildUseSelectItems.ts`, bringing it from 0% to 100% coverage with four focused unit tests for both exported hook factories.

- **`buildUseSelectItems`**: Two tests verify that a string `entityPath` is wrapped into a single path segment and an array `entityPath` is appended verbatim, both correctly combined with the `reactionEntityContext` path components before being passed to the selector.
- **`buildUseSelectItemsListFromMap`**: Two tests confirm that the entity map is resolved under the context path with `Object.values` sorted by the supplied comparator, and that `useMemo` returns a stable reference across re-renders when the underlying map reference is unchanged.

<h3>Confidence Score: 5/5</h3>

Pure test addition with no production code changes; safe to merge.

This PR adds only a test file. The mocking strategy is sound — vi.hoisted is used correctly for the selector mock, the useSelector mock captures the module-level selectorReturn reference safely, and the context wrapper provides a realistic reactionEntityContext value. The memoization test verifies reference stability correctly. The afterEach cleanup prevents state leaking between tests. No production code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseSelectItems.test.tsx | New test file bringing buildUseSelectItems.ts from 0% to 100% coverage; 4 tests correctly exercise path-building, return value forwarding, and useMemo memoization with stable mock setup |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover buildUseSelectItems hook..."](https://github.com/open-reaction-database/ord-app/commit/dd43f6ac003c00eb9a36b9f77fc04afe608e3b60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35535042)</sub>

<!-- /greptile_comment -->