### PR TITLE
revert(ui): back out #598 preview changes accidentally merged via #731

### DIFF
--- a/ui/src/common/components/ReactionPreview/ComponentMetadata.test.tsx
+++ b/ui/src/common/components/ReactionPreview/ComponentMetadata.test.tsx
@@ -57,13 +57,4 @@ describe('ComponentMetadata', () => {
     expect(screen.getByText('5 g')).toBeInTheDocument();
     expect(screen.queryByText(/GRAM/)).toBeNull();
   });
-
-  it("shows a product's yield % from its YIELD measurement (#598)", () => {
-    const product = {
-      identifiers: [],
-      measurements: [{ type: 'YIELD', value: { type: '%', value: { value: 85 } } }],
-    } as unknown as ReactionInputComponent;
-    renderWithMantine(<ComponentMetadata component={product} />);
-    expect(screen.getByText('85% yield')).toBeInTheDocument();
-  });
 });

--- a/ui/src/common/components/ReactionPreview/ComponentMetadata.tsx
+++ b/ui/src/common/components/ReactionPreview/ComponentMetadata.tsx
@@ -22,7 +22,6 @@ import type {
 } from 'store/entities/reactions/reactionComponent/reactionComponent.types';
 import { ReactionBoolean } from 'store/entities/reactions/reactionEntity/reactionEntity.types';
 import { renderValuePrecisionUnit } from 'features/reactions/ReactionView/renderValuePrecisionUnit';
