### PR TITLE
test(ui): cover parseReaction/parseReactionList in reactions.utils (#662)

### DIFF
--- a/ui/src/store/entities/reactions/reactions.utils.test.ts
+++ b/ui/src/store/entities/reactions/reactions.utils.test.ts
@@ -231,52 +231,50 @@ describe('parseValidation', () => {
   });
 });
 
-describe('parseReaction', () => {
-  const molblocks = { inputs: {}, outcomes: [], workups: [] } as unknown as ReactionMolBlocks;
+// Real ReactionResponse field names so the pass-through assertions are a faithful
+// spec; binpb/molblocks/summary still need a cast (decode + render are stubbed).
+const reactionResponse = (id: number, validation: ReactionResponse['validation'] = null) =>
+  ({
+    id,
+    pb_reaction_id: `rx${id}`,
+    is_valid: true,
+    summary: {},
+    binpb: 'AAEC',
+    molblocks: { inputs: {}, outcomes: [], workups: [] },
+    validation,
+  }) as unknown as ReactionResponse;
 
-  it('decodes the protobuf, attaches previews, and keeps remaining fields with null validation', () => {
-    const response = { binpb: 'AAEC', molblocks, validation: null, reactionId: 'rx1', isValid: true };
-    expect(parseReaction(response as unknown as ReactionResponse)).toEqual({
-      reactionId: 'rx1',
-      isValid: true,
-      previews: {},
-      data: { inputs: {}, outcomes: [], workups: [] },
-      validation: null,
-    });
+describe('parseReaction', () => {
+  it('decodes the protobuf, attaches previews, and preserves the response fields with null validation', () => {
+    const result = parseReaction(reactionResponse(1));
+    expect(result.id).toBe(1);
+    expect(result.pb_reaction_id).toBe('rx1');
+    expect(result.is_valid).toBe(true);
+    expect(result.previews).toEqual({});
+    expect(result.data).toEqual({ inputs: {}, outcomes: [], workups: [] });
+    expect(result.validation).toBeNull();
   });
 
   it('parses validation when present', () => {
-    const response = {
-      binpb: 'AAEC',
-      molblocks,
-      validation: { errors: ['plain error'], warnings: [] },
-      reactionId: 'rx2',
-    };
-    expect(parseReaction(response as unknown as ReactionResponse).validation).toEqual({
-      errors: [{ text: 'plain error' }],
-      warnings: [],
-    });
+    const result = parseReaction(reactionResponse(2, { errors: ['plain error'], warnings: [] }));
+    expect(result.validation).toEqual({ errors: [{ text: 'plain error' }], warnings: [] });
   });
 });
 
 describe('parseReactionList', () => {
-  it('wraps every item with parseReaction while preserving pagination', () => {
-    const molblocks = { inputs: {}, outcomes: [], workups: [] };
+  it('maps every item through parseReaction in order while preserving pagination', () => {
     const pages = {
       page: 1,
       size: 10,
       total: 2,
-      items: [
-        { binpb: 'AAEC', molblocks, validation: null, reactionId: 'rx1' },
-        { binpb: 'AAEC', molblocks, validation: null, reactionId: 'rx2' },
-      ],
+      items: [reactionResponse(1), reactionResponse(2)],
     } as unknown as Pages<ReactionResponse>;
 
     const result = parseReactionList(pages);
     expect(result.page).toBe(1);
     expect(result.total).toBe(2);
-    expect(result.items).toHaveLength(2);
+    expect(result.items.map(item => item.id)).toEqual([1, 2]);
+    expect(result.items.map(item => item.pb_reaction_id)).toEqual(['rx1', 'rx2']);
     expect(result.items[0].previews).toEqual({});
-    expect(result.items[1].data).toEqual({ inputs: {}, outcomes: [], workups: [] });
   });
 });

--- a/ui/src/store/entities/reactions/reactions.utils.test.ts
+++ b/ui/src/store/entities/reactions/reactions.utils.test.ts
@@ -13,18 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// parseReaction orchestrates protobuf decode → app reaction → previews/validation.
+// Stub the decode + ord→app converter so the test exercises parseReaction's own
+// assembly (previews via the real getReactionPreviews, validation passthrough)
+// without a real binpb fixture. getReactionPreviews/parseValidation stay real.
+// Keep the real ord namespace (other modules read ord.ReactionRole etc. at load)
+// and override only the two decode helpers parseReaction calls.
+vi.mock('ord-schema-protobufjs', async importActual => {
+  const actual = (await importActual()) as { ord: Record<string, unknown> } & Record<string, unknown>;
+  return {
+    ...actual,
+    ord: { ...actual.ord, Reaction: { decode: vi.fn(() => ({})), toObject: vi.fn(() => ({})) } },
+  };
+});
+vi.mock('./reactions.converters.ts', () => ({
+  ordReactionToReaction: vi.fn(() => ({ inputs: {}, outcomes: [], workups: [] })),
+  convertReactionFloatsToDoubles: vi.fn(),
+}));
+
 import {
   convertObjectToNullIfEmpty,
   deepMergeWithArrayMerge,
   generateDeepPartialReactionByPath,
   getDeepReactionPart,
   getReactionPreviews,
+  parseReaction,
+  parseReactionList,
   parseValidation,
   reactionFlatPathToSidebars,
   removeDeepReactionPart,
 } from './reactions.utils.ts';
-import type { AppReaction, ReactionMolBlocks, OrdValidation } from './reactions.types.ts';
+import type { AppReaction, ReactionMolBlocks, OrdValidation, ReactionResponse } from './reactions.types.ts';
+import type { Pages } from 'common/types';
 
 describe('generateDeepPartialReactionByPath', () => {
   it('returns the value directly for an empty path', () => {
@@ -206,5 +228,55 @@ describe('parseValidation', () => {
   it('falls back to the raw text when the path cannot be resolved', () => {
     const validation = { errors: ['inputs["ghost"].value: orphaned'], warnings: [] } as OrdValidation;
     expect(parseValidation(validation, reaction).errors).toEqual([{ text: 'inputs["ghost"].value: orphaned' }]);
+  });
+});
+
+describe('parseReaction', () => {
+  const molblocks = { inputs: {}, outcomes: [], workups: [] } as unknown as ReactionMolBlocks;
+
+  it('decodes the protobuf, attaches previews, and keeps remaining fields with null validation', () => {
+    const response = { binpb: 'AAEC', molblocks, validation: null, reactionId: 'rx1', isValid: true };
+    expect(parseReaction(response as unknown as ReactionResponse)).toEqual({
+      reactionId: 'rx1',
+      isValid: true,
+      previews: {},
+      data: { inputs: {}, outcomes: [], workups: [] },
+      validation: null,
+    });
+  });
+
+  it('parses validation when present', () => {
+    const response = {
+      binpb: 'AAEC',
+      molblocks,
+      validation: { errors: ['plain error'], warnings: [] },
+      reactionId: 'rx2',
+    };
+    expect(parseReaction(response as unknown as ReactionResponse).validation).toEqual({
+      errors: [{ text: 'plain error' }],
+      warnings: [],
+    });
+  });
+});
+
+describe('parseReactionList', () => {
+  it('wraps every item with parseReaction while preserving pagination', () => {
+    const molblocks = { inputs: {}, outcomes: [], workups: [] };
+    const pages = {
+      page: 1,
+      size: 10,
+      total: 2,
+      items: [
+        { binpb: 'AAEC', molblocks, validation: null, reactionId: 'rx1' },
+        { binpb: 'AAEC', molblocks, validation: null, reactionId: 'rx2' },
+      ],
+    } as unknown as Pages<ReactionResponse>;
+
+    const result = parseReactionList(pages);
+    expect(result.page).toBe(1);
+    expect(result.total).toBe(2);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].previews).toEqual({});
+    expect(result.items[1].data).toEqual({ inputs: {}, outcomes: [], workups: [] });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the `reactions.utils` backfill ([#713](https://github.com/open-reaction-database/ord-app/pull/713)): covers the protobuf-decode orchestrators, taking `reactions.utils.ts` to **~97% lines/branches**.

The `ord` decode helpers are stubbed (via `importActual` spread, so other modules' `ord.*` usage at load stays real) and `ordReactionToReaction` is mocked, so the tests exercise `parseReaction`'s own assembly — previews via the real `getReactionPreviews` and validation passthrough — without a real `binpb` fixture:

- **`parseReaction`** decodes, attaches previews, keeps the remaining fields, and leaves `validation` null when absent / parses it when present.
- **`parseReactionList`** maps every item through `parseReaction` while preserving pagination.

## Test plan
- [x] `vitest run` — 31/31 in this file pass (3 new); full suite 512/512 green
- [x] `reactions.utils.ts` → ~97% lines/branches
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Follow-up test coverage for `reactions.utils.ts`, specifically the `parseReaction` and `parseReactionList` orchestrators, addressing gaps identified in #713 and feedback from the prior review iteration.

- **`parseReaction` tests**: verify protobuf-decode stub wiring, `getReactionPreviews` integration with an empty reaction, null-validation passthrough, and `parseValidation` execution when validation is present; fixtures now use real `ReactionResponse` snake_case field names (`pb_reaction_id`, `is_valid`).
- **`parseReactionList` test**: asserts pagination fields are preserved and that `items.map(item => item.id)` / `items.map(item => item.pb_reaction_id)` match expected order, directly pinning item identity and ordering.

<h3>Confidence Score: 5/5</h3>

Pure test additions with no changes to production code; safe to merge.

The change is entirely new test code. The mock strategy is sound — vi.mock hoisting is handled correctly by Vitest, the ord namespace spread preserves load-time usage by other modules, and ordReactionToReaction is isolated without touching real protobuf fixtures. Both issues raised in the previous review round (snake_case field names in fixtures, item-order pinning in the list test) are fully addressed. No production logic is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.utils.test.ts | Adds 3 new tests for parseReaction and parseReactionList using real ReactionResponse field names; mocks are correctly scoped and both prior review concerns (snake_case field names, item-order pinning) are addressed. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): use real ReactionResponse fiel..."](https://github.com/open-reaction-database/ord-app/commit/17abefa9e1981632060d5c5c2f1af3b825760c3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35537302)</sub>

<!-- /greptile_comment -->