### PR TITLE
fix(ui): restrict the dataset Remove action to Admins (#610)

### DIFF
--- a/ui/src/features/datasets/DatasetHeader/DatasetHeader.tsx
+++ b/ui/src/features/datasets/DatasetHeader/DatasetHeader.tsx
@@ -34,7 +34,10 @@ import { useDisclosure } from '@mantine/hooks';
 import { removeDataset } from 'store/entities/datasets/datasets.thunks.ts';
 import { GroupsListWithRoles } from 'common/components/GroupsListWithRoles/GroupsListWithRoles.tsx';
 import classes from './datasetHeader.module.scss';
-import { selectCanDatasetBeEdited } from 'store/features/canDatasetBeEdited/canDatasetBeEdited.selectors.ts';
+import {
+  selectCanDatasetBeDeleted,
+  selectCanDatasetBeEdited,
+} from 'store/features/canDatasetBeEdited/canDatasetBeEdited.selectors.ts';
 import { domain } from 'common/configuration.constants.ts';
 import { typographyClasses } from 'common/styling';
 import { ShareDataset } from '../ShareDataset/ShareDataset.tsx';
@@ -50,6 +53,7 @@ export function DatasetHeader({ dataset }: Readonly<DatasetHeaderProps>) {
   const isEditOpened = useSelector(selectIsDatasetOpened);
   const [removeConfirmOpened, { open: openRemoveConfirm, close: closeRemoveConfirm }] = useDisclosure(false);
   const canDatasetBeEdited = useSelector(selectCanDatasetBeEdited);
+  const canDatasetBeDeleted = useSelector(selectCanDatasetBeDeleted);
 
   const openEdit = useCallback(() => {
     dispatch(setDatasetEditOpenedAction(true));
@@ -136,7 +140,7 @@ export function DatasetHeader({ dataset }: Readonly<DatasetHeaderProps>) {
         className={classes.buttonContainer}
         gap="sm"
       >
-        {canDatasetBeEdited && (
+        {canDatasetBeDeleted && (
           <ConfirmPopover
             opened={removeConfirmOpened}
             position="right"

--- a/ui/src/store/features/canDatasetBeEdited/canDatasetBeEdited.selectors.test.ts
+++ b/ui/src/store/features/canDatasetBeEdited/canDatasetBeEdited.selectors.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, it, expect } from 'vitest';
-import { selectCanDatasetBeEdited } from './canDatasetBeEdited.selectors.ts';
+import { selectCanDatasetBeDeleted, selectCanDatasetBeEdited } from './canDatasetBeEdited.selectors.ts';
 import { USER_ROLES } from 'common/types';
 import type { Dataset } from 'store/entities/datasets/datasets.types.ts';
 import type { GroupItem } from 'store/entities/groups/groups.types.ts';
@@ -64,5 +64,35 @@ describe('selectCanDatasetBeEdited', () => {
   it('is false when a dataset group is missing from the groups store (undefined role)', () => {
     const state = buildState(1, { 1: datasetWithGroups([99]) }, {});
     expect(selectCanDatasetBeEdited(state)).toBe(false);
+  });
+});
+
+describe('selectCanDatasetBeDeleted (Admin-only, #610)', () => {
+  it('is true only when the user is an admin in one of the dataset groups', () => {
+    const state = buildState(1, { 1: datasetWithGroups([10]) }, { 10: group(10, USER_ROLES.ADMIN) });
+    expect(selectCanDatasetBeDeleted(state)).toBe(true);
+  });
+
+  it('is false for an editor (editors can edit but not delete)', () => {
+    const state = buildState(1, { 1: datasetWithGroups([10]) }, { 10: group(10, USER_ROLES.EDITOR) });
+    expect(selectCanDatasetBeDeleted(state)).toBe(false);
+  });
+
+  it('is false for a viewer', () => {
+    const state = buildState(1, { 1: datasetWithGroups([10]) }, { 10: group(10, USER_ROLES.VIEWER) });
+    expect(selectCanDatasetBeDeleted(state)).toBe(false);
+  });
+
+  it('is true when the user is admin in at least one of several dataset groups', () => {
+    const state = buildState(
+      1,
+      { 1: datasetWithGroups([10, 20]) },
+      { 10: group(10, USER_ROLES.EDITOR), 20: group(20, USER_ROLES.ADMIN) },
+    );
+    expect(selectCanDatasetBeDeleted(state)).toBe(true);
+  });
+
+  it('is false when the active dataset is not loaded', () => {
+    expect(selectCanDatasetBeDeleted(buildState(1, {}, {}))).toBe(false);
   });
 });

--- a/ui/src/store/features/canDatasetBeEdited/canDatasetBeEdited.selectors.ts
+++ b/ui/src/store/features/canDatasetBeEdited/canDatasetBeEdited.selectors.ts
@@ -19,13 +19,21 @@ import { selectGroupsByIds } from '../../entities/groups/groups.selectors.ts';
 import { selectDatasets } from '../../entities/datasets/datasets.selectors.ts';
 import { USER_ROLES } from 'common/types';
 
-export const selectCanDatasetBeEdited = createSelector(
+const selectActiveDatasetRoles = createSelector(
   [selectActiveDatasetId, selectDatasets, selectGroupsByIds],
   (activeDatasetId, datasets, groups) => {
     const dataset = datasets[activeDatasetId];
-    if (!dataset) return false;
-
-    const roles = dataset.groups.map(group => groups[group.id]?.role);
-    return roles.some(role => [USER_ROLES.ADMIN, USER_ROLES.EDITOR].includes(role));
+    if (!dataset) return [];
+    return dataset.groups.map(group => groups[group.id]?.role);
   },
+);
+
+// Editing is allowed for Admins and Editors.
+export const selectCanDatasetBeEdited = createSelector([selectActiveDatasetRoles], roles =>
+  roles.some(role => [USER_ROLES.ADMIN, USER_ROLES.EDITOR].includes(role)),
+);
+
+// Deleting a dataset is Admin-only — Editors can edit but must not see/use the Remove action. (#610)
+export const selectCanDatasetBeDeleted = createSelector([selectActiveDatasetRoles], roles =>
+  roles.some(role => role === USER_ROLES.ADMIN),
 );


### PR DESCRIPTION
## Summary

The Dataset View gated the **"Remove" button** on `selectCanDatasetBeEdited`, which is true for both **Admins and Editors** — so an Editor saw (and could trigger) Remove. Deleting a dataset should be **Admin-only**.

### Fix
- Added `selectCanDatasetBeDeleted` (Admin-only) next to the existing `selectCanDatasetBeEdited`, refactoring the shared "roles for the active dataset's groups" logic into one memoized selector.
- Gated the Remove `ConfirmPopover` in `DatasetHeader` on `selectCanDatasetBeDeleted`. All editing affordances stay on `selectCanDatasetBeEdited` (unchanged).
- Consistent with the existing "any group" semantics: a user who is Admin in **any** of the dataset's groups can delete it.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx vitest run` — selector tests assert `selectCanDatasetBeDeleted` is **true only for Admin** (false for Editor and Viewer, true if Admin in any of several groups, false when the dataset isn't loaded). 560 passing.
- [x] `prettier` / `eslint` clean
- [ ] Runtime: the **Admin** case (Remove still shown) is observable and unchanged; the **Editor-hidden** case can't be exercised in the single-user no-auth stack (the dev user is always Admin of their groups), so it's covered by the selector unit tests + the direct gate swap.

Closes #610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UI authorization gap where Editors could see and trigger the dataset Remove action, which should be Admin-only. It aligns the frontend gate with the backend `DELETE /datasets/{dataset_id}` endpoint, which already enforces `admin`-only authorization.

- Extracts a private `selectActiveDatasetRoles` memoized selector to deduplicate the role-lookup logic shared by both `selectCanDatasetBeEdited` (Admin + Editor) and the new `selectCanDatasetBeDeleted` (Admin only).
- Replaces the `canDatasetBeEdited` guard on the Remove `ConfirmPopover` in `DatasetHeader` with `canDatasetBeDeleted`, leaving all edit affordances unchanged.
- Adds five unit tests covering Admin, Editor, Viewer, multi-group, and no-dataset scenarios for the new selector.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single targeted gate swap backed by unit tests and consistent with existing backend enforcement.

The change is minimal: one selector file, one component file, one test file. The new `selectCanDatasetBeDeleted` selector is well-tested, the refactor to `selectActiveDatasetRoles` preserves existing behavior for `selectCanDatasetBeEdited`, and the backend already enforces admin-only deletion independently. No regressions were introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/features/canDatasetBeEdited/canDatasetBeEdited.selectors.ts | Refactors shared role-lookup logic into a private memoized selector and adds the new Admin-only `selectCanDatasetBeDeleted`; clean and correct. |
| ui/src/store/features/canDatasetBeEdited/canDatasetBeEdited.selectors.test.ts | Adds five unit tests for `selectCanDatasetBeDeleted` covering Admin, Editor, Viewer, multi-group (admin in any), and no-dataset cases. |
| ui/src/features/datasets/DatasetHeader/DatasetHeader.tsx | Swaps `canDatasetBeEdited` for `canDatasetBeDeleted` on the Remove/ConfirmPopover gate; edit affordances remain unchanged. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): restrict the dataset Remove act..."](https://github.com/open-reaction-database/ord-app/commit/a8c3fc731da9ff35f11c8651435146d64699d7b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37451746)</sub>

<!-- /greptile_comment -->