### PR TITLE
fix(ui): drop the doubled colon on the Dynamic conditions label

### DIFF
--- a/ui/src/features/reactions/ReactionView/Conditions/Conditions.tsx
+++ b/ui/src/features/reactions/ReactionView/Conditions/Conditions.tsx
@@ -50,7 +50,7 @@ export function Conditions({ reactionId }: ReactionViewSectionProps) {
           requiredFields={[
             { label: 'Reflux', render: conditions => conditions.reflux },
             { label: 'pH', render: conditions => conditions.ph },
-            { label: 'Dynamic conditions:', render: conditions => conditions.conditionsAreDynamic },
+            { label: 'Dynamic conditions', render: conditions => conditions.conditionsAreDynamic },
           ]}
         />
         <span className={classes.conditionsLabel}>Temperature</span>


### PR DESCRIPTION
## What

The read-only Conditions view rendered **"Dynamic conditions::"** (doubled colon). The `requiredFields` label literal in `Conditions.tsx` ended in `:`, and `KeyValueDisplay` already appends a `:` to every label. Removed the literal's trailing colon so it matches the sibling `Reflux`/`pH` rows.

## Verification

Confirmed in the running no-auth app: the label now reads `Dynamic conditions:` (single colon). `tsc -b` clean.

Drive-by spotted while screenshot-verifying the conditions form for #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the trailing `:` from the `'Dynamic conditions'` label string in `Conditions.tsx`. Since `KeyValueDisplay` already appends a colon to every label it renders (line 35: `{label}:`), the old literal caused the display to read `Dynamic conditions::` instead of `Dynamic conditions:`.

- Single character removed from one label string, making it consistent with the sibling `'Reflux'` and `'pH'` entries in the same `requiredFields` array.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one character removed from a label string with no logic, state, or data-handling changes.

The change touches a single string literal in a read-only display component. The root cause (KeyValueDisplay appending its own colon) is verified in the source, and the fix correctly aligns 'Dynamic conditions' with its sibling labels 'Reflux' and 'pH' which never carried a trailing colon.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionView/Conditions/Conditions.tsx | Removes trailing colon from the 'Dynamic conditions' label literal; KeyValueDisplay already appends ':' to every label, so this eliminates the doubled-colon display bug. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): drop the doubled colon on the D..."](https://github.com/open-reaction-database/ord-app/commit/592e9ced62d9a373a43b5ce5090d8bb2cd9e29c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37790178)</sub>

<!-- /greptile_comment -->