### PR TITLE
fix(ui): drop "Product" from the Isolated Characteristics heading (#549)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/reactionProducts.model.ts
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/reactionProducts.model.ts
@@ -105,7 +105,7 @@ export const reactionProducts: Array<ReactionFormNode> = [
     type: ReactionFormNodeType.block,
     name: 'texture',
     title: {
-      label: 'Isolated Product Characteristics',
+      label: 'Isolated Material Characteristics',
     },
     fields: [
       wrapInputsWithGrid(


### PR DESCRIPTION
## What

Relabels the products texture-block heading from **"Isolated Product Characteristics"** to **"Isolated Material Characteristics"**, resolving #549.

## Why

The reporter asked to drop "Product" from the heading. "Isolated Material Characteristics" was the maintainer-chosen wording, and it also matches the label already used in `reactionComponentsBase.model.tsx:106` — so this removes an inconsistency between the two models rather than introducing new copy.

## Scope note

This PR covers **#549 only**. The sibling wording issue **#554** ("Type" placeholder) turned out to be mis-scoped against the code: there is no literal "Type" placeholder — the "Type" the reporter sees is the field *label* on Select dropdowns (20+ legitimate type-selectors). It needs the issue screenshot to identify the specific field(s) before any change, so it's held.

## Test

`tsc -b` clean; pure wording change, no logic touched.

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renames the products texture-block heading from "Isolated Product Characteristics" to "Isolated Material Characteristics", resolving a label inconsistency between `reactionProducts.model.ts` and `reactionComponentsBase.model.tsx`.

- The change is a one-line string update; no logic, schema, or type definitions are touched.
- Both files now use the same "Isolated Material Characteristics" label, eliminating the previous inconsistency.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single UI label string is updated with no logic or type changes.

The diff is one changed string literal that brings this file into alignment with an identical label already present in a sibling model file. There are no functional, schema, or type-level modifications.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/reactionProducts.model.ts | Single label string changed from "Isolated Product Characteristics" to "Isolated Material Characteristics", aligning this block with the identical label already used in reactionComponentsBase.model.tsx:106. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): drop &quot;Product&quot; from the Isolate..."](https://github.com/open-reaction-database/ord-app/commit/1f098f2645cb32fba06efb790635f7ec6ad6850d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37785060)</sub>

<!-- /greptile_comment -->