### PR TITLE
Default API endpoint to relative same-origin path in the image build

### DIFF
--- a/Dockerfile.single
+++ b/Dockerfile.single
@@ -23,6 +23,14 @@ COPY ui/ ./
 # Install dependencies
 RUN npm ci --ignore-scripts
 
+# The backend is served from the same origin (nginx proxies /api to uvicorn), so
+# default the API base to a relative path. This keeps every deployed environment
+# (prod, staging, ...) calling its own origin instead of a hardcoded host, which
+# would otherwise be baked in from a local ui/.env at build time. A build-time env
+# var takes precedence over .env files in Vite. Override with --build-arg if needed.
+ARG VITE_API_ENDPOINT=/api/v1
+ENV VITE_API_ENDPOINT=${VITE_API_ENDPOINT}
+
 # Build the React app
 RUN npm run build
 


### PR DESCRIPTION
## Problem

The SPA's API base is `VITE_API_ENDPOINT` (see `ui/src/store/axiosInstance.ts`), baked into the bundle at build time. It's sourced from a local `ui/.env` that holds the **absolute prod URL**. That's fine for the prod image, but any other image built from the same tree — e.g. a **staging** deployment — ships a frontend that calls `https://app.open-reaction-database.org/api/...` cross-origin. The browser blocks it with CORS, and even if allowed it would hit **prod** data instead of the environment's own backend.

(Surfaced standing up an `app-staging` environment: the staging SPA threw `Access to XMLHttpRequest at 'https://app.open-reaction-database.org/api/v1/auth/jit-provisioning' from origin 'https://app-staging.open-reaction-database.org' blocked by CORS`.)

## Fix

The backend is served from the **same origin** (nginx proxies `/api` to uvicorn in the single container), so the API base should be **relative**. `Dockerfile.single` now defaults `VITE_API_ENDPOINT=/api/v1` via a build `ARG`/`ENV` before `npm run build`. A build-time env var takes precedence over `.env` files in Vite, so every deployed environment calls its own origin regardless of the local `ui/.env`. Overridable with `--build-arg VITE_API_ENDPOINT=...`.

No effect on local dev (`vite dev` doesn't use this Dockerfile). Prod is unaffected behaviorally — `/api/v1` resolves to its own origin, which is what it already calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CORS and wrong-environment-data bug in non-production deployments by defaulting `VITE_API_ENDPOINT` to the relative path `/api/v1` at image-build time instead of relying on the `ui/.env` file, which contains an absolute prod URL.

- Adds `ARG VITE_API_ENDPOINT=/api/v1` + `ENV VITE_API_ENDPOINT=${VITE_API_ENDPOINT}` in the `react-build` stage, placed after `npm ci` so the dependency-install layer is unaffected by changes to the arg. The value aligns exactly with the `location /api/v1/` block in `nginx.conf`.
- Vite respects shell env vars over `.env` files, so this override is effective even when a `ui/.env` with a hardcoded host is copied into the build context (`.dockerignore` does not exclude `.env` files). Overridable per-build with `--build-arg`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line addition that defaults a build-time variable to a relative path already matched by the nginx proxy config.

The fix is minimal and targets exactly the right layer: the ARG/ENV pair overrides any hardcoded prod URL that might be present in a copied ui/.env, the default value /api/v1 matches the nginx proxy location block verbatim, and the placement after npm ci preserves the dependency-install cache. No runtime behavior changes, no security surface added.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Dockerfile.single | Adds ARG/ENV to default VITE_API_ENDPOINT to /api/v1 before the Vite build step, matching the nginx proxy path and fixing CORS in non-prod deployments. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Default the API endpoint to a relative s..."](https://github.com/open-reaction-database/ord-app/commit/7f18fd34b2486f85eb677f7970e1bc0d81e0b232) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37463702)</sub>

<!-- /greptile_comment -->