### PR TITLE
fix(ui): order outcomes by reaction time in the reaction view (#599)

### DIFF
--- a/ui/src/features/reactions/ReactionView/Outcomes/Outcomes.tsx
+++ b/ui/src/features/reactions/ReactionView/Outcomes/Outcomes.tsx
@@ -25,6 +25,7 @@ import classes from './outcomes.module.scss';
 import { typographyClasses } from 'common/styling';
 import type { ReactionOutcome } from 'store/entities/reactions/reactionsOutcomes/reactionOutcomes.types.ts';
 import { ordOutcomeToReactionOutcome } from 'store/entities/reactions/reactionsOutcomes/reactionOutcomes.converters.ts';
+import { sortOutcomesByReactionTime } from 'store/entities/reactions/reactionsOutcomes/reactionOutcomes.utils.ts';
 import { OutcomeListItem } from 'features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItem.tsx';
 import { useMemo, useContext } from 'react';
 import { reactionContext } from '../../reactions.context.ts';
@@ -46,6 +47,9 @@ export function Outcomes({ reactionId }: ReactionViewSectionProps) {
   };
 
   const ids = useMemo(() => outcomes?.map(outcome => outcome.id), [outcomes]);
+  // Display outcomes ordered by reaction time when available, else stored order. The original
+  // stored index is preserved for each so the edit path stays correct. (#599)
+  const orderedOutcomes = useMemo(() => sortOutcomesByReactionTime(outcomes ?? []), [outcomes]);
 
   return (
     <Flex direction="column">
@@ -76,7 +80,7 @@ export function Outcomes({ reactionId }: ReactionViewSectionProps) {
           className={classes.itemsList}
           defaultValue={ids}
         >
-          {outcomes.map((outcome, index) => (
+          {orderedOutcomes.map(({ outcome, index }) => (
             <OutcomeListItem
               key={outcome.id}
               reactionId={reactionId}

--- a/ui/src/store/entities/reactions/reactionsOutcomes/reactionOutcomes.utils.test.ts
+++ b/ui/src/store/entities/reactions/reactionsOutcomes/reactionOutcomes.utils.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { sortOutcomesByReactionTime } from './reactionOutcomes.utils.ts';
+import type { ReactionOutcome } from './reactionOutcomes.types.ts';
+
+const outcome = (id: number, value?: number, units?: string): ReactionOutcome =>
+  ({ id, reactionTime: { value, units } }) as unknown as ReactionOutcome;
+
+const order = (outcomes: Array<ReactionOutcome>) =>
+  sortOutcomesByReactionTime(outcomes).map(({ outcome, index }) => ({ id: outcome.id, index }));
+
+describe('sortOutcomesByReactionTime (#599)', () => {
+  it('orders by ascending reaction time while preserving each outcome’s stored index', () => {
+    // stored order ids: 1 (2h), 2 (30min), 3 (1h)
+    const result = order([outcome(1, 2, 'HOUR'), outcome(2, 30, 'MINUTE'), outcome(3, 1, 'HOUR')]);
+    expect(result.map(r => r.id)).toEqual([2, 3, 1]); // 30min < 1h < 2h
+    // The original stored index travels with each outcome (for the edit path).
+    expect(result).toEqual([
+      { id: 2, index: 1 },
+      { id: 3, index: 2 },
+      { id: 1, index: 0 },
+    ]);
+  });
+
+  it('normalizes across units (DAY/HOUR/MINUTE/SECOND)', () => {
+    const result = order([outcome(1, 1, 'DAY'), outcome(2, 90, 'MINUTE'), outcome(3, 5000, 'SECOND')]);
+    // 90min = 5400s, 5000s, 1day = 86400s
+    expect(result.map(r => r.id)).toEqual([3, 2, 1]);
+  });
+
+  it('keeps stored order for outcomes without a usable reaction time, after the timed ones', () => {
+    const result = order([
+      outcome(1), // no time
+      outcome(2, 1, 'HOUR'),
+      outcome(3), // no time
+      outcome(4, 30, 'MINUTE'),
+    ]);
+    expect(result.map(r => r.id)).toEqual([4, 2, 1, 3]); // timed asc (30m, 1h), then untimed in stored order
+  });
+
+  it('preserves stored order when no outcome has a reaction time', () => {
+    const result = order([outcome(3), outcome(1), outcome(2)]);
+    expect(result.map(r => r.id)).toEqual([3, 1, 2]);
+  });
+
+  it('treats an unknown/unspecified unit as no usable time', () => {
+    const result = order([outcome(1, 5, 'UNSPECIFIED'), outcome(2, 1, 'HOUR')]);
+    expect(result.map(r => r.id)).toEqual([2, 1]); // timed first, unspecified-unit outcome last
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [outcome(1, 2, 'HOUR'), outcome(2, 1, 'HOUR')];
+    const snapshot = input.map(o => o.id);
+    sortOutcomesByReactionTime(input);
+    expect(input.map(o => o.id)).toEqual(snapshot);
+  });
+});

--- a/ui/src/store/entities/reactions/reactionsOutcomes/reactionOutcomes.utils.ts
+++ b/ui/src/store/entities/reactions/reactionsOutcomes/reactionOutcomes.utils.ts
@@ -15,18 +15,23 @@
  */
 import type { ReactionOutcome } from './reactionOutcomes.types.ts';
 import type { ReactionTime } from '../reactionEntity/reactionEntity.types.ts';
+import type { ReactionTimeType } from '../reactionEntityTypes/reactionEntityTypes.types.ts';
 
 // Reaction-time units normalized to seconds so outcomes recorded in different units sort correctly.
-const TIME_UNIT_TO_SECONDS: Record<string, number> = {
+// `satisfies` makes this exhaustive at compile time: every non-UNSPECIFIED `ord.Time.TimeUnit`
+// must have a factor here, so adding a unit to the schema (e.g. WEEK) breaks the build until mapped.
+const TIME_UNIT_TO_SECONDS = {
   DAY: 86_400,
   HOUR: 3_600,
   MINUTE: 60,
   SECOND: 1,
-};
+} satisfies Record<Exclude<ReactionTimeType, 'UNSPECIFIED'>, number>;
 
 /** A reaction time normalized to seconds, or undefined when it has no usable value/unit. */
 function reactionTimeInSeconds(time: ReactionTime | undefined): number | undefined {
-  const unitSeconds = time?.units ? TIME_UNIT_TO_SECONDS[time.units] : undefined;
+  const unitSeconds = time?.units
+    ? (TIME_UNIT_TO_SECONDS as Record<string, number | undefined>)[time.units]
+    : undefined;
   if (time?.value == null || unitSeconds === undefined) return undefined;
   return time.value * unitSeconds;
 }

--- a/ui/src/store/entities/reactions/reactionsOutcomes/reactionOutcomes.utils.ts
+++ b/ui/src/store/entities/reactions/reactionsOutcomes/reactionOutcomes.utils.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ReactionOutcome } from './reactionOutcomes.types.ts';
+import type { ReactionTime } from '../reactionEntity/reactionEntity.types.ts';
+
+// Reaction-time units normalized to seconds so outcomes recorded in different units sort correctly.
+const TIME_UNIT_TO_SECONDS: Record<string, number> = {
+  DAY: 86_400,
+  HOUR: 3_600,
+  MINUTE: 60,
+  SECOND: 1,
+};
+
+/** A reaction time normalized to seconds, or undefined when it has no usable value/unit. */
+function reactionTimeInSeconds(time: ReactionTime | undefined): number | undefined {
+  const unitSeconds = time?.units ? TIME_UNIT_TO_SECONDS[time.units] : undefined;
+  if (time?.value == null || unitSeconds === undefined) return undefined;
+  return time.value * unitSeconds;
+}
+
+/**
+ * Order outcomes for display by reaction time (ascending) when available, otherwise keep their
+ * stored order. (#599)
+ *
+ * Outcomes without a usable reaction time retain their stored order and follow the timed ones;
+ * ties break on stored order. Stable and non-mutating — each outcome is returned with its original
+ * stored index so the edit path (`['outcomes', index]`) stays correct regardless of display order.
+ */
+export function sortOutcomesByReactionTime(
+  outcomes: Array<ReactionOutcome>,
+): Array<{ outcome: ReactionOutcome; index: number }> {
+  return outcomes
+    .map((outcome, index) => ({ outcome, index, seconds: reactionTimeInSeconds(outcome.reactionTime) }))
+    .sort((a, b) => {
+      if (a.seconds === undefined && b.seconds === undefined) return a.index - b.index;
+      if (a.seconds === undefined) return 1;
+      if (b.seconds === undefined) return -1;
+      return a.seconds - b.seconds || a.index - b.index;
+    })
+    .map(({ outcome, index }) => ({ outcome, index }));
+}


### PR DESCRIPTION
## Summary

Per **AC#4 of #53** (#599): outcomes should display **ordered by reaction time when available, otherwise in stored order**. The Outcomes list rendered them in raw stored order.

### Fix
New `sortOutcomesByReactionTime` helper:
- Normalizes reaction time to **seconds** (`DAY`/`HOUR`/`MINUTE`/`SECOND`) so outcomes recorded in different units sort correctly.
- **Stable** ascending sort; **non-mutating**.
- Preserves each outcome's **original stored index**, which is passed as `outcomeIndex` (the edit path is `['outcomes', index]`) — so reordering the display never targets the wrong outcome when editing. `outcomeIndex` is path-only (not a displayed number), so there's no numbering side effect.

### ⚠️ Interpretation to confirm (review)
The AC is explicit for the all-timed case but underspecified when **some** outcomes lack a reaction time. I chose: **timed outcomes first (ascending), then untimed in stored order** (an unspecified/unknown unit counts as "no usable time"). If you'd rather untimed outcomes stay interleaved in stored position, or only reorder when *every* outcome has a time, say so and I'll adjust.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx vitest run` — 6 new `sortOutcomesByReactionTime` tests (ascending order + index preserved; cross-unit normalization; untimed kept in stored order after timed; all-untimed unchanged; unspecified unit treated as untimed; input not mutated). Full suite green.
- [x] `prettier` / `eslint` clean
- [ ] Held for review — behavioral display change; the runtime setup (multiple outcomes with differing reaction times) is awkward to script, and the sort logic is fully unit-covered.

Closes #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces `sortOutcomesByReactionTime` to display reaction outcomes in ascending reaction-time order, falling back to stored order for untimed outcomes, and wires it into `Outcomes.tsx` while preserving original stored indices for correct edit paths.

- New `reactionOutcomes.utils.ts` normalises reaction time to seconds, uses a `satisfies`-enforced map so any future schema unit addition breaks the build rather than silently misbehaving, and performs a stable non-mutating sort.
- `Outcomes.tsx` adds a single `useMemo` for the sorted list and destructures `{ outcome, index }` so `outcomeIndex` passed to `OutcomeListItem` always reflects the stored position, not the display position.
- Six unit tests cover the key behaviours: ascending order, cross-unit normalisation, untimed-after-timed, all-untimed stability, UNSPECIFIED-unit treatment, and input immutability.

<h3>Confidence Score: 5/5</h3>

Safe to merge — isolated display-order change with no mutation of stored data and full preservation of edit paths.

The change is narrowly scoped to rendering order. The sort helper is non-mutating, original stored indices flow through unchanged to `outcomeIndex`, and the unit-exhaustiveness constraint is compile-time enforced. The six unit tests cover every documented edge case. No store writes, selectors, or API calls are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactionsOutcomes/reactionOutcomes.utils.ts | New utility: `reactionTimeInSeconds` normalizer + `sortOutcomesByReactionTime` exported function. Compile-time exhaustive unit map via `satisfies`, stable non-mutating sort, preserves original stored index. |
| ui/src/store/entities/reactions/reactionsOutcomes/reactionOutcomes.utils.test.ts | Six focused unit tests covering ascending sort, cross-unit normalization, untimed-after-timed ordering, all-untimed stability, UNSPECIFIED unit treatment, and non-mutation. Good coverage of the defined behaviour. |
| ui/src/features/reactions/ReactionView/Outcomes/Outcomes.tsx | Adds `orderedOutcomes` memo via `sortOutcomesByReactionTime`, replaces raw `.map` with destructured `{ outcome, index }` iteration, passes original stored `index` as `outcomeIndex` to preserve edit paths. Minimal and correct change. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(ui): make the outcome time-unit..."](https://github.com/open-reaction-database/ord-app/commit/efefbeab53d918a8dff6d5408677e96709c7a4d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37453074)</sub>

<!-- /greptile_comment -->