-import { getProductYieldPercent } from 'common/components/ReactionPreview/reactionPreview.utils';
 
 interface ComponentMetadataProps {
   component: ReactionInputComponent | ReactionProduct;
@@ -32,14 +31,6 @@ export function ComponentMetadata({ component }: Readonly<ComponentMetadataProps
   const name = useMemo(() => {
     return (component.identifiers || []).find(identifier => identifier.type === 'NAME');
   }, [component]);
-
-  // Products carry a yield as a YIELD measurement; surface it as a bottom-label "% yield". (#598)
-  const productYield = useMemo(
-    () => ('measurements' in component ? getProductYieldPercent(component) : undefined),
-    [component],
-  );
-  const amount = 'amount' in component ? component.amount : undefined;
-  const isLimiting = 'isLimiting' in component && component.isLimiting === ReactionBoolean.True;
 
   return (
     <Flex
@@ -57,10 +48,11 @@ export function ComponentMetadata({ component }: Readonly<ComponentMetadataProps
           </Text>
         </Tooltip>
       )}
-      {amount && <Text size="xs">{renderValuePrecisionUnit(amount)}</Text>}
-      {productYield != null && <Text size="xs">{productYield}% yield</Text>}
+      {'amount' in component && component?.amount && (
+        <Text size="xs">{renderValuePrecisionUnit(component.amount)}</Text>
+      )}
       {component?.reactionRole && <Text size="xs">{component.reactionRole}</Text>}
-      {isLimiting && (
+      {'isLimiting' in component && component.isLimiting === ReactionBoolean.True && (
         <Badge
           size="xs"
           variant="light"

--- a/ui/src/common/components/ReactionPreview/ReactionOutcomePreview.tsx
+++ b/ui/src/common/components/ReactionPreview/ReactionOutcomePreview.tsx
@@ -38,12 +38,6 @@ export function ReactionOutcomePreview({ reactionId, outcomeIndex }: Readonly<Re
   const outcomeTime = useMemo(() => {
     return outcome.reactionTime?.value ? renderValuePrecisionUnit(outcome.reactionTime) : '';
   }, [outcome.reactionTime]);
-  // Top label: reaction time and the limiting-reactant conversion %, when available. (#598)
-  const outcomeLabel = useMemo(() => {
-    const conversion = outcome.conversion?.value != null ? `${outcome.conversion.value}% conversion` : '';
-    const parts = [outcomeTime, conversion].filter(Boolean);
-    return parts.length > 0 ? ` (${parts.join(', ')})` : '';
-  }, [outcomeTime, outcome.conversion]);
 
   return (
     <div className={classes.inputCard}>
@@ -52,7 +46,7 @@ export function ReactionOutcomePreview({ reactionId, outcomeIndex }: Readonly<Re
         color="primary"
         size="lg"
       >
-        Outcome{outcomeLabel}
+        Outcome{outcomeTime ? ` (${outcomeTime})` : ''}
       </Badge>
       <Flex
         gap="sm"

--- a/ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts
+++ b/ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts
@@ -15,10 +15,9 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as htmlToImage from 'html-to-image';
-import { copyPreviewAsImage, getProductYieldPercent } from './reactionPreview.utils.ts';
+import { copyPreviewAsImage } from './reactionPreview.utils.ts';
 import { showNotification } from 'common/utils/showNotification.tsx';
 import { NotificationVariant } from 'common/types/notification.ts';
-import type { ReactionProduct } from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
 
 vi.mock('html-to-image', () => ({ toBlob: vi.fn() }));
 vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
@@ -68,39 +67,5 @@ describe('copyPreviewAsImage', () => {
     toBlobMock.mockRejectedValue(new Error('boom'));
     await copyPreviewAsImage(node);
     expectNotified(NotificationVariant.ERROR);
-  });
-});
-
-describe('getProductYieldPercent (#598)', () => {
-  const product = (measurements: Array<unknown>): ReactionProduct => ({ measurements }) as unknown as ReactionProduct;
-
-  it('returns the percent value of a YIELD measurement', () => {
-    const p = product([
-      { type: 'PURITY', value: { type: '%', value: { value: 99 } } },
-      { type: 'YIELD', value: { type: '%', value: { value: 85 } } },
-    ]);
-    expect(getProductYieldPercent(p)).toBe(85);
-  });
-
-  it('returns undefined when there is no YIELD measurement', () => {
-    expect(
-      getProductYieldPercent(product([{ type: 'PURITY', value: { type: '%', value: { value: 99 } } }])),
-    ).toBeUndefined();
-  });
-
-  it('returns undefined when the YIELD measurement is not a percent value', () => {
-    expect(
-      getProductYieldPercent(product([{ type: 'YIELD', value: { type: 'String', value: 'n/a' } }])),
-    ).toBeUndefined();
-  });
-
-  it('returns undefined when the YIELD percent has no numeric value', () => {
-    expect(
-      getProductYieldPercent(product([{ type: 'YIELD', value: { type: '%', value: { value: null } } }])),
-    ).toBeUndefined();
-  });
-
-  it('handles a product with no measurements', () => {
-    expect(getProductYieldPercent({} as ReactionProduct)).toBeUndefined();
   });
 });

--- a/ui/src/common/components/ReactionPreview/reactionPreview.utils.ts
+++ b/ui/src/common/components/ReactionPreview/reactionPreview.utils.ts
@@ -16,25 +16,6 @@
 import { showNotification } from 'common/utils/showNotification.tsx';
 import * as htmlToImage from 'html-to-image';
 import { NotificationVariant, type AppNotification } from 'common/types/notification.ts';
-import {
-  ReactionMeasurementValueType,
-  type ReactionProduct,
-} from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
-
-// The protobuf ProductMeasurementType key for a yield measurement.
-const YIELD_MEASUREMENT_TYPE = 'YIELD';
-
-/**
- * The product's yield as a percent number, or undefined when there's no usable YIELD measurement.
- * Used to surface the yield % in the outcome/product preview. (#598)
- */
-export function getProductYieldPercent(product: ReactionProduct): number | undefined {
-  const yieldValue = product.measurements?.find(measurement => measurement.type === YIELD_MEASUREMENT_TYPE)?.value;
-  if (yieldValue?.type === ReactionMeasurementValueType.Percent && yieldValue.value.value != null) {
-    return yieldValue.value.value;
-  }
-  return undefined;
-}
 
 const errorMessage: AppNotification = {
   variant: NotificationVariant.ERROR,


### PR DESCRIPTION
## Why

#598 (conversion %/yield % in the outcome preview) is a **behavioral change held for review** in **PR #730**, but it rode onto `main` when the #623 branch was mistakenly cut from `fix/598` instead of `main`.

This restores the five `ReactionPreview` files to their pre-#598 state, **keeping**:
- the #726 limiting-reactant badge + readable units, and
- the #623 electrochemistry voltage field.

#598 stays open in **PR #730** for your review.

Restores known-good (already-reviewed) code; tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts the five `ReactionPreview` files to their pre-#598 state, removing the conversion %/yield % display that was accidentally merged via #731. The #726 limiting-reactant badge and #623 electrochemistry voltage field are intentionally kept.

- **`reactionPreview.utils.ts` / tests**: `getProductYieldPercent` and all five of its test cases are removed cleanly.
- **`ComponentMetadata.tsx` / tests**: The `productYield` derived state and `"% yield"` label are removed; the `isLimiting` badge from #726 is preserved.
- **`ReactionOutcomePreview.tsx`**: `outcomeLabel` (reaction time + conversion %) is replaced with the simpler `outcomeTime`-only label from before #598.

<h3>Confidence Score: 5/5</h3>

Clean, surgical revert of five files to their previously reviewed state; intentional #726 and #623 additions are preserved.

Every removal matches the #598 diff exactly — `getProductYieldPercent`, its call sites, and all related tests are gone without leaving dangling imports or orphaned references. The limiting-reactant badge and electrochemistry voltage that should survive the revert are both still present. No new logic is introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/ReactionPreview/reactionPreview.utils.ts | Removes `getProductYieldPercent` function and its imports; file now contains only `copyPreviewAsImage`. |
| ui/src/common/components/ReactionPreview/ComponentMetadata.tsx | Removes `productYield` derived state and its "% yield" display; restores inline `amount`/`isLimiting` guards; the #726 limiting-reactant badge is preserved. |
| ui/src/common/components/ReactionPreview/ReactionOutcomePreview.tsx | Removes `outcomeLabel` (which combined reaction time + conversion %) and reverts the badge label to show only reaction time. |
| ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts | Removes `getProductYieldPercent` import and its five test cases; test suite now covers only `copyPreviewAsImage`. |
| ui/src/common/components/ReactionPreview/ComponentMetadata.test.tsx | Removes the single test case that verified "85% yield" rendering for a product with a YIELD measurement. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["revert(ui): back out #598 preview change..."](https://github.com/open-reaction-database/ord-app/commit/ab39d82e32b0bb45654908aaed28e79a6ba01726) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37456685)</sub>

<!-- /greptile_comment -->