### PR TITLE
fix(ui): use SI capital L for volume amount units (#436)

### DIFF
--- a/ui/src/common/dictionary/formatting.json
+++ b/ui/src/common/dictionary/formatting.json
@@ -8,8 +8,8 @@
   "MICROMOLE": "µmol",
   "NANOMOLE": "nmol",
   "LITER": "L",
-  "MILLILITER": "ml",
-  "MICROLITER": "µl",
-  "NANOLITER": "nl",
+  "MILLILITER": "mL",
+  "MICROLITER": "µL",
+  "NANOLITER": "nL",
   "HOUR": "h"
 }


### PR DESCRIPTION
## What

Corrects the amount-unit display dictionary (`formatting.json`) so volume sub-units render with the SI-correct capital **L**: `ml`→`mL`, `µl`→`µL`, `nl`→`nL`.

## Why

The dict already mapped `LITER`→`L`, but the sub-units used lowercase `l`, which is both internally inconsistent and against SI convention (the litre symbol is a capital `L` to avoid confusion with the digit `1`). This is the "adjust the amounts unit display" fix requested in #436, applied at the dictionary that both the Structure-pane component preview (`ComponentMetadata`) and the Input table (`renderValuePrecisionUnit`) already route through — so it's a data-only change with no logic touched.

## Test

`useTextFormatting` tests pass; `renderValuePrecisionUnit` unit tests unaffected (they stub the dict). Will confirm visually via Playwright alongside the other UI fixes.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the display strings for volume sub-units in `formatting.json` to use the SI-correct capital `L` (`mL`, `µL`, `nL`), resolving an internal inconsistency with the already-correct `LITER: "L"` entry.

- Three keys updated (`MILLILITER`, `MICROLITER`, `NANOLITER`) — pure data change, no logic or component code modified.
- All consumers of this dictionary (`useTextFormatting`, `renderValuePrecisionUnit`) automatically pick up the corrected symbols with no further changes needed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a single-file, three-line data correction with no logic changes.

The only change is correcting three string values in a lookup dictionary from lowercase `l` to uppercase `L`. It is consistent with the existing `LITER` entry, aligns with SI notation, and cannot introduce regressions in any consuming logic.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/dictionary/formatting.json | Corrects MILLILITER, MICROLITER, and NANOLITER display strings from lowercase `l` to SI-standard capital `L`, making them consistent with the existing `LITER: "L"` entry. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): use SI capital L for volume amo..."](https://github.com/open-reaction-database/ord-app/commit/fdb86b7216e5ed63f44fa32015ab58b5ba1debeb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37786149)</sub>

<!-- /greptile_comment -->