### PR TITLE
test(ui): cover renderValuePrecisionUnit (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionView/renderValuePrecisionUnit.test.ts
+++ b/ui/src/features/reactions/ReactionView/renderValuePrecisionUnit.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// getFormattedValue (unit-symbol formatting) is the dependency, not the unit
+// under test; stub it so the composition logic is asserted deterministically.
+vi.mock('common/hooks/useTextFormatting', () => ({ getFormattedValue: (units: string) => `fmt:${units}` }));
+
+import { renderValuePrecisionUnit } from './renderValuePrecisionUnit.ts';
+
+describe('renderValuePrecisionUnit', () => {
+  it('joins value, ± precision, and formatted units', () => {
+    expect(renderValuePrecisionUnit({ value: 5, precision: 0.1, units: 'CELSIUS' })).toBe('5 ± 0.1 fmt:CELSIUS');
+  });
+
+  it('omits the precision segment when precision is falsy', () => {
+    expect(renderValuePrecisionUnit({ value: 5, precision: 0, units: 'CELSIUS' })).toBe('5 fmt:CELSIUS');
+  });
+
+  it('omits units entirely when the units key is absent', () => {
+    expect(renderValuePrecisionUnit({ value: 5, precision: 0.1 })).toBe('5 ± 0.1');
+  });
+
+  it('omits units when present but empty, leaving just the value', () => {
+    expect(renderValuePrecisionUnit({ value: 5, precision: 0, units: '' })).toBe('5');
+  });
+});


### PR DESCRIPTION
## Summary

Takes `renderValuePrecisionUnit.ts` from **40% → 100%**: joins value, `± precision`, and formatted units; omits the precision segment when precision is falsy; omits units when the key is absent or empty. `getFormattedValue` (the unit-symbol formatter dependency) is stubbed so the composition logic is asserted deterministically.

## Test plan
- [x] `vitest run` — 4/4 pass; `renderValuePrecisionUnit.ts` 100% lines/branches
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file that brings `renderValuePrecisionUnit.ts` from 40% to 100% branch coverage. No production code is modified.

- Four deterministic test cases cover the three independent boolean branches (`precision` truthy/falsy, `units` truthy/falsy, `units` key present/absent); all assertions were manually verified against the implementation logic.
- `getFormattedValue` is correctly stubbed via `vi.mock` (hoisted above the import under test), isolating the composition logic from the real unit-symbol formatter.

<h3>Confidence Score: 5/5</h3>

This PR only adds a test file; no production code is touched, so there is no regression risk.

All four test assertions were verified against the implementation: the filter-and-join logic with the stubbed formatter produces the expected strings in every branch. The vi.mock call is placed before the import (required for Vitest hoisting), and the copyright year matches the current year.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionView/renderValuePrecisionUnit.test.ts | New test file adding 100% branch coverage for renderValuePrecisionUnit; assertions are correct, vi.mock is properly hoisted, all 4 branches exercised. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover renderValuePrecisionUnit..."](https://github.com/open-reaction-database/ord-app/commit/1e1d75db6702c299c23dc518954e67a949b7468a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35539014)</sub>

<!-- /greptile_comment -->