### PR TITLE
test(ui): cover OutcomeListItemHeader + entity Row/Empty nodes (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityEmpty.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityEmpty.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { ReactionEntityEmpty } from './ReactionEntityEmpty.tsx';
+import type { ReactionEntityNodeProps } from './reactionEntityNode.types.ts';
+import type { ReactionFormEmpty } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+// The empty node is a thin pass-through that renders its child fields via the recursive registry;
+// stub the base node so the test stays off the Ketcher/d3 path.
+vi.mock(
+  'features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityBaseNode/ReactionEntityBaseNode.tsx',
+  () => ({
+    ReactionEntityBaseNode: ({ node }: Readonly<{ node: { type?: string } }>) => (
+      <div data-testid="base-node">{node?.type ?? 'node'}</div>
+    ),
+  }),
+);
+
+const formMethods = {} as ReactionEntityNodeProps<ReactionFormEmpty>['formMethods'];
+
+describe('ReactionEntityEmpty', () => {
+  it('renders one base node for each of its fields, with no wrapper of its own', () => {
+    const node = { fields: [{ type: 'x' }, { type: 'y' }, { type: 'z' }] } as unknown as ReactionFormEmpty;
+    const { getAllByTestId } = renderWithMantine(
+      <ReactionEntityEmpty
+        node={node}
+        formMethods={formMethods}
+      />,
+    );
+    expect(getAllByTestId('base-node')).toHaveLength(3);
+  });
+
+  it('renders nothing when there are no fields', () => {
+    const node = { fields: [] } as unknown as ReactionFormEmpty;
+    const { queryByTestId } = renderWithMantine(
+      <ReactionEntityEmpty
+        node={node}
+        formMethods={formMethods}
+      />,
+    );
+    expect(queryByTestId('base-node')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityRow/ReactionEntityRow.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityRow/ReactionEntityRow.test.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { ReactionEntityRow } from './ReactionEntityRow.tsx';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormWrapper } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+// Isolate the row from the recursive node registry (which pulls in the Ketcher/d3 editor).
+vi.mock('../ReactionEntityBaseNode/ReactionEntityBaseNode.tsx', () => ({
+  ReactionEntityBaseNode: ({ node }: Readonly<{ node: { type?: string } }>) => (
+    <div data-testid="base-node">{node?.type ?? 'node'}</div>
+  ),
+}));
+
+const formMethods = {} as ReactionEntityNodeProps<ReactionFormWrapper>['formMethods'];
+
+describe('ReactionEntityRow', () => {
+  it('renders the wrapper label and one base node per field', () => {
+    const node = {
+      grid: 2,
+      fields: [{ type: 'a' }, { type: 'b' }],
+      wrapperConfig: { label: 'Stirring' },
+    } as unknown as ReactionFormWrapper;
+
+    const { getByText, getAllByTestId } = renderWithMantine(
+      <ReactionEntityRow
+        node={node}
+        formMethods={formMethods}
+      />,
+    );
+
+    expect(getByText('Stirring')).toBeInTheDocument();
+    expect(getAllByTestId('base-node')).toHaveLength(2);
+  });
+
+  it('lays the fields out in the configured number of grid columns', () => {
+    const node = {
+      grid: 3,
+      fields: [{ type: 'a' }],
+      wrapperConfig: { label: 'Grid' },
+    } as unknown as ReactionFormWrapper;
+
+    const { getByTestId } = renderWithMantine(
+      <ReactionEntityRow
+        node={node}
+        formMethods={formMethods}
+      />,
+    );
+    expect(getByTestId('base-node').parentElement).toHaveStyle({ gridTemplateColumns: 'repeat(3, 1fr)' });
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItemHeader.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItemHeader.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { Accordion } from '@mantine/core';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { OutcomeListItemHeader } from './OutcomeListItemHeader.tsx';
+import type { ReactionOutcome } from 'store/entities/reactions/reactionsOutcomes/reactionOutcomes.types.ts';
+
+const renderHeader = (outcome: Partial<ReactionOutcome>) =>
+  renderInReactionView(
+    <Accordion>
+      <Accordion.Item value="outcome">
+        <OutcomeListItemHeader
+          reactionId={1}
+          outcome={outcome as ReactionOutcome}
+          pathComponents={['outcomes', 0]}
+        />
+      </Accordion.Item>
+    </Accordion>,
+  );
+
+describe('OutcomeListItemHeader', () => {
+  it('renders the reaction-time and limiting-reactant-conversion rows when present', () => {
+    const { getByText } = renderHeader({
+      products: [],
+      reactionTime: { value: 5, units: 'HOUR' },
+      conversion: { value: 90 },
+    } as unknown as ReactionOutcome);
+
+    expect(getByText('Time:')).toBeInTheDocument();
+    expect(getByText('5 h')).toBeInTheDocument();
+    expect(getByText(/Limiting reactant conversion:/)).toBeInTheDocument();
+    expect(getByText('90')).toBeInTheDocument();
+  });
+
+  it('omits the time and conversion rows when those values are absent', () => {
+    const { queryByText } = renderHeader({ products: [] } as unknown as ReactionOutcome);
+    expect(queryByText('Time:')).not.toBeInTheDocument();
+    expect(queryByText(/Limiting reactant conversion:/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Continues the #662 view-component test backfill (test-only, no production code):

- **`OutcomeListItemHeader`** — renders the reaction-time and limiting-reactant-conversion rows when those values are present, and omits them when absent (via `renderInReactionView` + an `Accordion` wrapper).
- **`ReactionEntityRow`** — renders the wrapper label, one base node per field, and the configured grid-column layout.
- **`ReactionEntityEmpty`** — pass-through that renders one base node per field (and nothing when empty).

The two `reactionEntityNode` tests stub `ReactionEntityBaseNode` so they stay off the recursive Ketcher/d3 registry path (per the ui-testing skill).

## Test

6 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Test-only backfill adding 6 new Vitest tests across three new files; no production code is changed.

- **`OutcomeListItemHeader.test.tsx`** — uses `renderInReactionView` (providing the Redux store and `reactionContext`) with an `Accordion`/`Accordion.Item` wrapper that matches the component's expected DOM hierarchy; assertions verify both presence and absence of the time and conversion rows using the same formatting path (`'HOUR'` → `'h'`) as production code.
- **`ReactionEntityRow.test.tsx`** and **`ReactionEntityEmpty.test.tsx`** — both stub `ReactionEntityBaseNode` via `vi.mock` to avoid the Ketcher/d3 registry, use the lighter `renderWithMantine` helper (sufficient because neither component reads from Redux or custom contexts beyond Mantine), and cover label rendering, field count, and grid-column layout.

<h3>Confidence Score: 5/5</h3>

Pure test additions with no changes to production code; safe to merge.

All three files are new test-only additions. The production components are unchanged, the mocking strategy correctly isolates the recursive node registry, and the render helper choices (renderWithMantine vs renderInReactionView) are appropriate for each component's context requirements. The formatting assertion ('5 h') was verified against the actual formatting.json dictionary and renderValuePrecisionUnit logic.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityEmpty.test.tsx | New test file: verifies ReactionEntityEmpty renders one stubbed base-node per field and nothing on an empty fields array. Correctly stubs ReactionEntityBaseNode via vi.mock to stay off the Ketcher/d3 path. |
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityRow/ReactionEntityRow.test.tsx | New test file: verifies ReactionEntityRow renders the wrapper label and one base-node per field, and applies the correct CSS grid-template-columns value. Uses renderWithMantine (no Redux/context needed since useReactionEntityLabel only uses Mantine). |
| ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItemHeader.test.tsx | New test file: verifies OutcomeListItemHeader renders the reaction-time and conversion rows when present (including the formatted unit '5 h') and omits them when absent. Correctly wraps in Accordion/Accordion.Item and uses renderInReactionView for the required reactionContext. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover OutcomeListItemHeader + ..."](https://github.com/open-reaction-database/ord-app/commit/9af7d4b838d5a22953491027de095eb6dbcbdcdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37794879)</sub>

<!-- /greptile_comment -->