### PR TITLE
Stamp source commit into the image (OCI revision label)

### DIFF
--- a/Dockerfile.single
+++ b/Dockerfile.single
@@ -104,4 +104,11 @@ RUN chmod +x ./entrypoint_single.sh
 # Expose both FastAPI and Nginx ports
 EXPOSE 8000 80
 
+# Record the source commit so the deployed image is traceable to a commit. The infra
+# build (ord-infrastructure) passes --build-arg GIT_COMMIT=$(git rev-parse HEAD) from
+# the checkout; defaults to "unknown" for local/manual builds. Declared last so only
+# this layer rebuilds per commit.
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.revision=$GIT_COMMIT
+
 ENTRYPOINT ["sh", "./entrypoint_single.sh"]


### PR DESCRIPTION
## What

Add `ARG GIT_COMMIT` + `LABEL org.opencontainers.image.revision=$GIT_COMMIT` to `Dockerfile.single` so the built image records the commit it was built from.

## Why

Today the deployed image carries no commit provenance: `awsx.ecr.Image` tags by build-context content hash (e.g. `34cf0c6e-container`), and source is copied with a plain `COPY ord_app/` — no label. Answering "which commit is in prod?" currently means pulling the running task definition's image digest, reading layer-history timestamps to find the build time, and correlating that against `main`'s history. After this it's a one-line label read:

```
aws ecr batch-get-image ... | <image config> | jq '.config.Labels["org.opencontainers.image.revision"]'
```

The `ARG` is declared just before `ENTRYPOINT` so only that final layer rebuilds per commit. It defaults to `unknown` for local/manual builds that don't pass the arg.

## Coordination

The infra build supplies the value: open-reaction-database/ord-infrastructure#24 passes `--build-arg GIT_COMMIT=$(git rev-parse HEAD)` from the checkout. Both must land for the label to be populated — until then it resolves to the harmless `unknown` default, so this PR is safe to merge on its own.

Closes #738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bakes the source commit SHA into the Docker image as an OCI-standard label (`org.opencontainers.image.revision`) by introducing a build-time `ARG GIT_COMMIT` that defaults to `"unknown"` for local builds.

- The `ARG` and `LABEL` are deliberately placed after all expensive build steps (npm, pip, COPY), so only the last layer is invalidated when the commit changes — all prior cache layers remain warm.
- The infra repo must pass `--build-arg GIT_COMMIT=$(git rev-parse HEAD)` to populate the label; until that change lands, the label resolves to `"unknown"`, which is harmless.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change adds only a metadata label with a harmless fallback default and no functional side effects.

The diff is two lines of Dockerfile metadata. The `ARG` default of `"unknown"` means no build breaks without the infra-side `--build-arg`, and the label carries no runtime behaviour.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Dockerfile.single | Adds ARG GIT_COMMIT=unknown and the OCI org.opencontainers.image.revision label just before ENTRYPOINT; placement correctly limits cache invalidation to this final layer only |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Stamp source commit into the image (OCI ..."](https://github.com/open-reaction-database/ord-app/commit/eedb08570beaffcb83cdab39dbdd65c8ec30b8dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37787680)</sub>

<!-- /greptile_comment -->