### PR TITLE
test(ui): cover reactions.converters orchestrators (#662)

### DIFF
--- a/ui/src/store/entities/reactions/reactions.converters.test.ts
+++ b/ui/src/store/entities/reactions/reactions.converters.test.ts
@@ -13,8 +13,58 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect } from 'vitest';
-import { convertReactionFloatsToDoubles } from './reactions.converters.ts';
+import { describe, it, expect, vi } from 'vitest';
+
+// ordReactionToReaction/reactionToOrdReaction/linkReactionEntities are thin
+// orchestrators delegating each field to a per-entity sub-converter. Stub every
+// sub-converter with a recognizable sentinel so the tests assert the field
+// wiring and the length-gated null branches without the sub-converters' logic.
+vi.mock('store/entities/reactions/reactionsInputs/reactionsInputs.converters.ts', () => ({
+  ordInputsToReactionInputs: () => 'INPUTS',
+  reactionInputsToOrdInputs: () => 'ORD_INPUTS',
+}));
+vi.mock('store/entities/reactions/reactionsOutcomes/reactionOutcomes.converters.ts', () => ({
+  linkReactionOutcome: (outcome: unknown) => ({ linked: outcome }),
+  ordOutcomesListToReactionOutcomesList: () => 'OUTCOMES',
+  reactionOutcomesListToOrdOutcomesList: () => 'ORD_OUTCOMES',
+}));
+vi.mock('store/entities/reactions/reactionEntity/reactionEntity.converters.ts', () => ({
+  ordReactionIdentifierToReaction: (identifier: unknown) => ({ id: identifier }),
+  reactionIdentifierToOrd: (identifier: unknown) => ({ ordId: identifier }),
+}));
+vi.mock('store/entities/reactions/reactionNotes/reactionNotes.converters.ts', () => ({
+  ordNotesToReaction: () => 'NOTES',
+  reactionNotesToOrd: () => 'ORD_NOTES',
+}));
+vi.mock('./reactionObservation/reactionObservation.converter', () => ({
+  ordObservationToReaction: (observation: unknown) => ({ obs: observation }),
+  reactionObservationToOrd: (observation: unknown) => ({ ordObs: observation }),
+}));
+vi.mock('./reactionProvenance/reactionProvenance.converters.ts', () => ({
+  ordProvenanceToReaction: () => 'PROVENANCE',
+  reactionProvenanceToOrd: () => 'ORD_PROVENANCE',
+}));
+vi.mock('./reactionConditions/reactionConditions.converter', () => ({
+  ordConditionsToReaction: () => 'CONDITIONS',
+  reactionConditionsToOrd: () => 'ORD_CONDITIONS',
+}));
+vi.mock('./reactionWorkups/reactionWorkups.converters.ts', () => ({
+  ordWorkupToReaction: (workup: unknown) => ({ wu: workup }),
+  reactionWorkupToOrd: (workup: unknown) => ({ ordWu: workup }),
+}));
+vi.mock('./reactionSetup/reactionSetup.converter.ts', () => ({
+  ordSetupToReactionSetup: () => 'SETUP',
+  reactionSetupToOrd: () => 'ORD_SETUP',
+}));
+
+import type { AppReaction } from './reactions.types.ts';
+import type { ord } from 'ord-schema-protobufjs';
+import {
+  convertReactionFloatsToDoubles,
+  linkReactionEntities,
+  ordReactionToReaction,
+  reactionToOrdReaction,
+} from './reactions.converters.ts';
 
 describe('convertReactionFloatsToDoubles', () => {
   it('rounds floats to 7 significant figures in place', () => {
@@ -51,5 +101,109 @@ describe('convertReactionFloatsToDoubles', () => {
   it('is a no-op for null or non-object input', () => {
     expect(() => convertReactionFloatsToDoubles(null)).not.toThrow();
     expect(() => convertReactionFloatsToDoubles(5)).not.toThrow();
+  });
+});
+
+describe('ordReactionToReaction', () => {
+  it('spreads the proto and routes each field through its sub-converter', () => {
+    const reaction = {
+      reactionId: 'r1',
+      extra: 'preserved',
+      inputs: { a: 1 },
+      outcomes: ['o1'],
+      identifiers: ['i1', 'i2'],
+      setup: { s: 1 },
+      observations: ['ob1'],
+      conditions: { c: 1 },
+      notes: { n: 1 },
+      provenance: { p: 1 },
+      workups: ['w1'],
+    } as unknown as ord.IReaction;
+
+    expect(ordReactionToReaction(reaction)).toEqual({
+      reactionId: 'r1',
+      extra: 'preserved',
+      inputs: 'INPUTS',
+      outcomes: 'OUTCOMES',
+      identifiers: [{ id: 'i1' }, { id: 'i2' }],
+      setup: 'SETUP',
+      observations: [{ obs: 'ob1' }],
+      conditions: 'CONDITIONS',
+      notes: 'NOTES',
+      provenance: 'PROVENANCE',
+      workups: [{ wu: 'w1' }],
+    });
+  });
+
+  it('defaults missing list fields to empty arrays', () => {
+    const result = ordReactionToReaction({ reactionId: 'r2' } as unknown as ord.IReaction);
+    expect(result.identifiers).toEqual([]);
+    expect(result.observations).toEqual([]);
+    expect(result.workups).toEqual([]);
+  });
+});
+
+describe('reactionToOrdReaction', () => {
+  const base = {
+    reactionId: 'r1',
+    inputs: {},
+    outcomes: [],
+    setup: {},
+    conditions: {},
+    notes: {},
+    provenance: {},
+  };
+
+  it('nulls the list fields that are empty and routes the rest through sub-converters', () => {
+    const result = reactionToOrdReaction({
+      ...base,
+      identifiers: [],
+      observations: [],
+      workups: [],
+    } as unknown as AppReaction);
+
+    expect(result).toEqual({
+      reactionId: 'r1',
+      inputs: 'ORD_INPUTS',
+      outcomes: 'ORD_OUTCOMES',
+      identifiers: null,
+      setup: 'ORD_SETUP',
+      observations: null,
+      conditions: 'ORD_CONDITIONS',
+      notes: 'ORD_NOTES',
+      provenance: 'ORD_PROVENANCE',
+      workups: null,
+    });
+  });
+
+  it('maps non-empty list fields through their sub-converters', () => {
+    const result = reactionToOrdReaction({
+      ...base,
+      identifiers: ['i1'],
+      observations: ['ob1'],
+      workups: ['w1'],
+    } as unknown as AppReaction);
+
+    expect(result.identifiers).toEqual([{ ordId: 'i1' }]);
+    expect(result.observations).toEqual([{ ordObs: 'ob1' }]);
+    expect(result.workups).toEqual([{ ordWu: 'w1' }]);
+  });
+});
+
+describe('linkReactionEntities', () => {
+  it('links every outcome while preserving the rest of the reaction', () => {
+    const reaction = {
+      reactionId: 'r1',
+      extra: 'preserved',
+      inputs: { a: 1 },
+      outcomes: ['o1', 'o2'],
+    } as unknown as AppReaction;
+
+    expect(linkReactionEntities(reaction)).toEqual({
+      reactionId: 'r1',
+      extra: 'preserved',
+      inputs: { a: 1 },
+      outcomes: [{ linked: 'o1' }, { linked: 'o2' }],
+    });
   });
 });


### PR DESCRIPTION
## Summary

Takes `reactions.converters.ts` from **49% → 100%**. The three orchestrators delegate each reaction field to a per-entity sub-converter, so the sub-converters are stubbed with sentinels and the tests assert the field wiring + the length-gated `null` branches:

- **`ordReactionToReaction`** — spreads the proto and routes every field through its sub-converter; missing list fields default to empty arrays.
- **`reactionToOrdReaction`** — nulls empty `identifiers`/`observations`/`workups` and maps the non-empty case through their sub-converters; other fields routed.
- **`linkReactionEntities`** — links every outcome while preserving the rest of the reaction.

## Test plan
- [x] `vitest run` — 11/11 in this file pass (5 new); full suite green
- [x] `reactions.converters.ts` 49% → 100% lines/branches/functions
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends the existing `reactions.converters.test.ts` to cover the three orchestrator functions — `ordReactionToReaction`, `reactionToOrdReaction`, and `linkReactionEntities` — bringing line/branch/function coverage to 100%.

- All sub-converters are stubbed with `vi.mock` sentinels so the tests exclusively assert field-wiring and the length-gated `null` branches in `reactionToOrdReaction`, with mock module paths matching the source imports exactly.
- The `ordReactionToReaction` suite covers both the full-field routing case and the fallback-to-empty-array case for missing list fields; `linkReactionEntities` verifies that non-outcome fields are preserved via the spread.

<h3>Confidence Score: 5/5</h3>

Pure test-only change; no production code is modified and all new tests correctly mirror the implementation logic.

Every mock path matches the corresponding import in the source file, the sentinel strategy isolates orchestrator wiring from sub-converter logic, and the branch coverage for the ternary null checks is complete. No production code was touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.converters.test.ts | Adds 5 new test cases for the three orchestrator functions (ordReactionToReaction, reactionToOrdReaction, linkReactionEntities) using vi.mock sentinels; all mock module paths match the source file's import statements exactly |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover reactions.converters orc..."](https://github.com/open-reaction-database/ord-app/commit/f87e302b8f03b75b8fad39afdbe130def17738f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35536865)</sub>

<!-- /greptile_comment -->