### PR TITLE
fix(ui): "Limiting reactant" badge (#487) + readable amount units in component preview (#436)

### DIFF
--- a/ui/src/common/components/ReactionPreview/ComponentMetadata.test.tsx
+++ b/ui/src/common/components/ReactionPreview/ComponentMetadata.test.tsx
@@ -35,4 +35,26 @@ describe('ComponentMetadata', () => {
     renderWithMantine(<ComponentMetadata component={component} />);
     expect(screen.queryByText('O')).toBeNull();
   });
+
+  it('shows the "Limiting reactant" badge only when isLimiting is True (#487)', () => {
+    const limiting = { identifiers: [], isLimiting: 'True' } as unknown as ReactionInputComponent;
+    const { unmount } = renderWithMantine(<ComponentMetadata component={limiting} />);
+    expect(screen.getByText('Limiting reactant')).toBeInTheDocument();
+    unmount();
+
+    const notLimiting = { identifiers: [], isLimiting: 'False' } as unknown as ReactionInputComponent;
+    renderWithMantine(<ComponentMetadata component={notLimiting} />);
+    expect(screen.queryByText('Limiting reactant')).toBeNull();
+  });
+
+  it('renders the amount unit using the readability dictionary (#436)', () => {
+    const component = {
+      identifiers: [],
+      amount: { value: '5', units: 'GRAM' },
+    } as unknown as ReactionInputComponent;
+    renderWithMantine(<ComponentMetadata component={component} />);
+    // GRAM → "g" via the units dictionary, not the raw enum.
+    expect(screen.getByText('5 g')).toBeInTheDocument();
+    expect(screen.queryByText(/GRAM/)).toBeNull();
+  });
 });

--- a/ui/src/common/components/ReactionPreview/ComponentMetadata.tsx
+++ b/ui/src/common/components/ReactionPreview/ComponentMetadata.tsx
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Flex, Text, Tooltip } from '@mantine/core';
+import { Badge, Flex, Text, Tooltip } from '@mantine/core';
 import classes from './reactionPreview.module.scss';
 import { useMemo } from 'react';
 import type {
   ReactionInputComponent,
   ReactionProduct,
 } from 'store/entities/reactions/reactionComponent/reactionComponent.types';
+import { ReactionBoolean } from 'store/entities/reactions/reactionEntity/reactionEntity.types';
 import { renderValuePrecisionUnit } from 'features/reactions/ReactionView/renderValuePrecisionUnit';
 
 interface ComponentMetadataProps {
@@ -51,6 +52,15 @@ export function ComponentMetadata({ component }: Readonly<ComponentMetadataProps
         <Text size="xs">{renderValuePrecisionUnit(component.amount)}</Text>
       )}
       {component?.reactionRole && <Text size="xs">{component.reactionRole}</Text>}
+      {'isLimiting' in component && component.isLimiting === ReactionBoolean.True && (
+        <Badge
+          size="xs"
+          variant="light"
+          w="fit-content"
+        >
+          Limiting reactant
+        </Badge>
+      )}
     </Flex>
   );
 }

--- a/ui/src/common/dictionary/formatting.json
+++ b/ui/src/common/dictionary/formatting.json
@@ -1,10 +1,15 @@
 {
+  "KILOGRAM": "kg",
+  "GRAM": "g",
+  "MILLIGRAM": "mg",
+  "MICROGRAM": "µg",
+  "MOLE": "mol",
+  "MILLIMOLE": "mmol",
+  "MICROMOLE": "µmol",
+  "NANOMOLE": "nmol",
   "LITER": "L",
   "MILLILITER": "ml",
   "MICROLITER": "µl",
   "NANOLITER": "nl",
-  "MILLIMOLE": "mmol",
-  "MICROMOLE": "µmol",
-  "HOUR": "h",
-  "MILLIGRAM": "mg"
+  "HOUR": "h"
 }


### PR DESCRIPTION
## Summary

