### PR TITLE
docs(skill): screenshot-verification gotchas for ui-testing skill

### DIFF
--- a/.claude/skills/ord-app-ui-testing/SKILL.md
+++ b/.claude/skills/ord-app-ui-testing/SKILL.md
@@ -112,6 +112,25 @@ E2E driving tips (the app is WASM/Ketcher-heavy and slow):
 - Create-reaction lives on the **dataset** page (`/datasets/:id` → "Reaction" button → "From Scratch"), not the reaction editor.
 - **Before/after on a one-line change**: edit the source file while the dev server runs — Vite HMR reloads it live — capture the buggy screenshot, revert, capture the fixed one. Verify the working tree is clean afterward.
 
+## Exploratory screenshot verification (manual, not a spec)
+
+For confirming a fix in the real app (e.g. "does this label/badge/unit render?"), drive Chromium with a throwaway Node script instead of a Playwright spec. It iterates faster — dump affordances, screenshot, adjust, rerun. These gotchas each cost a rerun; avoid them:
+
+- **Standalone script import**: `@playwright/test` is CJS, so `import { chromium }` fails. Use:
+  ```js
+  import pkg from '/abs/path/ui/node_modules/@playwright/test/index.js';
+  const { chromium } = pkg;
+  ```
+  Run with `node /tmp/shot.mjs`. Screenshot to `/tmp/*.png` and Read the image back.
+- **`Close` discards unsaved edits.** The entity edit drawer commits only via its bottom **`Save`**; clicking `Close` (or navigating away) throws away role/amount/etc. you just set — they'll show as `UNSPECIFIED` on reload. The in-drawer select still shows your value (in-memory form state) even when nothing persisted, so **verify by reloading the page and reading the read-only view**, not the drawer.
+- **Nested drawers have their own `Save`.** Adding an Identifier opens a sub-drawer (breadcrumb `Input / Component / Identifier`); its `Save` persists only the identifier. Set the component-level fields (role, amount, limiting) and then click the **component** drawer's `Save` — saving the sub-drawer or `Close`-ing the parent loses them. Breadcrumb items are links but not reliably `getByRole('link')`; click via `locator('a,[role=link],button').filter({ hasText: /^Component$/ })`.
+- **Menu items are `role=menuitem`, not `button`.** The Reaction dropdown's "From Scratch"/"From File"/"From Enumeration" need `getByRole('menuitem', { name })`; `getByRole('button', …)` times out.
+- **Combobox vs native `<select>` — don't assume.** The Create-Dataset **Group** field is a Mantine combobox: `dialog.getByPlaceholder('Select a group').click()` then `getByRole('option').first().click()`. Unit / reaction-role / identifier-type fields are real `<select>` (`AppNativeSelect`): use `selectOption({ label })`. To find the right one among several, match by its options (`if ((await s.locator('option').allTextContents()).includes('MILLILITER'))`).
+- **Empty `placeholder=""` breaks `input:not([placeholder])`** (the attribute is present-but-empty). Target form fields by `getByLabel(/…/)` instead.
+- **Build a component without Ketcher**: set Reaction role `REACTANT` (this reveals the `Limiting reactant` field), add an identifier row and set Type `SMILES` + value `O`/`CCO` — no WASM structure editor needed.
+- **Cross-branch visual checks**: DB data persists across `git checkout`, and HMR picks up the new branch's source. Build the fixture reaction once, then check out each branch and re-screenshot the same URL — handy when two fixes live on separate branches.
+- **Dumping the DOM for text** catches `<style>`/`<script>` contents (they contain words like "License"). Filter to leaf nodes (`el.childElementCount === 0`) or just read the screenshot.
+
 ## SonarCloud issues (public API, no token)
 
 ```bash


### PR DESCRIPTION
## What

Adds an **"Exploratory screenshot verification"** subsection to the `ord-app-ui-testing` skill, documenting the manual Playwright-screenshot workflow for confirming UI fixes against the live no-auth stack.

## Why

Verifying a fix in the real app repeatedly hit the same non-obvious traps, each costing a rerun. Captured so the next run doesn't relearn them:

- the entity edit drawer's **`Close` discards unsaved edits** — only the drawer's `Save` persists (the in-drawer select still shows your value from in-memory form state, so verify by reloading the read-only view)
- **nested sub-drawers** (Identifier) have their own `Save`; saving them doesn't persist component-level fields
- reaction-menu items are **`role=menuitem`**, not `button`
- **combobox vs native `<select>`** targeting (Group field vs unit/role/type)
- empty **`placeholder=""`** breaks `input:not([placeholder])` → use `getByLabel`
- building a component **without Ketcher** (SMILES identifier)
- **cross-branch** visual checks via persisted DB + HMR
- standalone-script CJS import shape for `@playwright/test`

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Docs-only addition to the `ord-app-ui-testing` skill documenting the manual Playwright screenshot workflow and the non-obvious traps that cause wasted reruns when verifying UI fixes against the live no-auth stack.

- Adds an \"Exploratory screenshot verification\" section listing eight concrete gotchas: the CJS import shape for `@playwright/test` in a standalone `.mjs` script, drawer `Close`-vs-`Save` persistence, nested sub-drawer save order, `role=menuitem` vs `button`, Mantine combobox vs native `<select>`, empty `placeholder=\"\"` breaking attribute selectors, building a component without Ketcher, and cross-branch visual checks via persisted DB + HMR.
- No production code or test files are modified.

<h3>Confidence Score: 5/5</h3>

Docs-only change to an internal skill file; no production code, tests, or configuration are touched.

All eight new bullet points document real, verified app behaviors (save semantics, ARIA roles, selector gotchas). The technical claims are consistent with Playwright's CJS module format, Mantine's combobox API, and standard DOM attribute-selector behavior. Nothing in the diff could affect runtime correctness.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/skills/ord-app-ui-testing/SKILL.md | Adds 19-line "Exploratory screenshot verification" subsection documenting manual Playwright gotchas (CJS import, drawer save semantics, ARIA roles, combobox vs select, etc.); no code changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(skill): add exploratory screenshot-..."](https://github.com/open-reaction-database/ord-app/commit/b2878db5b5427fcbdc0d1d86cb24721f51bdd954) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37790005)</sub>

<!-- /greptile_comment -->