### PR TITLE
fix(ui): guard null payload in previews worker onmessage

### DIFF
--- a/ui/src/store/features/previewsWorker/worker.test.ts
+++ b/ui/src/store/features/previewsWorker/worker.test.ts
@@ -58,6 +58,12 @@ describe('previews worker', () => {
     expect(postMessageMock).not.toHaveBeenCalled();
   });
 
+  it('ignores a null payload (typeof null === "object") instead of throwing', () => {
+    handler({ data: null });
+    expect(waitForIndigoMock).not.toHaveBeenCalled();
+    expect(postMessageMock).not.toHaveBeenCalled();
+  });
+
   it('renders every preview to SVG and posts the keyed result', async () => {
     handler({ data: { a: 'molA', b: 'molB' } });
     await vi.waitFor(() => expect(postMessageMock).toHaveBeenCalledTimes(1));

--- a/ui/src/store/features/previewsWorker/worker.ts
+++ b/ui/src/store/features/previewsWorker/worker.ts
@@ -19,7 +19,9 @@ import { initIndigo, renderSvg, waitForIndigo } from 'common/utils/indigo.ts';
 initIndigo();
 
 onmessage = event => {
-  if (typeof event.data !== 'object') {
+  // typeof null === 'object', so guard null explicitly — otherwise Object.entries(null)
+  // below would throw a TypeError inside the waitForIndigo() callback.
+  if (typeof event.data !== 'object' || event.data === null) {
     return;
   }
 


### PR DESCRIPTION
## Summary

`previewsWorker/worker.ts` guarded its `onmessage` handler with `typeof event.data !== 'object'`. Because `typeof null === 'object'`, a `null` payload slips past and reaches `Object.entries(null)`, which throws a `TypeError` inside the `waitForIndigo().then(...)` callback (an unhandled rejection). This adds an explicit `|| event.data === null` check.

**Not reachable today** — `previewsWorkerMiddleware` only ever calls `worker.postMessage(...)` with preview-map objects — so this is a defensive one-line fix, not an active-bug fix. Flagged by Greptile during the worker-plumbing test backfill ([#709](https://github.com/open-reaction-database/ord-app/pull/709)).

Adds a regression test asserting a `null` payload is ignored (no render, no `postMessage`); `worker.ts` stays at 100% line + branch coverage.

> ⚠️ This touches production code (behavioral), so per our gate it's **held for your review** rather than auto-merged.

## Test plan
- [x] `vitest run` — 5/5 pass (incl. new null case); `worker.ts` 100% lines + branches
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a defensive guard in `previewsWorker/worker.ts` by adding an explicit `null` check alongside the existing `typeof !== 'object'` guard, preventing a `TypeError` from `Object.entries(null)` if a null payload were ever posted to the worker.

- **`worker.ts`**: Extends the early-return condition from `typeof event.data !== 'object'` to `typeof event.data !== 'object' || event.data === null`, with an inline comment explaining the `typeof null === 'object'` JavaScript quirk.
- **`worker.test.ts`**: Adds a targeted regression test verifying that a `null` payload exits early without calling `waitForIndigo` or `postMessage`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-scoped defensive fix with a targeted regression test and no behavioral change on the current code path.

The change is a single-condition addition to an existing guard. The fix correctly addresses the typeof null === 'object' JavaScript quirk, the inline comment explains the rationale clearly, and the new test directly covers the previously unguarded branch. No logic is altered for valid (non-null object) payloads.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/features/previewsWorker/worker.ts | Adds `|| event.data === null` to the early-return guard, preventing `Object.entries(null)` from throwing a TypeError on a null payload; one-line change with an explanatory comment. |
| ui/src/store/features/previewsWorker/worker.test.ts | Adds a focused regression test asserting that a null payload causes an early return without invoking waitForIndigo or postMessage; all other test cases are unchanged. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): guard null payload in previews ..."](https://github.com/open-reaction-database/ord-app/commit/84e94d14dcd66d26b74846049cbac56bc7289064) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35535656)</sub>

<!-- /greptile_comment -->