### PR TITLE
fix(ui): paginate after deleting the last reaction on a page (#586)

### DIFF
--- a/ui/src/store/entities/reactions/reactions.thunks.test.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.test.ts
@@ -108,8 +108,8 @@ describe('removeReaction', () => {
     expect(types()).not.toContain(getReactionPageActions.request.type);
   });
 
-  it('refetches the clamped page when the last reaction on the last page is removed (#586)', async () => {
-    const { store, types } = makeStore();
+  it('refetches the clamped page (1) when the last reaction on the last page is removed (#586)', async () => {
+    const { store, actions } = makeStore();
     // On page 2 of 2, with a single reaction (#42) loaded on that page.
     store.dispatch(getReactionsListActions.request(5)); // sets the active dataset id
     store.dispatch(getReactionPageActions.request({ page: 2, size: 10 }));
@@ -122,12 +122,19 @@ describe('removeReaction', () => {
         pages: 2,
       } as unknown as Parameters<typeof getReactionPageActions.success>[0]),
     );
-    const before = types().length;
+    const before = actions().length;
 
     await store.dispatch(removeReaction(42) as unknown as UnknownAction);
 
-    // Page 2 is now past the new last page (1), so the thunk refetches the clamped page.
-    expect(types().slice(before)).toContain(getReactionPageActions.request.type);
+    // Page 2 is now past the new last page (1), so the thunk refetches the clamped page —
+    // assert it requests page 1 specifically, not just that some page request fired.
+    const refetch = actions()
+      .slice(before)
+      .find(action => action.type === getReactionPageActions.request.type) as
+      | { payload?: { page?: number } }
+      | undefined;
+    expect(refetch).toBeDefined();
+    expect(refetch?.payload?.page).toBe(1);
   });
 });
 

--- a/ui/src/store/entities/reactions/reactions.thunks.test.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.test.ts
@@ -102,9 +102,32 @@ describe('removeReaction', () => {
     // Refetches the parent dataset so its "Last modified" / reaction counts refresh
     // even when already on the dataset page (navigate is a no-op there). (#431)
     expect(types()).toContain(getDatasetActions.request.type);
-    // Removal still updates the reactions store optimistically (reducer prunes order + total) and
-    // does NOT trigger a reactions-list refetch — no getReactionPage request follows the success.
+    // In the common case (not the last reaction on an out-of-range page) removal just prunes the
+    // store optimistically and does NOT refetch the list — no getReactionPage request. (#586 covers
+    // the edge case where a refetch IS needed; see the next test.)
     expect(types()).not.toContain(getReactionPageActions.request.type);
+  });
+
+  it('refetches the clamped page when the last reaction on the last page is removed (#586)', async () => {
+    const { store, types } = makeStore();
+    // On page 2 of 2, with a single reaction (#42) loaded on that page.
+    store.dispatch(getReactionsListActions.request(5)); // sets the active dataset id
+    store.dispatch(getReactionPageActions.request({ page: 2, size: 10 }));
+    store.dispatch(
+      getReactionPageActions.success({
+        items: [{ id: 42, data: {} }],
+        page: 2,
+        size: 10,
+        total: 11,
+        pages: 2,
+      } as unknown as Parameters<typeof getReactionPageActions.success>[0]),
+    );
+    const before = types().length;
+
+    await store.dispatch(removeReaction(42) as unknown as UnknownAction);
+
+    // Page 2 is now past the new last page (1), so the thunk refetches the clamped page.
+    expect(types().slice(before)).toContain(getReactionPageActions.request.type);
   });
 });
 

--- a/ui/src/store/entities/reactions/reactions.thunks.ts
+++ b/ui/src/store/entities/reactions/reactions.thunks.ts
@@ -29,7 +29,12 @@ import {
 import axiosInstance from 'store/axiosInstance.ts';
 import type { Pages } from 'common/types';
 import type { AppReaction, ReactionId, ReactionResponse, UpdateReactionSuccessPayload } from './reactions.types.ts';
-import { selectActiveDatasetId, selectReactionById, selectReactionsPagination } from './reactions.selectors.ts';
+import {
+  selectActiveDatasetId,
+  selectReactionById,
+  selectReactionsOrder,
+  selectReactionsPagination,
+} from './reactions.selectors.ts';
 import { navigate } from 'wouter/use-browser-location';
 import type { AppState } from '../../configureAppStore.ts';
 import { ord } from 'ord-schema-protobufjs';
@@ -190,6 +195,13 @@ export const removeReaction = createThunkWithExplicitResult(
     // Refresh the dataset so its "Last modified" and reaction counts reflect the removal
     // even when we're already on the dataset page (navigate to the same URL is a no-op there). (#431)
     dispatch(getDataset(datasetId));
+    // If removing the last reaction on the current page left it empty or past the new last page,
+    // fetch the now-correct page so pagination and the list stay usable without a reload. (#586)
+    // (The list is server-paged, so the optimistic prune alone leaves the page stranded.)
+    const { page, pages } = selectReactionsPagination(getState());
+    if (pages > 0 && (page > pages || selectReactionsOrder(getState()).length === 0)) {
+      dispatch(getReactionsPage({ page: Math.min(page, pages) }));
+    }
     navigate(`/datasets/${datasetId}`);
   },
 );

