### PR TITLE
test(ui): cover findReactionEntityUniqueName (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/findReactionEntityUniqueName.test.ts
+++ b/ui/src/features/reactions/ReactionEntities/findReactionEntityUniqueName.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { findReactionEntityUniqueName } from './findReactionEntityUniqueName.ts';
+
+describe('findReactionEntityUniqueName', () => {
+  it('returns the first numbered name when none are taken', () => {
+    expect(findReactionEntityUniqueName('Reagent', [])).toBe('Reagent 1');
+  });
+
+  it('skips taken names and returns the next available counter', () => {
+    expect(findReactionEntityUniqueName('Reagent', ['Reagent 1', 'Reagent 2'])).toBe('Reagent 3');
+  });
+
+  it('fills the first gap rather than always appending at the end', () => {
+    expect(findReactionEntityUniqueName('Reagent', ['Reagent 2', 'Reagent 3'])).toBe('Reagent 1');
+  });
+
+  it('ignores unrelated names', () => {
+    expect(findReactionEntityUniqueName('Reagent', ['Solvent 1', 'Catalyst 1'])).toBe('Reagent 1');
+  });
+
+  it('omits the space when includeSpace is false', () => {
+    expect(findReactionEntityUniqueName('Reagent', ['Reagent1'], false)).toBe('Reagent2');
+  });
+});


### PR DESCRIPTION
## Summary

Takes `findReactionEntityUniqueName.ts` from **26% → 100%**. Covers: returns the first numbered name when none are taken, skips taken names to the next counter, fills the first gap rather than appending at the end, ignores unrelated names, and omits the space separator when `includeSpace` is false.

## Test plan
- [x] `vitest run` — 5/5 pass; `findReactionEntityUniqueName.ts` 100% lines/branches
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Vitest unit test file for `findReactionEntityUniqueName`, taking that module from 26% to 100% line/branch coverage.

- Five test cases exercise: no names taken → returns `"Reagent 1"`; sequential names taken → skips to next counter; first gap present → fills it rather than appending; unrelated names → ignored; `includeSpace: false` → omits the space separator.
- No production code is changed; the implementation file is read-only context.

<h3>Confidence Score: 5/5</h3>

Pure test addition with no changes to production code; all five assertions correctly reflect the source implementation's behavior.

Every test case maps accurately to a distinct branch in the implementation: the empty-list base case, sequential skipping, gap-filling, unrelated-name filtering, and the optional includeSpace flag. No production code is touched, so there is no regression risk.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/findReactionEntityUniqueName.test.ts | New test file covering all five logical branches of findReactionEntityUniqueName: empty list, sequential taken names, gap-filling, unrelated name filtering, and the includeSpace=false path. All assertions match the source implementation correctly. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover findReactionEntityUnique..."](https://github.com/open-reaction-database/ord-app/commit/55284b32477157cc8de5a292a3794b4693ccf36e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35538497)</sub>

<!-- /greptile_comment -->