### PR TITLE
fix(ui): show conversion % and yield % in the outcome preview (#598)

### DIFF
--- a/ui/src/common/components/ReactionPreview/ComponentMetadata.test.tsx
+++ b/ui/src/common/components/ReactionPreview/ComponentMetadata.test.tsx
@@ -57,4 +57,13 @@ describe('ComponentMetadata', () => {
     expect(screen.getByText('5 g')).toBeInTheDocument();
     expect(screen.queryByText(/GRAM/)).toBeNull();
   });
+
+  it("shows a product's yield % from its YIELD measurement (#598)", () => {
+    const product = {
+      identifiers: [],
+      measurements: [{ type: 'YIELD', value: { type: '%', value: { value: 85 } } }],
+    } as unknown as ReactionInputComponent;
+    renderWithMantine(<ComponentMetadata component={product} />);
+    expect(screen.getByText('85% yield')).toBeInTheDocument();
+  });
 });

--- a/ui/src/common/components/ReactionPreview/ComponentMetadata.tsx
+++ b/ui/src/common/components/ReactionPreview/ComponentMetadata.tsx
@@ -22,6 +22,7 @@ import type {
 } from 'store/entities/reactions/reactionComponent/reactionComponent.types';
 import { ReactionBoolean } from 'store/entities/reactions/reactionEntity/reactionEntity.types';
 import { renderValuePrecisionUnit } from 'features/reactions/ReactionView/renderValuePrecisionUnit';
