### PR TITLE
test(ui): backfill thunk coverage (#662)

### DIFF
--- a/ui/src/store/entities/reactions/reactionsInputs/reactionInputs.thunks.test.ts
+++ b/ui/src/store/entities/reactions/reactionsInputs/reactionInputs.thunks.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { type UnknownAction } from '@reduxjs/toolkit';
+import axiosInstance from 'store/axiosInstance.ts';
+import { makeRecordingStore } from 'test/recordingStore.ts';
+import { addIdentifierByName } from './reactionInputs.thunks.ts';
+import { addIdentifierByNameActions } from './reactionInputs.actions.ts';
+
+vi.mock('store/axiosInstance.ts', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
+// addUpdateReactionField is exercised in reactions.thunks.test.ts; here we only care that this thunk
+// hands it the resolved identifier at the next free index, so replace it with a plain recorded action.
+const addUpdateReactionField = vi.fn((arg: unknown) => ({
+  type: 'reactions/addUpdateReactionField/mock',
+  payload: arg,
+}));
+vi.mock('store/entities/reactions/reactions.thunks.ts', async importActual => ({
+  ...((await importActual()) as Record<string, unknown>),
+  addUpdateReactionField: (arg: unknown) => addUpdateReactionField(arg),
+}));
+
+const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
+const makeStore = makeRecordingStore;
+const pathComponents = ['inputs', 0, 'components', 0, 'identifiers'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  axiosMock.post.mockResolvedValue({ data: { smiles: 'O' } });
+});
+
+describe('addIdentifierByName', () => {
+  it('resolves the name to a SMILES identifier and appends it at the next index', async () => {
+    const { store, types } = makeStore();
+    await store.dispatch(
+      addIdentifierByName({ reactionId: 99, pathComponents, name: 'water' }) as unknown as UnknownAction,
+    );
+
+    expect(axiosMock.post).toHaveBeenCalledWith('/resolve-compound', {
+      identifier_type: 'name',
+      identifier: 'water',
+    });
+    expect(types()).toContain(addIdentifierByNameActions.success.type);
+
+    // No identifiers in the (empty) store, so the new one lands at index 0, and the resolved SMILES
+    // is carried through with the looked-up name kept as the identifier details.
+    expect(addUpdateReactionField).toHaveBeenCalledTimes(1);
+    const arg = addUpdateReactionField.mock.calls[0][0] as {
+      reactionId: number;
+      pathComponents: Array<string | number>;
+      newValue: { value: string; details: string };
+    };
+    expect(arg.reactionId).toBe(99);
+    expect(arg.pathComponents).toEqual([...pathComponents, 0]);
+    expect(arg.newValue.value).toBe('O');
+    expect(arg.newValue.details).toBe('water');
+  });
+
+  it('dispatches failure and does not update the reaction when resolution rejects', async () => {
+    axiosMock.post.mockRejectedValueOnce(new Error('not found'));
+    const { store, types } = makeStore();
+    await store.dispatch(
+      addIdentifierByName({ reactionId: 99, pathComponents, name: 'bogus' }) as unknown as UnknownAction,
+    );
+
+    expect(types()).toContain(addIdentifierByNameActions.failure.type);
+    expect(types()).not.toContain(addIdentifierByNameActions.success.type);
+    expect(addUpdateReactionField).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/store/entities/templates/templates.thunks.test.ts
+++ b/ui/src/store/entities/templates/templates.thunks.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { type UnknownAction } from '@reduxjs/toolkit';
+import axiosInstance from 'store/axiosInstance.ts';
+import { makeRecordingStore } from 'test/recordingStore.ts';
+import { navigate } from 'wouter/use-browser-location';
+import { removeTemplate, importFromFile } from './templates.thunks.ts';
+import { removeTemplateActions, importTemplateFromFileActions } from './templates.actions.ts';
+
+vi.mock('store/axiosInstance.ts', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('wouter/use-browser-location', () => ({ navigate: vi.fn() }));
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
+
+const axiosMock = axiosInstance as unknown as Record<'get' | 'post' | 'patch' | 'delete', ReturnType<typeof vi.fn>>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  axiosMock.delete.mockResolvedValue({ data: {} });
+});
+
+describe('removeTemplate', () => {
+  it('parses the numeric id, deletes the template, dispatches success, and navigates to the list', async () => {
+    const { store, types } = makeRecordingStore();
+    await store.dispatch(removeTemplate('template_5') as unknown as UnknownAction);
+
+    expect(axiosMock.delete).toHaveBeenCalledWith('/templates/5');
+    expect(types()).toContain(removeTemplateActions.success.type);
+    expect(navigate).toHaveBeenCalledWith('/templates');
+  });
+});
+
+describe('importFromFile', () => {
+  it('dispatches failure (and never POSTs) when the file variables are not an array', async () => {
+    const file = new File([JSON.stringify({ binpb: 'AA==', variables: 'not-an-array' })], 't.json', {
+      type: 'application/json',
+    });
+    const { store, actions, types } = makeRecordingStore();
+    await store.dispatch(importFromFile({ name: 'T', file }) as unknown as UnknownAction);
+
+    expect(types()).toContain(importTemplateFromFileActions.failure.type);
+    const failure = actions().find(a => a.type === importTemplateFromFileActions.failure.type) as { payload?: string };
+    expect(failure?.payload).toBe('Incorrect template file provided');
+    expect(axiosMock.post).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/store/entities/templates/templates.thunks.test.ts
+++ b/ui/src/store/entities/templates/templates.thunks.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { type UnknownAction } from '@reduxjs/toolkit';
 import axiosInstance from 'store/axiosInstance.ts';
 import { makeRecordingStore } from 'test/recordingStore.ts';
@@ -34,6 +34,10 @@ beforeEach(() => {
   axiosMock.delete.mockResolvedValue({ data: {} });
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('removeTemplate', () => {
   it('parses the numeric id, deletes the template, dispatches success, and navigates to the list', async () => {
     const { store, types } = makeRecordingStore();
@@ -47,6 +51,8 @@ describe('removeTemplate', () => {
 
 describe('importFromFile', () => {
   it('dispatches failure (and never POSTs) when the file variables are not an array', async () => {
+    // The production catch logs the parse error; silence it so the failure test stays quiet in CI.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     const file = new File([JSON.stringify({ binpb: 'AA==', variables: 'not-an-array' })], 't.json', {
       type: 'application/json',
     });

--- a/ui/src/store/entities/users/users.thunks.test.ts
+++ b/ui/src/store/entities/users/users.thunks.test.ts
@@ -23,6 +23,9 @@ import { createUserActions } from './users.actions.ts';
 vi.mock('store/axiosInstance.ts', () => ({
   default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
+// createThunk imports showNotification transitively; mock it so this file stays insulated from the
+// toast infrastructure even if a future transitive dependency needs React context.
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
 
 const axiosMock = axiosInstance as unknown as Record<'post', ReturnType<typeof vi.fn>>;
 const tokens = { access_token: 'a-token', id_token: 'i-token' };

--- a/ui/src/store/entities/users/users.thunks.test.ts
+++ b/ui/src/store/entities/users/users.thunks.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { type UnknownAction } from '@reduxjs/toolkit';
+import axiosInstance from 'store/axiosInstance.ts';
+import { makeRecordingStore } from 'test/recordingStore.ts';
+import { createUser } from './users.thunks.ts';
+import { createUserActions } from './users.actions.ts';
+
+vi.mock('store/axiosInstance.ts', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+const axiosMock = axiosInstance as unknown as Record<'post', ReturnType<typeof vi.fn>>;
+const tokens = { access_token: 'a-token', id_token: 'i-token' };
+const user = { id: 7, orcid_id: '0000', name: 'E2E User', email: 'e2e@example.com' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  axiosMock.post.mockResolvedValue({ data: user });
+});
+
+describe('createUser', () => {
+  it('JIT-provisions the user from the auth tokens and dispatches success with the user', async () => {
+    const { store, actions, types } = makeRecordingStore();
+    await store.dispatch(createUser(tokens) as unknown as UnknownAction);
+
+    expect(axiosMock.post).toHaveBeenCalledWith('/auth/jit-provisioning', tokens);
+    expect(types()).toContain(createUserActions.success.type);
+    const success = actions().find(a => a.type === createUserActions.success.type) as { payload?: typeof user };
+    expect(success?.payload).toEqual(user);
+  });
+
+  it('dispatches failure when provisioning rejects', async () => {
+    axiosMock.post.mockRejectedValueOnce(new Error('401'));
+    const { store, types } = makeRecordingStore();
+    await store.dispatch(createUser(tokens) as unknown as UnknownAction);
+    expect(types()).toContain(createUserActions.failure.type);
+    expect(types()).not.toContain(createUserActions.success.type);
+  });
+});

--- a/ui/src/store/utils/downloadFile.thunks.test.ts
+++ b/ui/src/store/utils/downloadFile.thunks.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import axiosInstance from '../axiosInstance.ts';
+import { downloadFile, downloadFileFromUrl, downloadAsJson } from './downloadFile.thunks.ts';
+
+vi.mock('../axiosInstance.ts', () => ({ default: { get: vi.fn() } }));
+const axiosMock = axiosInstance as unknown as Record<'get', ReturnType<typeof vi.fn>>;
+
+let clickSpy: ReturnType<typeof vi.fn>;
+let lastAnchor: HTMLAnchorElement | undefined;
+let createObjectURL: ReturnType<typeof vi.fn>;
+let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  lastAnchor = undefined;
+  clickSpy = vi.fn();
+  createObjectURL = vi.fn(() => 'blob:mock-url');
+  revokeObjectURL = vi.fn();
+  // happy-dom doesn't implement object URLs; stub the two methods used here.
+  vi.stubGlobal('URL', Object.assign(Object.create(URL), { createObjectURL, revokeObjectURL }));
+  const realCreate = document.createElement.bind(document);
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    const el = realCreate(tag);
+    if (tag === 'a') {
+      (el as HTMLAnchorElement).click = clickSpy;
+      lastAnchor = el as HTMLAnchorElement;
+    }
+    return el;
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('downloadFile', () => {
+  it('creates an object URL, clicks an anchor with the filename, and revokes the URL', () => {
+    downloadFile(new Blob(['hi']), 'note.txt');
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(lastAnchor?.download).toBe('note.txt');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('downloadFileFromUrl', () => {
+  it('fetches the blob and downloads it using the content-disposition filename', async () => {
+    axiosMock.get.mockResolvedValueOnce({
+      data: 'payload',
+      headers: { 'content-type': 'application/json', 'content-disposition': 'attachment; filename="report.json"' },
+    });
+    await downloadFileFromUrl('/datasets/5/download')(vi.fn(), vi.fn(), undefined);
+    expect(axiosMock.get).toHaveBeenCalledWith('/datasets/5/download', { responseType: 'blob' });
+    expect(lastAnchor?.download).toBe('report.json');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows errors (logs, no throw, no download) when the request fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axiosMock.get.mockRejectedValueOnce(new Error('network'));
+    await expect(downloadFileFromUrl('/bad')(vi.fn(), vi.fn(), undefined)).resolves.toBeUndefined();
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+
+describe('downloadAsJson', () => {
+  it('serializes the object and downloads it under the given filename', () => {
+    downloadAsJson({ a: 1 }, 'data.json');
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(lastAnchor?.download).toBe('data.json');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for the four previously-untested thunk modules (recording-store harness from `test/recordingStore.ts`):

- **`reactionInputs.addIdentifierByName`** — resolve-compound name lookup → SMILES identifier appended at the next index; failure path doesn't update the reaction.
- **`users.createUser`** — JIT-provisioning success (user payload threaded through) + failure.
- **`downloadFile` / `downloadFileFromUrl` / `downloadAsJson`** — object-URL anchor click, `content-disposition` filename parsing, error swallowing (logs, no throw, no download).
- **`templates.removeTemplate`** (id parse + delete + navigate) and **`importFromFile`** failure path (non-array variables → failure, never POSTs).

## Why

Part of the epic #662 backfill tail (async thunks). The heavy protobuf-decoding template paths (`parseTemplate`) are intentionally left for the leaf-converter tail.

## Test

All 10 new tests pass; `tsc -b` + lint clean. No production code changed (test-only / no-behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds unit tests for four previously-uncovered thunk modules as part of a backfill effort, with no production code changes. All new tests follow the established `makeRecordingStore` harness pattern and correctly isolate external dependencies via `vi.mock`.

- **`reactionInputs.thunks.test.ts`**: Covers `addIdentifierByName` success (name→SMILES resolution, index calculation, `addUpdateReactionField` delegation) and failure (API rejection → failure action, no field update).
- **`users.thunks.test.ts`** / **`templates.thunks.test.ts`**: Cover `createUser` JIT-provisioning and `removeTemplate`/`importFromFile` paths; previously-flagged gaps (`showNotification` mock, `console.error` silencing) are both addressed in this revision.
- **`downloadFile.thunks.test.ts`**: Covers object-URL lifecycle (`createObjectURL` → click → `revokeObjectURL`), `content-disposition` filename parsing, and error-swallowing in `downloadFileFromUrl`, using a `vi.stubGlobal` approach to work around happy-dom's lack of object-URL support.

<h3>Confidence Score: 5/5</h3>

Test-only PR with no production code changes; safe to merge.

All four files are new test modules with no changes to production code. The previously-raised issues from earlier review rounds (missing `showNotification` mock in `users.thunks.test.ts` and noisy `console.error` output in `templates.thunks.test.ts`) are both resolved in this revision. Mock isolation, action-type assertions, and payload checks are correctly structured throughout.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactionsInputs/reactionInputs.thunks.test.ts | New test file covering `addIdentifierByName` success and failure paths; correctly mocks axios, `showNotification`, and delegates `addUpdateReactionField` to a spy to verify the resolved SMILES+details payload and index selection. |
| ui/src/store/entities/templates/templates.thunks.test.ts | New test file covering `removeTemplate` (id parsing, DELETE call, navigate) and the `importFromFile` failure path (non-array variables → failure action, no POST); `console.error` is properly silenced in the failure test. |
| ui/src/store/entities/users/users.thunks.test.ts | New test file covering `createUser` success (payload forwarded) and failure paths; `showNotification` is correctly mocked to insulate the test from toast infrastructure, matching the pattern used in the other thunk test files. |
| ui/src/store/utils/downloadFile.thunks.test.ts | New test file covering `downloadFile`, `downloadFileFromUrl` (success + error-swallowing), and `downloadAsJson`; stubs `URL.createObjectURL`/`revokeObjectURL` via `vi.stubGlobal` since happy-dom omits object-URL support, and intercepts anchor `.click()` via `createElement` spy. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): address Greptile review on thu..."](https://github.com/open-reaction-database/ord-app/commit/d621feaca66cc80a8834bbdc4e0e476a4b0ccaa5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37791865)</sub>

<!-- /greptile_comment -->