Two small component-preview fixes (decisions confirmed by the maintainer), both in `common/components/ReactionPreview/ComponentMetadata.tsx` and the units dictionary.

### #487 — "Limiting reactant" badge
`isLimiting` existed in the model but was never surfaced in the read/preview view. Per the maintainer's "badge when limiting" decision, the component preview now shows a small **"Limiting reactant"** badge when `isLimiting === True`.

### #436 — readable amount units under the structure
The component's amount-unit display already routes through the **#578 readability dictionary** (`renderValuePrecisionUnit` → `getFormattedValue`), but `formatting.json` only covered a handful of units, so the rest rendered as raw enums (`GRAM`, `MOLE`, …). Expanded the dictionary to cover the mass/moles amount units (`KILOGRAM`→kg, `GRAM`→g, `MICROGRAM`→µg, `MOLE`→mol, `NANOMOLE`→nmol), so e.g. "5 GRAM" now shows as "5 g".

### Also: #554 closed (no code)
Verified at runtime that the "Type" placeholder #554 reported (Conditions pH/Details/RPM) is **already gone** — every one of those fields now renders empty. Closed #554 as already-resolved.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx vitest run` — **559 passing**; `ComponentMetadata` tests assert the badge shows only for `isLimiting === True` (and is absent for `False`), and that a GRAM amount renders **"5 g"** (not the raw `GRAM` enum).
- [x] `prettier` / `eslint` clean
- [ ] Visual: the live component-edit flow (drawer + native selects + toasts) was costly to automate reliably, so verification leans on the `ComponentMetadata` tests, which render the **real** preview component and assert the exact visible output. A reviewer can eyeball a REACTANT component with a mass amount to see the "g"/badge.

Closes #487, #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces two previously missing pieces of component-preview information: a "Limiting reactant" badge when `isLimiting === ReactionBoolean.True`, and human-readable SI unit abbreviations for mass/mole amounts by expanding `formatting.json`.

- **`ComponentMetadata.tsx`**: imports `Badge` from Mantine and renders it inside an `'isLimiting' in component` guard compared against `ReactionBoolean.True`, which correctly handles the `ReactionInputComponent`/`ReactionProduct` union without touching product previews.
- **`formatting.json`**: adds `KILOGRAM`, `GRAM`, `MICROGRAM`, `MOLE`, `NANOMOLE` (plus re-orders the pre-existing `MILLIGRAM`, `MILLIMOLE`, `MICROMOLE`), completing the mass and moles unit coverage so `renderValuePrecisionUnit` no longer falls back to raw enum strings.
- **`ComponentMetadata.test.tsx`**: two new Vitest cases confirm the badge appears only for `True` and that `GRAM` renders as `"g"` (not the raw enum).

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are additive, well-tested, and scoped to the read-only preview component with no data-mutation paths.

The badge guard uses an 'isLimiting' in component check before comparing to the typed enum value, so it cannot accidentally render on ReactionProduct objects. The dictionary additions are purely additive (no keys removed that weren't already present). Tests directly exercise the two new behaviours against the real component.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/ReactionPreview/ComponentMetadata.tsx | Adds "Limiting reactant" Badge (using ReactionBoolean.True guard) and imports Badge from Mantine; logic is correct and type-safe. |
| ui/src/common/components/ReactionPreview/ComponentMetadata.test.tsx | Adds two new tests asserting the badge shows only for isLimiting=True and that GRAM renders as "g"; both cover the key behaviours from the PR. |
| ui/src/common/dictionary/formatting.json | Adds mass (KILOGRAM–NANOMOLE) SI unit abbreviations to the readability dictionary; MILLIMOLE/MICROMOLE/MILLIGRAM previously existed and were just re-ordered. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): &quot;Limiting reactant&quot; badge (#487..."](https://github.com/open-reaction-database/ord-app/commit/9c65bde01c6590b7cf3feeb6ac40dbc49bf4e00b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37450684)</sub>

<!-- /greptile_comment -->