+import { getProductYieldPercent } from 'common/components/ReactionPreview/reactionPreview.utils.ts';
 
 interface ComponentMetadataProps {
   component: ReactionInputComponent | ReactionProduct;
@@ -31,6 +32,14 @@ export function ComponentMetadata({ component }: Readonly<ComponentMetadataProps
   const name = useMemo(() => {
     return (component.identifiers || []).find(identifier => identifier.type === 'NAME');
   }, [component]);
+
+  // Products carry a yield as a YIELD measurement; surface it as a bottom-label "% yield". (#598)
+  const productYield = useMemo(
+    () => ('measurements' in component ? getProductYieldPercent(component) : undefined),
+    [component],
+  );
+  const amount = 'amount' in component ? component.amount : undefined;
+  const isLimiting = 'isLimiting' in component && component.isLimiting === ReactionBoolean.True;
 
   return (
     <Flex
@@ -48,11 +57,10 @@ export function ComponentMetadata({ component }: Readonly<ComponentMetadataProps
           </Text>
         </Tooltip>
       )}
-      {'amount' in component && component?.amount && (
-        <Text size="xs">{renderValuePrecisionUnit(component.amount)}</Text>
-      )}
+      {amount && <Text size="xs">{renderValuePrecisionUnit(amount)}</Text>}
+      {productYield != null && <Text size="xs">{productYield}% yield</Text>}
       {component?.reactionRole && <Text size="xs">{component.reactionRole}</Text>}
-      {'isLimiting' in component && component.isLimiting === ReactionBoolean.True && (
+      {isLimiting && (
         <Badge
           size="xs"
           variant="light"

--- a/ui/src/common/components/ReactionPreview/ComponentMetadata.tsx
+++ b/ui/src/common/components/ReactionPreview/ComponentMetadata.tsx
@@ -22,7 +22,7 @@ import type {
 } from 'store/entities/reactions/reactionComponent/reactionComponent.types';
 import { ReactionBoolean } from 'store/entities/reactions/reactionEntity/reactionEntity.types';
 import { renderValuePrecisionUnit } from 'features/reactions/ReactionView/renderValuePrecisionUnit';
-import { getProductYieldPercent } from 'common/components/ReactionPreview/reactionPreview.utils.ts';
+import { getProductYieldPercent } from 'common/components/ReactionPreview/reactionPreview.utils';
 
 interface ComponentMetadataProps {
   component: ReactionInputComponent | ReactionProduct;

--- a/ui/src/common/components/ReactionPreview/ReactionOutcomePreview.tsx
+++ b/ui/src/common/components/ReactionPreview/ReactionOutcomePreview.tsx
@@ -38,6 +38,12 @@ export function ReactionOutcomePreview({ reactionId, outcomeIndex }: Readonly<Re
   const outcomeTime = useMemo(() => {
     return outcome.reactionTime?.value ? renderValuePrecisionUnit(outcome.reactionTime) : '';
   }, [outcome.reactionTime]);
+  // Top label: reaction time and the limiting-reactant conversion %, when available. (#598)
+  const outcomeLabel = useMemo(() => {
+    const conversion = outcome.conversion?.value != null ? `${outcome.conversion.value}% conversion` : '';
+    const parts = [outcomeTime, conversion].filter(Boolean);
+    return parts.length > 0 ? ` (${parts.join(', ')})` : '';
+  }, [outcomeTime, outcome.conversion]);
 
   return (
     <div className={classes.inputCard}>
@@ -46,7 +52,7 @@ export function ReactionOutcomePreview({ reactionId, outcomeIndex }: Readonly<Re
         color="primary"
         size="lg"
       >
-        Outcome{outcomeTime ? ` (${outcomeTime})` : ''}
+        Outcome{outcomeLabel}
       </Badge>
       <Flex
         gap="sm"

--- a/ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts
+++ b/ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts
@@ -15,9 +15,10 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as htmlToImage from 'html-to-image';
-import { copyPreviewAsImage } from './reactionPreview.utils.ts';
+import { copyPreviewAsImage, getProductYieldPercent } from './reactionPreview.utils.ts';
 import { showNotification } from 'common/utils/showNotification.tsx';
 import { NotificationVariant } from 'common/types/notification.ts';
+import type { ReactionProduct } from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
 
 vi.mock('html-to-image', () => ({ toBlob: vi.fn() }));
 vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
@@ -67,5 +68,39 @@ describe('copyPreviewAsImage', () => {
     toBlobMock.mockRejectedValue(new Error('boom'));
     await copyPreviewAsImage(node);
     expectNotified(NotificationVariant.ERROR);
+  });
+});
+
+describe('getProductYieldPercent (#598)', () => {
+  const product = (measurements: Array<unknown>): ReactionProduct => ({ measurements }) as unknown as ReactionProduct;
+
+  it('returns the percent value of a YIELD measurement', () => {
+    const p = product([
+      { type: 'PURITY', value: { type: '%', value: { value: 99 } } },
+      { type: 'YIELD', value: { type: '%', value: { value: 85 } } },
+    ]);
+    expect(getProductYieldPercent(p)).toBe(85);
+  });
+
+  it('returns undefined when there is no YIELD measurement', () => {
+    expect(
+      getProductYieldPercent(product([{ type: 'PURITY', value: { type: '%', value: { value: 99 } } }])),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the YIELD measurement is not a percent value', () => {
+    expect(
+      getProductYieldPercent(product([{ type: 'YIELD', value: { type: 'String', value: 'n/a' } }])),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the YIELD percent has no numeric value', () => {
+    expect(
+      getProductYieldPercent(product([{ type: 'YIELD', value: { type: '%', value: { value: null } } }])),
+    ).toBeUndefined();
+  });
+
+  it('handles a product with no measurements', () => {
+    expect(getProductYieldPercent({} as ReactionProduct)).toBeUndefined();
   });
 });

--- a/ui/src/common/components/ReactionPreview/reactionPreview.utils.ts
+++ b/ui/src/common/components/ReactionPreview/reactionPreview.utils.ts
@@ -16,6 +16,25 @@
 import { showNotification } from 'common/utils/showNotification.tsx';
 import * as htmlToImage from 'html-to-image';
 import { NotificationVariant, type AppNotification } from 'common/types/notification.ts';
+import {
+  ReactionMeasurementValueType,
+  type ReactionProduct,
+} from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
+
+// The protobuf ProductMeasurementType key for a yield measurement.
+const YIELD_MEASUREMENT_TYPE = 'YIELD';
+
+/**
+ * The product's yield as a percent number, or undefined when there's no usable YIELD measurement.
+ * Used to surface the yield % in the outcome/product preview. (#598)
+ */
+export function getProductYieldPercent(product: ReactionProduct): number | undefined {
+  const yieldValue = product.measurements?.find(measurement => measurement.type === YIELD_MEASUREMENT_TYPE)?.value;
+  if (yieldValue?.type === ReactionMeasurementValueType.Percent && yieldValue.value.value != null) {
+    return yieldValue.value.value;
+  }
+  return undefined;
+}
 
 const errorMessage: AppNotification = {
   variant: NotificationVariant.ERROR,


### PR DESCRIPTION
## Summary

Per **AC#4 of #53** (#598): the outcome preview should show the limiting-reactant **conversion %** (top label) and each product's **yield %** (bottom label). Currently only reaction time and reaction role are shown.

### Changes
- **`ReactionOutcomePreview`** — the "Outcome" badge now appends the conversion next to the reaction time, e.g. **`Outcome (2 h, 95% conversion)`**, from `outcome.conversion`.
- **`ComponentMetadata`** (the product bottom label) — products now show **`85% yield`**, from the product's `YIELD` measurement.
- **`getProductYieldPercent`** helper extracts the percent value of a product's `YIELD` measurement (`ProductMeasurementType.YIELD`, Percent value).

### 🎨 Format to confirm (review)
The AC specifies the *content and position* (conversion % top, yield % bottom); I used `"<n>% conversion"` and `"<n>% yield"` as the wording. Easy to adjust to whatever matches the design mockups — flag it if you'd prefer different phrasing/precision/placement.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx vitest run` — new `getProductYieldPercent` tests (returns the YIELD percent; undefined for no-YIELD / non-percent / null / no-measurements) and a `ComponentMetadata` test asserting `85% yield` renders. Full suite green.
- [x] `prettier` / `eslint` clean
- [ ] Held for review — behavioral preview change with a format choice; runtime setup (a reaction with conversion + a YIELD measurement) is awkward to script, and the data extraction is unit-covered.

Closes #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces conversion % and yield % in the reaction outcome preview, addressing AC#4 of #598. Data extraction is cleanly isolated in a new `getProductYieldPercent` helper, and the UI changes are minimal and well-guarded.

- **`getProductYieldPercent`** walks the product's `measurements` array for a `YIELD` entry, type-narrows to `ReactionMeasurementValueType.Percent`, and guards the `OrdOptional<number>` value with `!= null` before returning it — all edge cases (no measurements, non-percent type, null value) are covered by dedicated unit tests.
- **`ReactionOutcomePreview`** builds the outcome badge label by composing `outcomeTime` and `conversion` with `filter(Boolean)`, so the parenthetical is omitted entirely when both are absent.
- **`ComponentMetadata`** renders `{productYield}% yield` only for components that carry a `measurements` field (`ReactionProduct`), preserving the existing display for `ReactionInputComponent`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive display-only additions with no mutations to shared state or data-fetching paths.

All data access is guarded against null/undefined at every layer, the new helper is fully unit-tested, and the UI refactor in ComponentMetadata is a direct logical equivalent of the original inline expressions.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/ReactionPreview/reactionPreview.utils.ts | Adds getProductYieldPercent helper; correctly uses optional chaining and != null guard against OrdOptional<number> |
| ui/src/common/components/ReactionPreview/ReactionOutcomePreview.tsx | outcomeLabel memo correctly composes time + conversion parts with filter(Boolean), dependency array is complete |
| ui/src/common/components/ReactionPreview/ComponentMetadata.tsx | productYield != null guard is correct for number | undefined; amount/isLimiting refactor is logically equivalent to original |
| ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts | Five cases cover the happy path, no-YIELD, non-percent, null value, and missing measurements; comprehensive |
| ui/src/common/components/ReactionPreview/ComponentMetadata.test.tsx | New render test correctly asserts '85% yield' text is present for a product with a YIELD measurement |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["style(ui): match file-local import conve..."](https://github.com/open-reaction-database/ord-app/commit/b19f67ba327efdd31134175eaf7bc606e6807061) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37455554)</sub>

<!-- /greptile_comment -->