### PR TITLE
test(ui): cover reactionViewDeleteButtons utils (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionInteractions/ReactionViewDeleteButtons/reactionViewDeleteButtons.utils.test.ts
+++ b/ui/src/features/reactions/ReactionInteractions/ReactionViewDeleteButtons/reactionViewDeleteButtons.utils.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { MouseEvent } from 'react';
+
+const dispatch = vi.hoisted(() => vi.fn());
+vi.mock('store/useAppDispatch.ts', () => ({ useAppDispatch: () => dispatch }));
+vi.mock('store/features/reactionForm/reactionForm.actions.ts', () => ({
+  addReactionPathComponentToList: (path: unknown) => ({ type: 'addReactionPathComponentToList', payload: path }),
+  setReactionPathComponentsList: (list: unknown) => ({ type: 'setReactionPathComponentsList', payload: list }),
+}));
+
+import { onViewDeleteButtonsWrapperClick, useOnViewEdit } from './reactionViewDeleteButtons.utils.ts';
+
+afterEach(() => {
+  dispatch.mockClear();
+});
+
+describe('onViewDeleteButtonsWrapperClick', () => {
+  it('stops event propagation', () => {
+    const stopPropagation = vi.fn();
+    onViewDeleteButtonsWrapperClick({ stopPropagation } as unknown as MouseEvent);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useOnViewEdit', () => {
+  it('appends the path to the list when there is no history', () => {
+    const { result } = renderHook(() => useOnViewEdit({ pathComponents: ['inputs', 0] }));
+    result.current();
+    expect(dispatch).toHaveBeenCalledWith({ type: 'addReactionPathComponentToList', payload: ['inputs', 0] });
+  });
+
+  it('replaces the list with history plus the current path when history is provided', () => {
+    const { result } = renderHook(() =>
+      useOnViewEdit({ pathComponents: ['inputs', 0], historyPathComponents: [['setup'], ['conditions']] }),
+    );
+    result.current();
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'setReactionPathComponentsList',
+      payload: [['setup'], ['conditions'], ['inputs', 0]],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Takes `reactionViewDeleteButtons.utils.ts` from **66% → 100%**:
- `onViewDeleteButtonsWrapperClick` stops event propagation;
- `useOnViewEdit` appends the path to the list when there's no history, and replaces the list with `history + [current path]` when history is provided.

## Test plan
- [x] `vitest run` — 3/3 pass; `reactionViewDeleteButtons.utils.ts` 100% lines/branches
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a unit-test file for `reactionViewDeleteButtons.utils.ts`, bringing its coverage from 66% to 100%. The two utility functions — `onViewDeleteButtonsWrapperClick` and `useOnViewEdit` — are exercised through their full branch paths via properly hoisted vitest mocks and `renderHook`.

- `onViewDeleteButtonsWrapperClick`: one test confirms `stopPropagation` is called exactly once.
- `useOnViewEdit`: two tests cover the no-history path (`addReactionPathComponentToList`) and the history-provided path (`setReactionPathComponentsList` with the history array concatenated with the current path), both matching the production logic precisely.

<h3>Confidence Score: 5/5</h3>

Adding tests only — no production code is modified, so there is no regression risk.

The new test file covers both branches of `useOnViewEdit` and the single branch of `onViewDeleteButtonsWrapperClick`, uses the correct `vi.hoisted` pattern for the dispatch mock, and clears state between tests with `afterEach`. The assertions match the production implementation exactly. Nothing in the diff can break existing behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionInteractions/ReactionViewDeleteButtons/reactionViewDeleteButtons.utils.test.ts | New test file covering both exported utilities: `onViewDeleteButtonsWrapperClick` (event propagation) and `useOnViewEdit` (no-history and with-history dispatch paths). Mocks are correctly hoisted and cleared between tests. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover reactionViewDeleteButton..."](https://github.com/open-reaction-database/ord-app/commit/2032519f145528ecb31843aa8ddc92cfbd01fc10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35539396)</sub>

<!-- /greptile_comment -->