### PR TITLE
test(ui): cover reactions.utils path/preview/validation helpers (#662)

### DIFF
--- a/ui/src/store/entities/reactions/reactions.utils.test.ts
+++ b/ui/src/store/entities/reactions/reactions.utils.test.ts
@@ -19,8 +19,12 @@ import {
   deepMergeWithArrayMerge,
   generateDeepPartialReactionByPath,
   getDeepReactionPart,
+  getReactionPreviews,
+  parseValidation,
+  reactionFlatPathToSidebars,
   removeDeepReactionPart,
 } from './reactions.utils.ts';
+import type { AppReaction, ReactionMolBlocks, OrdValidation } from './reactions.types.ts';
 
 describe('generateDeepPartialReactionByPath', () => {
   it('returns the value directly for an empty path', () => {
@@ -116,5 +120,91 @@ describe('deepMergeWithArrayMerge', () => {
     const target = { a: { x: 1 }, list: [{ k: 1 }] };
     deepMergeWithArrayMerge(target, { a: { y: 2 }, list: [{ j: 2 }] });
     expect(target).toEqual({ a: { x: 1 }, list: [{ k: 1 }] });
+  });
+});
+
+describe('reactionFlatPathToSidebars', () => {
+  it('expands a collection entity plus its index into one sidebar path, nesting deeper collections', () => {
+    expect(reactionFlatPathToSidebars(['inputs', 0, 'components', 1])).toEqual([
+      ['inputs', 0],
+      ['inputs', 0, 'components', 1],
+    ]);
+  });
+
+  it('treats collection-less entities (e.g. conditions) as a single segment with no index skip', () => {
+    expect(reactionFlatPathToSidebars(['conditions', 'temperatureMeasurements', 0])).toEqual([
+      ['conditions'],
+      ['conditions', 'temperatureMeasurements', 0],
+    ]);
+  });
+
+  it('ignores path components that are neither collection-less entities nor known collections', () => {
+    expect(reactionFlatPathToSidebars(['notAnEntity', 3])).toEqual([]);
+  });
+});
+
+describe('getReactionPreviews', () => {
+  it('maps molblocks onto component/product/measurement/workup ids across inputs, outcomes, and workups', () => {
+    const reaction = {
+      inputs: { in1: { name: 'reagentA', components: [{ id: 'comp1' }] } },
+      outcomes: [{ products: [{ id: 'prod1', measurements: [{ authenticStandard: { id: 'auth1' } }] }] }],
+      workups: [{ input: { components: [{ id: 'wcomp1' }] } }],
+    } as unknown as AppReaction;
+    const molblocks = {
+      inputs: { reagentA: ['COMP1_MB'] },
+      outcomes: [
+        { products: [{ molblock: 'PROD1_MB', measurements: [{ authentic_standard: { molblock: 'AUTH1_MB' } }] }] },
+      ],
+      workups: [['WCOMP1_MB']],
+    } as unknown as ReactionMolBlocks;
+
+    expect(getReactionPreviews(reaction, molblocks)).toEqual({
+      comp1: 'COMP1_MB',
+      prod1: 'PROD1_MB',
+      auth1: 'AUTH1_MB',
+      wcomp1: 'WCOMP1_MB',
+    });
+  });
+
+  it('skips measurements without an authentic standard and workups whose input has no components', () => {
+    const reaction = {
+      inputs: {},
+      outcomes: [{ products: [{ id: 'prod1', measurements: [{ authenticStandard: undefined }] }] }],
+      workups: [{ input: undefined }],
+    } as unknown as AppReaction;
+    const molblocks = {
+      inputs: {},
+      outcomes: [{ products: [{ molblock: 'PROD1_MB', measurements: [{ authentic_standard: { molblock: 'X' } }] }] }],
+      workups: [['UNUSED_MB']],
+    } as unknown as ReactionMolBlocks;
+
+    expect(getReactionPreviews(reaction, molblocks)).toEqual({ prod1: 'PROD1_MB' });
+  });
+});
+
+describe('parseValidation', () => {
+  const reaction = {
+    inputs: { in1: { name: 'reagentA', id: 'input-id-1', components: [] } },
+  } as unknown as AppReaction;
+
+  it('returns plain text for a message with no path separator', () => {
+    const result = parseValidation({ errors: [], warnings: ['just a warning'] } as OrdValidation, reaction);
+    expect(result.warnings).toEqual([{ text: 'just a warning' }]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('strips the protobuf class prefix and resolves a name in the path to its id', () => {
+    const validation = {
+      errors: ['<class \'ord.Reaction\'> inputs["reagentA"].value: bad value'],
+      warnings: [],
+    } as OrdValidation;
+    expect(parseValidation(validation, reaction).errors).toEqual([
+      { text: ' bad value', path: ['inputs', 'input-id-1', 'value'], originalPath: 'inputs.reagentA.value' },
+    ]);
+  });
+
+  it('falls back to the raw text when the path cannot be resolved', () => {
+    const validation = { errors: ['inputs["ghost"].value: orphaned'], warnings: [] } as OrdValidation;
+    expect(parseValidation(validation, reaction).errors).toEqual([{ text: 'inputs["ghost"].value: orphaned' }]);
   });
 });


### PR DESCRIPTION
## Summary

Extends `reactions.utils.test.ts` to the previously untested **pure** helpers, taking `reactions.utils.ts` from **45% → ~89% lines** (96.66% branches):

- **`reactionFlatPathToSidebars`** — collection entity + index expansion (nesting deeper collections), collection-less entities (`conditions`) as a single segment with no index skip, and ignoring path components that are neither.
- **`getReactionPreviews`** — maps molblocks onto component / product / measurement / workup ids across inputs, outcomes, and workups; plus the skip paths (a measurement without an authentic standard, a workup whose `input` has no components).
- **`parseValidation`** — plain text when there's no path separator, protobuf class-prefix stripping with name→id path resolution, and the raw-text fallback when the path can't be resolved.

`parseReaction` / `parseReactionList` (protobuf-decode orchestration) are deferred to a follow-up that mocks the `ord` decode chain.

## Test plan
- [x] `vitest run` — 28/28 in this file pass (8 new); full suite 508/508 green
- [x] `reactions.utils.ts` 45% → 89.2% lines, 96.66% branches
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends `reactions.utils.test.ts` with 8 new unit tests covering three previously-untested pure helpers, pushing line coverage from ~45 % to ~89 % and branch coverage to ~97 %.

- **`reactionFlatPathToSidebars`** — tests collection-plus-index expansion, collection-less entity pass-through (`conditions`/`temperatureMeasurements`), and the fall-through for unknown path components.
- **`getReactionPreviews`** — covers the full mapping of molblocks to component/product/measurement/workup ids and the two skip conditions (no `authenticStandard`, no `input.components`).
- **`parseValidation`** — validates plain-text passthrough, protobuf class-prefix stripping with name→id resolution, and the raw-text fallback when path resolution throws.

<h3>Confidence Score: 5/5</h3>

Test-only change with no modifications to production code; safe to merge.

All new test assertions were traced against the implementation and match the expected output exactly. The test fixtures exercise the right conditional branches including skipping workups with no input, skipping measurements with no authenticStandard, and the replaceNameIdInReactionComponentPath throw path. No production code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.utils.test.ts | Adds 8 new test cases covering reactionFlatPathToSidebars, getReactionPreviews, and parseValidation; assertions are correct and match the implementation's behavior end-to-end. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover reactions.utils path/pre..."](https://github.com/open-reaction-database/ord-app/commit/c02e44f91c1879642efb954a03b8cf10d6176162) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35536277)</sub>

<!-- /greptile_comment -->