### PR TITLE
fix(ui): show the limiting-reactant badge in the Reaction pane (#487)

### DIFF
--- a/ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRowCustomActions.tsx
+++ b/ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRowCustomActions.tsx
@@ -15,7 +15,8 @@
  */
 import type { ComponentsDisplayRowCustomActions } from 'features/reactions/ReactionView/ComponentsList/componentsList.types.ts';
 import type { ReactionComponentBase } from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
-import { Flex } from '@mantine/core';
+import { Badge, Flex } from '@mantine/core';
+import { ReactionBoolean } from 'store/entities/reactions/reactionEntity/reactionEntity.types.ts';
 import classes from './componentsList.module.scss';
 import clsx from 'clsx';
 import { ReactionComponentPreview } from 'common/components/ReactionPreview/ReactionComponentPreview.tsx';
@@ -56,9 +57,20 @@ export function ComponentDisplayRowCustomActions<T extends ReactionComponentBase
       </Flex>
       <Flex
         align="center"
+        direction="column"
+        gap={4}
         className={classes.role}
       >
         {component.reactionRole}
+        {'isLimiting' in component && component.isLimiting === ReactionBoolean.True && (
+          <Badge
+            size="xs"
+            variant="light"
+            w="fit-content"
+          >
+            Limiting reactant
+          </Badge>
+        )}
       </Flex>
       <Flex
         align="center"


### PR DESCRIPTION
## What

Renders a **"Limiting reactant"** badge in the read-only Reaction pane component rows, for reactant components flagged `isLimiting`. Placed beneath the reaction role in `ComponentDisplayRowCustomActions`, mirroring the badge the reaction **preview** (`ComponentMetadata`) already shows.

## Why

`isLimiting` exists on the component model and is editable, and the preview surfaces it — but the Reaction pane never displayed it (#487). The fix reuses the exact badge styling already used in the preview for consistency.

## Notes

- Guarded with `'isLimiting' in component && component.isLimiting === ReactionBoolean.True`, so product rows (no `isLimiting`) are unaffected.
- `tsc -b` clean; existing `ComponentsList` test passes.

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces the `isLimiting` flag in the read-only Reaction pane by adding a "Limiting reactant" badge to `ComponentDisplayRowCustomActions`, closing a gap where the field was editable and shown in the reaction preview but never displayed in the pane itself.

- The runtime guard (`'isLimiting' in component && component.isLimiting === ReactionBoolean.True`) is identical to the one already used in `ComponentMetadata`, correctly excluding product rows that lack the field.
- Badge props (`size="xs"`, `variant="light"`, `w="fit-content"`) exactly mirror the preview badge, keeping the two surfaces visually consistent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, additive UI fix with no effect on data flow or state.

The change adds a single conditional badge to one component. The type guard, badge styling, and import paths all mirror the existing ComponentMetadata implementation exactly, and product rows are correctly unaffected by the 'isLimiting' in component check.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRowCustomActions.tsx | Adds a "Limiting reactant" Badge beneath the reaction-role text when `isLimiting === ReactionBoolean.True`, using the same guard and badge props already present in ComponentMetadata; no issues found. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show the limiting-reactant badg..."](https://github.com/open-reaction-database/ord-app/commit/a56ae2f6b23721ab7f2178e90d76fe3f472b04fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37785987)</sub>

<!-- /greptile_comment -->