### PR TITLE
test(ui): cover useIsHidden hook (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/useIsHidden.test.ts
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/useIsHidden.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useIsHidden } from './useIsHidden.ts';
+import type {
+  ReactionFormConditionalRendering,
+  ReactionFormMethods,
+} from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+type Condition = ReactionFormConditionalRendering['condition'];
+type WatchCallback = (payload: { value: unknown }) => void;
+
+const condition = (isHiddenFor: unknown): Condition =>
+  ({ name: 'fieldA', isHidden: (value: unknown) => value === isHiddenFor }) as unknown as Condition;
+
+function formMethods(currentValue: unknown) {
+  const watch = vi.fn();
+  const methods = { getValues: () => ({ fieldA: currentValue }), watch } as unknown as ReactionFormMethods;
+  return { methods, watch };
+}
+
+describe('useIsHidden', () => {
+  it('returns false immediately when there is no condition', () => {
+    const { methods } = formMethods('whatever');
+    const { result } = renderHook(() => useIsHidden(undefined, methods));
+    expect(result.current).toBe(false);
+  });
+
+  it('seeds the hidden state from the current field value and subscribes to changes', () => {
+    const { methods, watch } = formMethods('HIDE');
+    const { result } = renderHook(() => useIsHidden(condition('HIDE'), methods));
+    expect(result.current).toBe(true);
+    expect(watch).toHaveBeenCalledWith('fieldA', expect.any(Function));
+  });
+
+  it('seeds to visible when the current value is not the hidden value', () => {
+    const { methods } = formMethods('SHOW');
+    const { result } = renderHook(() => useIsHidden(condition('HIDE'), methods));
+    expect(result.current).toBe(false);
+  });
+
+  it('updates the hidden state when the watched value changes', () => {
+    const { methods, watch } = formMethods('SHOW');
+    const { result } = renderHook(() => useIsHidden(condition('HIDE'), methods));
+    expect(result.current).toBe(false);
+
+    const onChange = watch.mock.calls[0][1] as WatchCallback;
+    act(() => onChange({ value: 'HIDE' }));
+    expect(result.current).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Takes `useIsHidden.ts` from **25% → 100% lines** (the one uncovered branch is the unreachable `: false` ternary arm, already guarded by the earlier `if (!condition) return false`).

Covers:
- returns `false` immediately when there's no condition;
- seeds the hidden state from the current field value and subscribes via `watch(name, cb)`;
- seeds to visible when the value isn't the hidden one;
- flips state when the watched value changes (invoking the captured `watch` callback under `act`).

## Test plan
- [x] `vitest run` — 4/4 pass; `useIsHidden.ts` 100% lines
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

Part of #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Vitest unit test file for the `useIsHidden` hook, raising its line coverage from 25% to 100%. The tests are test-only with no production code changes.

- Four test cases cover: the `undefined`-condition early return, initial state seeding from `getValues()` for both the hidden and visible paths, and the watched-value callback driving a state transition under `act`.
- The mock setup (`vi.fn()` for `watch`, a real `getValues` closure) correctly mirrors the hook's calling contract, and the manual callback invocation in the fourth test faithfully exercises the reactive update path.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no production code changes; safe to merge.

All four tests correctly model the hook's contract: the `watch` mock captures the real callback argument, `act` is used properly for state transitions, and the fixture values (`'HIDE'`/`'SHOW'`) unambiguously distinguish the two state outcomes. No production code was touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/useIsHidden.test.ts | New test file covering all reachable branches of `useIsHidden`: no-condition early return, initial hidden state seeding, initial visible seeding, and callback-driven state update via the captured `watch` argument. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover useIsHidden hook (#662)"](https://github.com/open-reaction-database/ord-app/commit/ee9460e07c47f8bebe72a4d643a3a3ec3c0ad2da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35539820)</sub>

<!-- /greptile_comment -->