### PR TITLE
refactor(ui): drop unreachable ternary arm in useIsHidden

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/useIsHidden.ts
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/useIsHidden.ts
@@ -24,7 +24,7 @@ export const useIsHidden = (
   formMethods: ReactionFormMethods,
 ) => {
   if (!condition) return false;
-  const initialValue = condition ? condition.isHidden(formMethods.getValues()[condition.name]) : false;
+  const initialValue = condition.isHidden(formMethods.getValues()[condition.name]);
   // condition will always stay the same in the runtime due to it being readonly property
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const [isHidden, setIsHidden] = useState(initialValue);


### PR DESCRIPTION
## Summary

`condition` is guaranteed truthy after the preceding `if (!condition) return false;`, so the `condition ? … : false` ternary's `: false` arm is unreachable dead code. Simplify to a direct call:

```ts
const initialValue = condition.isHidden(formMethods.getValues()[condition.name]);
```

Pure no-op cleanup (flagged while covering the file in #721). The `useIsHidden` test suite passes unchanged, and the file is now **100% branches** (the dead arm was the only gap).

## Test plan
- [x] `vitest run` — `useIsHidden` 4/4 pass unchanged; file 100% lines + branches
- [x] `tsc -b --force`, `eslint`, `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes a dead `condition ? … : false` ternary arm in `useIsHidden` — `condition` is already guaranteed truthy by the `if (!condition) return false` guard on the line above, so the `: false` branch was unreachable. The replacement is a direct method call with identical runtime behavior.

- Eliminates the dead branch, bringing the file to 100% branch coverage without changing any observable behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the single-line change is a pure dead-code removal with no behavior change.

The removed ternary arm was provably unreachable: the early-return guard on the line above narrows `condition` to truthy before it is ever evaluated. The direct call is byte-for-byte equivalent on every reachable code path, and the test suite passes unchanged.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/useIsHidden.ts | Removes unreachable ternary `: false` arm; `condition` is already narrowed to truthy by the preceding early-return guard, so the direct call is semantically identical. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(ui): drop unreachable ternary a..."](https://github.com/open-reaction-database/ord-app/commit/4416bc09682d69a0bc4d1a4f9c05a5c6c6e3d974) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35540375)</sub>

<!-- /greptile_comment -->