--- a/ui/src/test/recordingStore.ts
+++ b/ui/src/test/recordingStore.ts
@@ -31,5 +31,10 @@ export function makeRecordingStore() {
     reducer: rootReducer,
     middleware: getDefault => getDefault().concat(recorder),
   });
-  return { store, types: () => actions.map(action => action.type) };
+  return {
+    store,
+    types: () => actions.map(action => action.type),
+    // The raw recorded actions, for asserting payloads (not just types).
+    actions: () => [...actions],
+  };
 }


### PR DESCRIPTION
## Summary

The dataset reaction list is **server-paged** (each page fetch replaces `reactionsOrder`; the list renders exactly the current page's items). When you removed the **last reaction on the last page**, the reducer optimistically pruned the item and decremented `total`/`pages`, but left `pagination.page` pointing **past the new last page** — so the list rendered empty and the pager was stuck on a non-existent page until a manual reload (#586).

### Fix
`removeReaction` now, after the optimistic update, checks the pagination and **refetches the clamped page** (`min(page, pages)`) when the current page is left empty or out of range:

```ts
const { page, pages } = selectReactionsPagination(getState());
if (pages > 0 && (page > pages || selectReactionsOrder(getState()).length === 0)) {
  dispatch(getReactionsPage({ page: Math.min(page, pages) }));
}
```

The **common case** — removing a reaction that isn't the last on an out-of-range page — is unchanged: it just prunes optimistically with no refetch (snappy). When the dataset is emptied entirely (`pages === 0`), no fetch is issued and the empty state shows.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx vitest run` — **560 passing**; new thunk test asserts the refetch fires when the last reaction on page 2-of-2 is removed, and the existing characterization test confirms the common case still issues **no** refetch.
- [x] `prettier` / `eslint` clean
- [ ] Runtime verification in progress (seed 11 reactions → page 2 → delete the last → confirm landing on page 1 with data); will confirm on the PR.

Closes #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a stale-pagination bug (#586) where deleting the last reaction on a page left the reactions list stranded on a now-non-existent page until a manual reload. The fix adds a post-deletion guard in `removeReaction` that reads the updated pagination state after the optimistic prune and issues a `getReactionsPage` call for the clamped page when needed.

- `reactions.thunks.ts`: After dispatching `removeReactionActions.success`, reads the updated `page`/`pages` from the store and refetches `Math.min(page, pages)` when the page is empty or out of range; the empty-dataset guard (`pages > 0`) prevents a spurious fetch when all reactions are gone.
- `reactions.thunks.test.ts`: Adds a targeted thunk test that seeds a two-page store with one reaction on page 2, deletes it, and asserts the dispatched `getReactionPageActions.request` carries `{ page: 1 }` — verifying the clamp arithmetic, not just that some request fired.
- `recordingStore.ts`: Exposes a raw `actions()` accessor so tests can inspect action payloads alongside the pre-existing `types()` helper.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to a post-deletion pagination check in one thunk, with both the common path and the edge case covered by precise payload-asserting tests.

The optimistic-prune + conditional-refetch logic aligns correctly with how the reducer updates pagination.pages after removeReactionActions.success, and with how getReactionPageActions.request propagates the page argument into state before the thunk body reads it. The pages > 0 guard cleanly handles the empty-dataset case.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.thunks.ts | Adds post-deletion pagination guard in removeReaction: reads updated pagination after the optimistic prune and refetches the clamped page when the current page is left empty or out of range. |
| ui/src/store/entities/reactions/reactions.thunks.test.ts | Adds a new test asserting the clamped-page refetch fires with payload { page: 1 } when the last reaction on page 2-of-2 is removed; updates the existing no-refetch characterisation test comment accordingly. |
| ui/src/test/recordingStore.ts | Exposes a raw actions() accessor alongside the existing types() helper so tests can assert action payloads, not just action types. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): assert the #586 refetch target..."](https://github.com/open-reaction-database/ord-app/commit/0be7a3c84a2257d5e8eef477ef57b816204928f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37451072)</sub>

<!-- /greptile_comment -->