### PR TITLE
fix(ui): keep the measurement value visible when the analysis name is long (#609)

### DIFF
--- a/ui/src/features/reactions/ReactionView/Outcomes/MeasurementsPreview/measurementPreview.module.scss
+++ b/ui/src/features/reactions/ReactionView/Outcomes/MeasurementsPreview/measurementPreview.module.scss
@@ -19,10 +19,19 @@
 
 .measurementKeyType {
   text-wrap: nowrap;
+
+  /* Let a long type/analysis name shrink and ellipsize instead of pushing the value out of
+     the (overflow:hidden) row. (#609) */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .measurementValue {
   overflow: hidden;
   text-wrap: nowrap;
   text-overflow: ellipsis;
+
+  /* Keep the measurement value visible even when the analysis name is long. (#609) */
+  flex-shrink: 0;
 }

--- a/ui/src/features/reactions/ReactionView/Outcomes/MeasurementsPreview/measurementPreview.module.scss
+++ b/ui/src/features/reactions/ReactionView/Outcomes/MeasurementsPreview/measurementPreview.module.scss
@@ -28,10 +28,10 @@
 }
 
 .measurementValue {
-  overflow: hidden;
   text-wrap: nowrap;
-  text-overflow: ellipsis;
 
-  /* Keep the measurement value visible even when the analysis name is long. (#609) */
+  /* Keep the measurement value visible even when the analysis name is long: never shrink it, so
+     the name (which can ellipsize) yields space instead of pushing the value out of the row. A
+     pathologically long value is hard-clipped by .measurementWrapper's overflow:hidden. (#609) */
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary

In the measurement preview row (`type · analysis-name · value`), a long **analysis name** had `text-wrap: nowrap` but no shrink/ellipsis, so it pushed the **value** out of the `overflow: hidden` row — the value was hidden (#609).

### Fix (CSS only)
- `.measurementKeyType` (type/name): add `min-width: 0` + `overflow: hidden` + `text-overflow: ellipsis` so a long name **shrinks and ellipsizes** instead of pushing siblings out.
- `.measurementValue`: add `flex-shrink: 0` so the value **stays visible**.

Short names are unaffected (everything still fits). Same flex-truncation pattern verified for the #355–358 work.

## Test plan
- [x] `npx tsc -b` clean
- [x] `prettier` / `stylelint` clean
- [ ] Held for review — pure CSS layout change; I didn't boot the stack to set up a measurement with a long analysis name, so a quick visual check (long analysis name → value still shown, name ellipsized) before merge would be good.

Closes #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a layout bug (#609) where a long analysis name in the measurement preview row (`type · analysis-name · value`) pushed the value out of the `overflow: hidden` container, hiding it entirely.

- Adds `min-width: 0`, `overflow: hidden`, and `text-overflow: ellipsis` to `.measurementKeyType` so long names shrink and ellipsize instead of overflowing their flex container.
- Adds `flex-shrink: 0` to `.measurementValue` to pin the value in place; removes the now-redundant `overflow: hidden` and `text-overflow: ellipsis` that were dead code once shrinking is disabled. The existing `Tooltip` wrapper on the value element ensures full content remains accessible on hover even if a pathologically long value is hard-clipped by the parent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is CSS-only, scoped to a single flex row, and removes code that was already dead rather than adding new behavior.

The fix correctly applies the standard flex-truncation pattern: min-width:0 lets the shrinkable item compress below its content size, text-overflow:ellipsis fires because overflow:hidden is set on the same element, and flex-shrink:0 pins the value. Removing overflow:hidden and text-overflow:ellipsis from .measurementValue cleans up code that had no effect once flex-shrink:0 was in place. The Tooltip wrapping the value element means a long String value that gets hard-clipped by the parent container is still fully readable on hover.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionView/Outcomes/MeasurementsPreview/measurementPreview.module.scss | CSS-only fix: adds min-width:0/overflow:hidden/text-overflow:ellipsis to .measurementKeyType so long analysis names shrink and ellipsize, and flex-shrink:0 to .measurementValue so the value stays visible. Old dead-code (overflow:hidden + text-overflow:ellipsis on .measurementValue) correctly removed. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): drop dead overflow/ellipsis on ..."](https://github.com/open-reaction-database/ord-app/commit/4a47ed1a5e859f7f0080d7223fb22455965ec723) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37457194)</sub>

<!-- /greptile_comment -->