### PR TITLE
test(ui): cover buildUseCreate hook factory (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseCreate.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseCreate.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { reactionContext } from 'features/reactions/reactions.context.ts';
+import { reactionEntityContext } from 'features/reactions/ReactionEntities/reactionEntity.context.ts';
+import type { ReactionsContext } from 'features/reactions/reactions.types.ts';
+
+const dispatch = vi.hoisted(() => vi.fn());
+vi.mock('store/useAppDispatch.ts', () => ({ useAppDispatch: () => dispatch }));
+vi.mock('store/entities/reactions/reactions.thunks.ts', () => ({
+  addUpdateReactionField: (payload: unknown) => ({ type: 'addUpdateReactionField', payload }),
+}));
+vi.mock('store/features/reactionForm/reactionForm.actions.ts', () => ({
+  addReactionPathComponentToList: (payload: unknown) => ({ type: 'addReactionPathComponentToList', payload }),
+  setReactionPathComponentsList: (payload: unknown) => ({ type: 'setReactionPathComponentsList', payload }),
+}));
+
+import { buildUseCreate } from './buildUseCreate.ts';
+
+interface NewEntity {
+  entity: string;
+}
+
+const reactionCtxValue: ReactionsContext = {
+  reactionId: 7,
+  isTemplate: false,
+  isViewOnly: false,
+  ViewDeleteButtonsComponent: () => null,
+  ValueLabelComponent: () => null,
+  ViewOnlyLabelComponent: () => null,
+};
+
+function ContextWrapper({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <reactionContext.Provider value={reactionCtxValue}>
+      <reactionEntityContext.Provider value={{ reactionId: 7, pathComponents: ['inputs', 0] }}>
+        {children}
+      </reactionEntityContext.Provider>
+    </reactionContext.Provider>
+  );
+}
+
+const createKey = vi.fn((_index: number, _list: Array<NewEntity>, _info?: Partial<NewEntity>): [string, NewEntity] => [
+  'key1',
+  { entity: 'new' },
+]);
+
+function renderCreate(entityName: string | Array<string | number>, shouldOpenSidebar?: boolean) {
+  const { result } = renderHook(() => buildUseCreate<NewEntity>(entityName, createKey, shouldOpenSidebar)(), {
+    wrapper: ContextWrapper,
+  });
+  return result.current;
+}
+
+afterEach(() => {
+  dispatch.mockClear();
+  createKey.mockClear();
+});
+
+describe('buildUseCreate', () => {
+  it('calls the key factory and dispatches the field update + sidebar open at the composed path', () => {
+    const create = renderCreate('components');
+    create(0, [], { entity: 'seed' });
+
+    expect(createKey).toHaveBeenCalledWith(0, [], { entity: 'seed' });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'addUpdateReactionField',
+      payload: { reactionId: 7, pathComponents: ['inputs', 0, 'components', 'key1'], newValue: { entity: 'new' } },
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'addReactionPathComponentToList',
+      payload: ['inputs', 0, 'components', 'key1'],
+    });
+  });
+
+  it('appends an array entityName verbatim to the context path', () => {
+    renderCreate(['conditions', 'temperature'])(0, []);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'addUpdateReactionField',
+      payload: {
+        reactionId: 7,
+        pathComponents: ['inputs', 0, 'conditions', 'temperature', 'key1'],
+        newValue: { entity: 'new' },
+      },
+    });
+  });
+
+  it('does not open the sidebar when shouldOpenSidebar is false', () => {
+    renderCreate('components', false)(0, []);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'addUpdateReactionField' }));
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseCreate.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseCreate.test.tsx
@@ -27,7 +27,6 @@ vi.mock('store/entities/reactions/reactions.thunks.ts', () => ({
 }));
 vi.mock('store/features/reactionForm/reactionForm.actions.ts', () => ({
   addReactionPathComponentToList: (payload: unknown) => ({ type: 'addReactionPathComponentToList', payload }),
-  setReactionPathComponentsList: (payload: unknown) => ({ type: 'setReactionPathComponentsList', payload }),
 }));
 
 import { buildUseCreate } from './buildUseCreate.ts';
@@ -88,7 +87,7 @@ describe('buildUseCreate', () => {
     });
   });
 
-  it('appends an array entityName verbatim to the context path', () => {
+  it('appends an array entityName verbatim to the context path (and opens the sidebar there)', () => {
     renderCreate(['conditions', 'temperature'])(0, []);
     expect(dispatch).toHaveBeenCalledWith({
       type: 'addUpdateReactionField',
@@ -97,6 +96,10 @@ describe('buildUseCreate', () => {
         pathComponents: ['inputs', 0, 'conditions', 'temperature', 'key1'],
         newValue: { entity: 'new' },
       },
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'addReactionPathComponentToList',
+      payload: ['inputs', 0, 'conditions', 'temperature', 'key1'],
     });
   });
 


### PR DESCRIPTION
## Summary

Takes `buildUseCreate.ts` from **57% → 100%**. Renders the produced hook with the `reactionContext` + `reactionEntityContext` providers and a mocked dispatch, asserting the returned callback:
- calls the key factory with `(index, list, info)`;
- dispatches `addUpdateReactionField` at the composed path (context `pathComponents` + `entityName` + key) with the new entity;
- appends an array `entityName` verbatim;
- opens the sidebar (`addReactionPathComponentToList`) only when `shouldOpenSidebar` is true.

## Test plan
- [x] `vitest run` — 3/3 pass; `buildUseCreate.ts` 100% lines/branches
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file that brings `buildUseCreate.ts` from 57% to 100% coverage by rendering the produced hook inside real `reactionContext` + `reactionEntityContext` providers with a hoisted dispatch mock.

- Three test cases cover: (1) string `entityName` with sidebar dispatch, (2) array `entityName` spread verbatim into the path with sidebar dispatch, and (3) `shouldOpenSidebar: false` suppressing the second dispatch call.
- `vi.hoisted` is used correctly for the dispatch mock so it is available before the mocked module resolves; `afterEach` clears both `dispatch` and `createKey` to keep tests independent.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no changes to production code; safe to merge.

The change is a single new test file. The mocking strategy (vi.hoisted, module-level mock factories, afterEach cleanup) follows established Vitest patterns. All three tests assert the correct dispatch payloads for the string path, array path, and no-sidebar branches, matching the implementation in buildUseCreate.ts exactly. No production code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/buildUseCreate.test.tsx | New test file covering buildUseCreate hook factory to 100%; three focused test cases with correct mocking patterns, proper context wrapping, and accurate dispatch assertions for both string and array entityName paths. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): drop unused mock + assert arra..."](https://github.com/open-reaction-database/ord-app/commit/9b2d18319c7fb9e643ed98bf71781a8161063305) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35539664)</sub>

<!-- /greptile_comment -->