### PR TITLE
fix(ui): refresh dataset on reaction remove (#431) + datasets list after enumeration (#611)

### DIFF
--- a/ui/src/store/entities/datasets/datasets.thunks.test.ts
+++ b/ui/src/store/entities/datasets/datasets.thunks.test.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { configureStore, type UnknownAction } from '@reduxjs/toolkit';
-import { rootReducer } from 'store/rootReducer.ts';
+import { type UnknownAction } from '@reduxjs/toolkit';
 import axiosInstance from 'store/axiosInstance.ts';
 import { navigate } from 'wouter/use-browser-location';
+import { makeRecordingStore } from 'test/recordingStore.ts';
 import {
   createEmptyDataset,
   getDataset,
@@ -46,19 +46,7 @@ vi.mock('wouter/use-browser-location', () => ({ navigate: vi.fn() }));
 // cast to a plain record of mock fns instead.
 const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
 
-/** A store that records every dispatched action so follow-up refetches can be asserted by type. */
-function makeStore() {
-  const actions: Array<UnknownAction> = [];
-  const recorder = () => (next: (action: unknown) => unknown) => (action: unknown) => {
-    actions.push(action as UnknownAction);
-    return next(action);
-  };
-  const store = configureStore({
-    reducer: rootReducer,
-    middleware: getDefault => getDefault().concat(recorder),
-  });
-  return { store, types: () => actions.map(action => action.type) };
-}
+const makeStore = makeRecordingStore;
 
 const dataset = { id: 1, name: 'd1', description: '', groups: [] };
 

--- a/ui/src/store/entities/enumeration/enumeration.thunks.test.ts
+++ b/ui/src/store/entities/enumeration/enumeration.thunks.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { configureStore, type UnknownAction } from '@reduxjs/toolkit';
-import { rootReducer } from 'store/rootReducer.ts';
+import { type UnknownAction } from '@reduxjs/toolkit';
 import axiosInstance from 'store/axiosInstance.ts';
+import { makeRecordingStore } from 'test/recordingStore.ts';
 import { finishEnumeration } from './enumeration.thunks.ts';
 import { enumerateBatchActions, finishEnumerationAction, startEnumerationActions } from './enumeration.actions.ts';
 import type { StartEnumeration } from './enumeration.types.ts';
@@ -30,19 +30,9 @@ vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() 
 const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
 const emptyPage = { items: [], page: 1, size: 10, total: 0, pages: 0 };
 
-function makeStore() {
-  const actions: Array<UnknownAction> = [];
-  const recorder = () => (next: (action: unknown) => unknown) => (action: unknown) => {
-    actions.push(action as UnknownAction);
-    return next(action);
-  };
-  const store = configureStore({ reducer: rootReducer, middleware: getDefault => getDefault().concat(recorder) });
-  return { store, types: () => actions.map(action => action.type) };
-}
-
 // Seed an in-progress enumeration that targets a NEW dataset (dataset is an object, not an id),
 // with one enumerated reaction so finishEnumeration doesn't early-return.
-function seedNewDatasetProgress(store: ReturnType<typeof makeStore>['store']) {
+function seedNewDatasetProgress(store: ReturnType<typeof makeRecordingStore>['store']) {
   const startPayload: StartEnumeration = {
     dataset: { groupId: 3, name: 'Enumerated', description: 'desc' },
     matching: [],
@@ -62,7 +52,7 @@ beforeEach(() => {
 
 describe('finishEnumeration (new dataset)', () => {
   it('creates the dataset and refetches the datasets list so it appears without a manual reload (#611)', async () => {
-    const { store, types } = makeStore();
+    const { store, types } = makeRecordingStore();
     seedNewDatasetProgress(store);
 
     await store.dispatch(finishEnumeration() as unknown as UnknownAction);

--- a/ui/src/store/entities/enumeration/enumeration.thunks.test.ts
+++ b/ui/src/store/entities/enumeration/enumeration.thunks.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { configureStore, type UnknownAction } from '@reduxjs/toolkit';
+import { rootReducer } from 'store/rootReducer.ts';
+import axiosInstance from 'store/axiosInstance.ts';
+import { finishEnumeration } from './enumeration.thunks.ts';
+import { enumerateBatchActions, finishEnumerationAction, startEnumerationActions } from './enumeration.actions.ts';
+import type { StartEnumeration } from './enumeration.types.ts';
+import { getGroupsInitialDatasetListActions } from '../datasets/datasets.actions.ts';
+
+vi.mock('store/axiosInstance.ts', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
+
+const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
+const emptyPage = { items: [], page: 1, size: 10, total: 0, pages: 0 };
+
+function makeStore() {
+  const actions: Array<UnknownAction> = [];
+  const recorder = () => (next: (action: unknown) => unknown) => (action: unknown) => {
+    actions.push(action as UnknownAction);
+    return next(action);
+  };
+  const store = configureStore({ reducer: rootReducer, middleware: getDefault => getDefault().concat(recorder) });
+  return { store, types: () => actions.map(action => action.type) };
+}
+
+// Seed an in-progress enumeration that targets a NEW dataset (dataset is an object, not an id),
+// with one enumerated reaction so finishEnumeration doesn't early-return.
+function seedNewDatasetProgress(store: ReturnType<typeof makeStore>['store']) {
+  const startPayload: StartEnumeration = {
+    dataset: { groupId: 3, name: 'Enumerated', description: 'desc' },
+    matching: [],
+    templateCSV: { headers: [], content: [] },
+    data: {} as StartEnumeration['data'],
+    variables: [],
+  };
+  store.dispatch(startEnumerationActions(startPayload));
+  store.dispatch(enumerateBatchActions.success({ reactions: ['serialized-reaction'], errors: [] }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  axiosMock.get.mockResolvedValue({ data: emptyPage });
+  axiosMock.post.mockResolvedValue({ data: { id: 7 } });
+});
+
+describe('finishEnumeration (new dataset)', () => {
+  it('creates the dataset and refetches the datasets list so it appears without a manual reload (#611)', async () => {
+    const { store, types } = makeStore();
+    seedNewDatasetProgress(store);
+
+    await store.dispatch(finishEnumeration() as unknown as UnknownAction);
+
+    expect(axiosMock.post).toHaveBeenCalledWith('/groups/3/datasets/enumerate', expect.any(Object));
+    expect(types()).toContain(finishEnumerationAction.type);
+    // The new dataset is created server-side but isn't in the list store yet; refetch the list. (#611)
+    expect(types()).toContain(getGroupsInitialDatasetListActions.request.type);
+  });
+});

--- a/ui/src/store/entities/enumeration/enumeration.thunks.ts
+++ b/ui/src/store/entities/enumeration/enumeration.thunks.ts
@@ -102,6 +102,10 @@ export const finishEnumeration: ThunkCustomWrapper<void> = () => async (dispatch
 
   const datasetEnumeration = prepareDataset(enumerationProgress);
   const isNewDataset = typeof dataset === 'object';
+  // Capture the active group before the await so a group switch during the request can't
+  // retarget the refetch. We refetch the *active* group's list (which can be null = "All
+  // Groups") to match what the Datasets page shows, rather than the new dataset's own group. (#611)
+  const activeGroupId = selectActiveGroupId(getState());
 
   if (isNewDataset) {
     const createdDataset = await axiosInstance.post<Dataset>(
@@ -111,7 +115,7 @@ export const finishEnumeration: ThunkCustomWrapper<void> = () => async (dispatch
     dispatch(finishEnumerationAction(createdDataset.data.id));
     // Refresh the datasets list so the newly created dataset appears without a manual
     // page reload, including when the user dismisses the result modal with "Close". (#611)
-    dispatch(getInitialDatasetsList(selectActiveGroupId(getState())));
+    dispatch(getInitialDatasetsList(activeGroupId));
   } else {
     const datasetId = dataset;
     await axiosInstance.post<Dataset>(`/datasets/${datasetId}/enumerate/extend`, datasetEnumeration);

--- a/ui/src/store/entities/enumeration/enumeration.thunks.ts
+++ b/ui/src/store/entities/enumeration/enumeration.thunks.ts
@@ -21,8 +21,9 @@ import type { EnumerationProgress, SetupEnumeration } from './enumeration.types.
 import { selectReactionById } from '../reactions/reactions.selectors.ts';
 import type { CreateDatasetBase, Dataset } from '../datasets/datasets.types.ts';
 import axiosInstance from '../../axiosInstance.ts';
-import { getDataset } from '../datasets/datasets.thunks.ts';
+import { getDataset, getInitialDatasetsList } from '../datasets/datasets.thunks.ts';
 import { getReactionsPage } from '../reactions/reactions.thunks.ts';
+import { selectActiveGroupId } from '../../features/groups/groups.selectors.ts';
 
 const BATCH_SIZE = 50;
 
@@ -108,6 +109,9 @@ export const finishEnumeration: ThunkCustomWrapper<void> = () => async (dispatch
       datasetEnumeration,
     );
     dispatch(finishEnumerationAction(createdDataset.data.id));
+    // Refresh the datasets list so the newly created dataset appears without a manual
+    // page reload, including when the user dismisses the result modal with "Close". (#611)
+    dispatch(getInitialDatasetsList(selectActiveGroupId(getState())));
   } else {
     const datasetId = dataset;
     await axiosInstance.post<Dataset>(`/datasets/${datasetId}/enumerate/extend`, datasetEnumeration);

--- a/ui/src/store/entities/reactions/reactions.thunks.test.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { configureStore, type UnknownAction } from '@reduxjs/toolkit';
-import { rootReducer } from 'store/rootReducer.ts';
+import { type UnknownAction } from '@reduxjs/toolkit';
 import axiosInstance from 'store/axiosInstance.ts';
+import { makeRecordingStore } from 'test/recordingStore.ts';
 import { navigate } from 'wouter/use-browser-location';
 import { createEmptyReaction, getReactionsList, getReactionsPage, removeReaction } from './reactions.thunks.ts';
 import {
@@ -49,15 +49,7 @@ vi.mock('./reactions.converters.ts', async importActual => ({
 const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
 const emptyPage = { items: [], page: 1, size: 10, total: 0, pages: 0 };
 
-function makeStore() {
-  const actions: Array<UnknownAction> = [];
-  const recorder = () => (next: (action: unknown) => unknown) => (action: unknown) => {
-    actions.push(action as UnknownAction);
-    return next(action);
-  };
-  const store = configureStore({ reducer: rootReducer, middleware: getDefault => getDefault().concat(recorder) });
-  return { store, types: () => actions.map(action => action.type) };
-}
+const makeStore = makeRecordingStore;
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/ui/src/store/entities/reactions/reactions.thunks.test.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.test.ts
@@ -25,6 +25,7 @@ import {
   getReactionsListActions,
   removeReactionActions,
 } from './reactions.actions.ts';
+import { getDatasetActions } from '../datasets/datasets.actions.ts';
 
 vi.mock('store/axiosInstance.ts', () => ({
   default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -106,8 +107,11 @@ describe('removeReaction', () => {
     expect(axiosMock.delete).toHaveBeenCalledWith('/datasets/5/reactions/42');
     expect(types()).toContain(removeReactionActions.success.type);
     expect(navigate).toHaveBeenCalledWith('/datasets/5');
-    // Characterization: removal updates the store optimistically (reducer prunes order + total) and
-    // does NOT trigger a list refetch — no getReactionPage/List request follows the success.
+    // Refetches the parent dataset so its "Last modified" / reaction counts refresh
+    // even when already on the dataset page (navigate is a no-op there). (#431)
+    expect(types()).toContain(getDatasetActions.request.type);
+    // Removal still updates the reactions store optimistically (reducer prunes order + total) and
+    // does NOT trigger a reactions-list refetch — no getReactionPage request follows the success.
     expect(types()).not.toContain(getReactionPageActions.request.type);
   });
 });

--- a/ui/src/store/entities/reactions/reactions.thunks.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.ts
@@ -187,6 +187,9 @@ export const removeReaction = createThunkWithExplicitResult(
     const datasetId = selectActiveDatasetId(getState());
     await axiosInstance.delete(`/datasets/${datasetId}/reactions/${reactionId}`);
     dispatch(removeReactionActions.success(reactionId));
+    // Refresh the dataset so its "Last modified" and reaction counts reflect the removal
+    // even when we're already on the dataset page (navigate to the same URL is a no-op there). (#431)
+    dispatch(getDataset(datasetId));
     navigate(`/datasets/${datasetId}`);
   },
 );

--- a/ui/src/test/recordingStore.ts
+++ b/ui/src/test/recordingStore.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { configureStore, type UnknownAction } from '@reduxjs/toolkit';
+import { rootReducer } from 'store/rootReducer.ts';
+
+/**
+ * Build a real app store wired with a middleware that records every dispatched action, for
+ * thunk tests. `types()` returns the dispatched action types in order, so a test can assert
+ * that a thunk fired (or didn't fire) a given follow-up action.
+ */
+export function makeRecordingStore() {
+  const actions: Array<UnknownAction> = [];
+  const recorder = () => (next: (action: unknown) => unknown) => (action: unknown) => {
+    actions.push(action as UnknownAction);
+    return next(action);
+  };
+  const store = configureStore({
+    reducer: rootReducer,
+    middleware: getDefault => getDefault().concat(recorder),
+  });
+  return { store, types: () => actions.map(action => action.type) };
+}


### PR DESCRIPTION
## Summary

First batch of **Cluster E** (stale-data / needs-refresh) fixes from the triage plan — two targeted refetch-after-mutation fixes, each one dispatch mirroring an existing pattern.

### #431 — Dataset "Last modified" not updated after removing a reaction
`removeReaction` deletes the reaction then `navigate(/datasets/{id})`, but when the user is **already on the dataset page** that navigate is a no-op, so the dataset's `modified_at` / `reactions_count` stayed stale until a manual reload. Fix: dispatch `getDataset(datasetId)` after the delete so the dataset metadata refreshes in place.

### #611 — Datasets list doesn't refresh after creating a dataset via enumeration
`finishEnumeration`'s new-dataset branch POSTs the dataset and stores only its id via `finishEnumerationAction`; the new dataset was never added to the list store, so it didn't appear on the Datasets page — notably when the user dismisses the result modal with **"Close"** rather than "Go to Dataset". Fix: refetch the datasets list for the active group (`getInitialDatasetsList(selectActiveGroupId(...))`), mirroring the existing **extend-existing** path which already refetches.

## Scope / deferred
This PR covers the two clean, low-risk items in Cluster E. The other two are deferred to a follow-up because they need more care or cross-session setup:
- **#586** — after deleting the *last reaction on the last page*, the stored `pagination.page` isn't clamped to the new page count; needs a reducer change plus a decision on client-vs-server page semantics.
- **#584** — a dataset deleted by *another user* still shows; hinges on Datasets-route refetch-on-revisit behavior and can't be reproduced in the single-user no-auth stack.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx vitest run` — **557 passing** (extended the `removeReaction` thunk test to assert the dataset refetch; new `enumeration.thunks.test.ts` asserts the new-dataset path refetches the list)
- [x] `prettier` / `eslint` clean on changed files
- [x] **Runtime-verified #431** on the no-auth stack: removing a reaction fires `DELETE /datasets/1/reactions/1` followed by `GET /datasets/1` (the new refetch) while staying on the same page (no remount), and the reaction-count badge updates **2 → 1** without a reload.
- [x] **#611** covered by the new thunk test (asserts `getGroupsInitialDatasetListActions.request` is dispatched on the new-dataset finish path). The full enumeration wizard (template + CSV + matching) is disproportionate to drive E2E; the fix mirrors the already-working extend-existing refetch.

Closes #431, #611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Two targeted refetch-after-mutation fixes: `removeReaction` now dispatches `getDataset` after the DELETE so dataset metadata refreshes even when `navigate` is a no-op (already on that page), and the new-dataset `finishEnumeration` path now dispatches `getInitialDatasetsList` after the POST so the dataset appears without a manual reload.

- **`reactions.thunks.ts`**: `dispatch(getDataset(datasetId))` inserted between the success dispatch and the navigate call; the existing optimistic reducer + navigation are unchanged.
- **`enumeration.thunks.ts`**: `activeGroupId` captured before the async POST, then `getInitialDatasetsList(activeGroupId)` dispatched on the new-dataset path — mirrors the already-correct extend-existing branch.
- **`recordingStore.ts`**: Shared test-harness utility extracted from two duplicated inline helpers, keeping test files DRY.

<h3>Confidence Score: 5/5</h3>

Both changes are additive dispatches after a successful mutation; they cannot regress existing behavior and the failure modes (stale data) are exactly the pre-fix state.

Each fix is a single dispatch call inserted in a narrow, well-understood code path. The new enumeration path mirrors an already-working pattern in the extend-existing branch. Tests cover the dispatch chain for both fixes, and the shared makeRecordingStore refactor is mechanical with no logic changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.thunks.ts | Added dispatch(getDataset(datasetId)) after deletion to refresh dataset metadata; small, surgical fix for stale Last modified / reaction counts (#431). |
| ui/src/store/entities/enumeration/enumeration.thunks.ts | New-dataset branch now dispatches getInitialDatasetsList(activeGroupId) after the POST, mirroring the extend-existing path; activeGroupId is captured before the await to avoid a group-switch race. |
| ui/src/test/recordingStore.ts | New shared test utility extracting the action-recording store middleware that was duplicated in two thunk test files. |
| ui/src/store/entities/enumeration/enumeration.thunks.test.ts | New test file covering the new-dataset finishEnumeration path; asserts the list-refetch action is dispatched after the POST. |
| ui/src/store/entities/reactions/reactions.thunks.test.ts | Migrated to shared makeRecordingStore; removeReaction test updated to assert getDatasetActions.request is dispatched after deletion (#431). |
| ui/src/store/entities/datasets/datasets.thunks.test.ts | Replaced local makeStore helper with the shared makeRecordingStore; no logic changes. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): address #724 review — capture a..."](https://github.com/open-reaction-database/ord-app/commit/c41df68e2c332860d6ef81f4594af2815e40ad33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37446793)</sub>

<!-- /greptile_comment -->