### PR TITLE
test(ui): cover reactions.reducer slices (#662)

### DIFF
--- a/ui/src/store/entities/reactions/reactions.reducer.test.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.test.ts
@@ -31,6 +31,7 @@ import {
 import {
   addUpdateVariableActions,
   getAllTemplatesActions,
+  removeTemplateActions,
   removeVariableActions,
   renameTemplateActions,
 } from 'store/entities/templates/templates.actions.ts';
@@ -71,9 +72,14 @@ describe('reactions.reducer — activeDatasetId', () => {
 
 describe('reactions.reducer — list/page lifecycle', () => {
   it('clears order/pagination and flags loading on a list request', () => {
-    const seeded = { reactionsOrder: [1, 2], areReactionsLoading: false };
+    const seeded = {
+      reactionsOrder: [1, 2],
+      areReactionsLoading: false,
+      pagination: { ...initialState().pagination, total: 9, page: 4 },
+    };
     const state = reduce(seeded, getReactionsListActions.request(3));
     expect(state.reactionsOrder).toEqual([]);
+    expect(state.pagination).toEqual(initialState().pagination);
     expect(state.areReactionsLoading).toBe(true);
   });
 
@@ -108,12 +114,14 @@ describe('reactions.reducer — create/remove', () => {
     expect(state.pagination.pages).toBe(1);
   });
 
-  it('flags creating on an import request and clears it on import success', () => {
+  it('flags creating on an import request and clears it (bumping pagination total) on import success', () => {
     expect(reduce(undefined, importReactionFromFileActions.request({} as never)).isReactionCreating).toBe(true);
-    expect(
-      reduce({ isReactionCreating: true }, importReactionFromFileActions.success(reaction(99) as never))
-        .isReactionCreating,
-    ).toBe(false);
+    const state = reduce(
+      { isReactionCreating: true, pagination: { ...initialState().pagination, total: 4, size: 10 } },
+      importReactionFromFileActions.success(reaction(99) as never),
+    );
+    expect(state.isReactionCreating).toBe(false);
+    expect(state.pagination.total).toBe(5);
   });
 
   it('removes the reaction from byId/order and decrements pagination total', () => {
@@ -163,6 +171,12 @@ describe('reactions.reducer — templates', () => {
     ];
     const state = reduce(undefined, getAllTemplatesActions.success(templates as never));
     expect(Object.keys(state.reactionsById)).toEqual(['t1', 't2']);
+  });
+
+  it('removes the template_<id> entry on a remove-template success', () => {
+    const seeded = { reactionsById: { template_5: { id: 'template_5' }, template_6: { id: 'template_6' } } as never };
+    const state = reduce(seeded, removeTemplateActions.success(5 as never));
+    expect(Object.keys(state.reactionsById)).toEqual(['template_6']);
   });
 
   it('replaces a template entry on a rename-template success', () => {

--- a/ui/src/store/entities/reactions/reactions.reducer.test.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.test.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import type { UnknownAction } from '@reduxjs/toolkit';
+import { reactionsReducer } from './reactions.reducer.ts';
+import {
+  addUpdateReactionFieldActions,
+  createEmptyReactionActions,
+  deleteReactionFieldActions,
+  getReactionActions,
+  getReactionPageActions,
+  getReactionsListActions,
+  importReactionFromFileActions,
+  removeReactionActions,
+  renameReactionActions,
+  setShowInvalidOnly,
+} from './reactions.actions.ts';
+import {
+  addUpdateVariableActions,
+  getAllTemplatesActions,
+  removeVariableActions,
+  renameTemplateActions,
+} from 'store/entities/templates/templates.actions.ts';
+
+type ReactionsState = ReturnType<typeof reactionsReducer>;
+
+const initialState = (): ReactionsState => reactionsReducer(undefined, { type: '@@INIT' } as UnknownAction);
+
+// Helper to dispatch an action creator's output against (optionally seeded) state.
+function reduce(state: Partial<ReactionsState> | undefined, action: unknown): ReactionsState {
+  const base = { ...initialState(), ...state };
+  return reactionsReducer(base, action as UnknownAction);
+}
+
+// Minimal reaction whose data linkReactionEntities can traverse (it maps over outcomes).
+const reaction = (id: number, data: Record<string, unknown> = {}) => ({ id, data: { outcomes: [], ...data } });
+
+// reactionsById entries are a Reaction|Template union; read nested fields through
+// a single cast from unknown for assertions (not narrowable from the union).
+interface EntryShape {
+  pb_reaction_id?: string;
+  data: { notes?: Record<string, unknown>; reactionId?: string; outcomes?: Array<unknown> };
+  variables: Record<string, unknown>;
+}
+const asEntry = (entry: unknown): EntryShape => entry as EntryShape;
+
+describe('reactions.reducer — activeDatasetId', () => {
+  it('tracks the datasetId from a single-reaction request', () => {
+    const state = reduce(undefined, getReactionActions.request({ datasetId: 5, reactionId: 9 }));
+    expect(state.activeDatasetId).toBe(5);
+  });
+
+  it('tracks the datasetId from a reactions-list request', () => {
+    const state = reduce(undefined, getReactionsListActions.request(7));
+    expect(state.activeDatasetId).toBe(7);
+  });
+});
+
+describe('reactions.reducer — list/page lifecycle', () => {
+  it('clears order/pagination and flags loading on a list request', () => {
+    const seeded = { reactionsOrder: [1, 2], areReactionsLoading: false };
+    const state = reduce(seeded, getReactionsListActions.request(3));
+    expect(state.reactionsOrder).toEqual([]);
+    expect(state.areReactionsLoading).toBe(true);
+  });
+
+  it('populates order, pagination, byId, and clears loading on a list success', () => {
+    const payload = { items: [reaction(1), reaction(2)], total: 2, pages: 1, page: 1, size: 10 };
+    const state = reduce({ areReactionsLoading: true }, getReactionsListActions.success(payload as never));
+    expect(state.reactionsOrder).toEqual([1, 2]);
+    expect(state.pagination).toMatchObject({ total: 2, pages: 1 });
+    expect(Object.keys(state.reactionsById)).toEqual(['1', '2']);
+    expect(state.areReactionsLoading).toBe(false);
+  });
+
+  it('merges the requested page into pagination and flags loading on a page request', () => {
+    const state = reduce(undefined, getReactionPageActions.request({ page: 3, size: 20 } as never));
+    expect(state.pagination).toMatchObject({ page: 3, size: 20 });
+    expect(state.areReactionsLoading).toBe(true);
+  });
+});
+
+describe('reactions.reducer — create/remove', () => {
+  it('flags creating on an empty-reaction request', () => {
+    expect(reduce(undefined, createEmptyReactionActions.request()).isReactionCreating).toBe(true);
+  });
+
+  it('clears creating and bumps pagination total on an empty-reaction success', () => {
+    const state = reduce(
+      { pagination: { ...initialState().pagination, total: 4, size: 10 } },
+      createEmptyReactionActions.success(reaction(99) as never),
+    );
+    expect(state.isReactionCreating).toBe(false);
+    expect(state.pagination.total).toBe(5);
+    expect(state.pagination.pages).toBe(1);
+  });
+
+  it('flags creating on an import request and clears it on import success', () => {
+    expect(reduce(undefined, importReactionFromFileActions.request({} as never)).isReactionCreating).toBe(true);
+    expect(
+      reduce({ isReactionCreating: true }, importReactionFromFileActions.success(reaction(99) as never))
+        .isReactionCreating,
+    ).toBe(false);
+  });
+
+  it('removes the reaction from byId/order and decrements pagination total', () => {
+    const seeded = {
+      reactionsById: { 1: reaction(1), 2: reaction(2) } as never,
+      reactionsOrder: [1, 2],
+      pagination: { ...initialState().pagination, total: 2, size: 10 },
+    };
+    const state = reduce(seeded, removeReactionActions.success(2));
+    expect(Object.keys(state.reactionsById)).toEqual(['1']);
+    expect(state.reactionsOrder).toEqual([1]);
+    expect(state.pagination.total).toBe(1);
+  });
+});
+
+describe('reactions.reducer — reactionsById field edits', () => {
+  it('deep-merges a new value at a path on an add/update field request', () => {
+    const seeded = { reactionsById: { 1: reaction(1, { notes: {} }) } as never };
+    const action = addUpdateReactionFieldActions.request({
+      reactionId: 1,
+      pathComponents: ['notes', 'text'],
+      newValue: 'hello',
+    } as never);
+    const state = reduce(seeded, action);
+    expect(asEntry(state.reactionsById[1]).data.notes).toEqual({ text: 'hello' });
+  });
+
+  it('removes the value at a path on a delete field request', () => {
+    const seeded = { reactionsById: { 1: reaction(1, { notes: { text: 'x' } }) } as never };
+    const action = deleteReactionFieldActions.request({ reactionId: 1, pathComponents: ['notes', 'text'] } as never);
+    const state = reduce(seeded, action);
+    expect(asEntry(state.reactionsById[1]).data.notes).toEqual({});
+  });
+
+  it('renames a reaction, updating both pb_reaction_id and data.reactionId', () => {
+    const seeded = { reactionsById: { 1: { ...reaction(1), pb_reaction_id: 'old' } } as never };
+    const state = reduce(seeded, renameReactionActions.success({ reactionId: 1, name: 'new-name' } as never));
+    expect(state.reactionsById[1]).toMatchObject({ pb_reaction_id: 'new-name', data: { reactionId: 'new-name' } });
+  });
+});
+
+describe('reactions.reducer — templates', () => {
+  it('indexes all templates by id on a get-all-templates success', () => {
+    const templates = [
+      { id: 't1', data: { outcomes: [] } },
+      { id: 't2', data: { outcomes: [] } },
+    ];
+    const state = reduce(undefined, getAllTemplatesActions.success(templates as never));
+    expect(Object.keys(state.reactionsById)).toEqual(['t1', 't2']);
+  });
+
+  it('replaces a template entry on a rename-template success', () => {
+    const seeded = { reactionsById: { t1: { id: 't1', name: 'old' } } as never };
+    const renamed = { id: 't1', name: 'renamed', data: { outcomes: [] } };
+    const state = reduce(seeded, renameTemplateActions.success(renamed as never));
+    expect(state.reactionsById.t1).toMatchObject({ name: 'renamed' });
+  });
+
+  it('adds a variable keyed by its dotted path on an add-variable request', () => {
+    const seeded = { reactionsById: { t1: { id: 't1', variables: {} } } as never };
+    const variable = { path: ['conditions', 'temperature'], name: 'temp' };
+    const state = reduce(seeded, addUpdateVariableActions.request({ templateId: 't1', variable } as never));
+    expect(asEntry(state.reactionsById.t1).variables).toHaveProperty('conditions.temperature');
+  });
+
+  it('removes a variable by its dotted path on a remove-variable request', () => {
+    const variable = { path: ['conditions', 'temperature'], name: 'temp' };
+    const seeded = { reactionsById: { t1: { id: 't1', variables: { 'conditions.temperature': variable } } } as never };
+    const state = reduce(seeded, removeVariableActions.request({ templateId: 't1', variable } as never));
+    expect(asEntry(state.reactionsById.t1).variables).toEqual({});
+  });
+});
+
+describe('reactions.reducer — showInvalidOnly', () => {
+  it('reflects the setShowInvalidOnly payload', () => {
+    expect(reduce(undefined, setShowInvalidOnly(true)).showInvalidOnly).toBe(true);
+    expect(reduce({ showInvalidOnly: true }, setShowInvalidOnly(false)).showInvalidOnly).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first test for `reactions.reducer.ts`, taking it from **57% → 90.5% lines / 100% branches** by dispatching real actions through the combined reducer and asserting each slice:

- **`activeDatasetId`** from single-reaction and list requests
- **list/page lifecycle** — order/pagination reset + loading flag on request; order, pagination, byId populated + loading cleared on success; page merge
- **create/remove** — `isReactionCreating` on empty-reaction & import request/success, pagination total bump/decrement, byId + order removal
- **`reactionsById` field edits** — deep-merge add/update, path removal on delete, reaction rename (`pb_reaction_id` + `data.reactionId`)
- **template cases** — index-by-id on get-all, rename replace, add/remove variable keyed by dotted path
- **`showInvalidOnly`** toggle

## Test plan
- [x] `vitest run` — 17/17 new tests pass; full suite 531/531 green
- [x] `reactions.reducer.ts` 57% → 90.5% lines, 100% branches
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the first unit test file for `reactions.reducer.ts`, dispatching real actions through the combined reducer and asserting each slice's state transitions. Coverage moves from 57% → 90.5% lines / 100% branches.

- All three findings from the previous review round were addressed: the `importReactionFromFileActions.success` pagination-bump assertion, the `template_<id>` key removal test, and the `pagination` reset assertion on list request.
- The remaining ~9.5% uncovered lines are the `failure` action paths for `isReactionCreating` and the `createNewTemplateActions.success` / `importTemplateFromFileActions.success` matchers in `reactionsById`, which the PR acknowledges as out-of-scope.

<h3>Confidence Score: 5/5</h3>

Pure test addition — no production code changes, no risk to existing behavior.

The change is a single new test file. All three gaps raised in the previous review round were incorporated: the import-success pagination assertion, the template_<id> removal path, and the pagination-reset check on list request. The reducer under test is untouched, and the tests correctly exercise the combined reducer using real action creators.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.reducer.test.ts | New test file adding 17 tests for reactions.reducer.ts, covering activeDatasetId, list/page lifecycle, create/remove, field edits, template operations, and showInvalidOnly. All three items from previous review rounds have been incorporated: import-success pagination bump, template_<id> removal path, and pagination-reset assertion on list request. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): tighten reducer tests per Grep..."](https://github.com/open-reaction-database/ord-app/commit/5a2e4eeefe41ac2b0382cf0291f006beb2320d81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35537991)</sub>

<!-- /greptile_comment -->