### PR TITLE
test(ui): cover ReactionEntityValue + ReactionEntitySelect nodes (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntitySelect/ReacitonEntitySelect.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntitySelect/ReacitonEntitySelect.test.tsx
@@ -51,4 +51,11 @@ describe('ReactionEntitySelect', () => {
     expect(getByText('A')).toBeInTheDocument();
     expect(getByText('B')).toBeInTheDocument();
   });
+
+  it('disables the segmented control in view-only mode', () => {
+    const { container } = renderSelect('segmented', true);
+    const radios = container.querySelectorAll('input[type=radio]');
+    expect(radios.length).toBeGreaterThan(0);
+    radios.forEach(radio => expect(radio).toBeDisabled());
+  });
 });

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntitySelect/ReacitonEntitySelect.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntitySelect/ReacitonEntitySelect.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntitySelect } from './ReacitonEntitySelect.tsx';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormSelect } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const formMethods = {
+  getInputProps: () => ({ value: 'A', onChange: vi.fn() }),
+} as unknown as ReactionEntityNodeProps<ReactionFormSelect>['formMethods'];
+
+const renderSelect = (selectType: string, isViewOnly = false) =>
+  renderInReactionView(
+    <ReactionEntitySelect
+      node={{ name: 'field', selectType, options: ['A', 'B'] } as unknown as ReactionFormSelect}
+      formMethods={formMethods}
+    />,
+    { isViewOnly },
+  );
+
+describe('ReactionEntitySelect', () => {
+  it('renders a native select with the options for the dropdown variant', () => {
+    const { container } = renderSelect('dropdown');
+    const select = container.querySelector('select');
+    expect(select).not.toBeNull();
+    expect(select?.querySelectorAll('option')).toHaveLength(2);
+  });
+
+  it('disables the dropdown in view-only mode', () => {
+    const { container } = renderSelect('dropdown', true);
+    expect(container.querySelector('select')).toBeDisabled();
+  });
+
+  it('renders a segmented control (radios) for the non-dropdown variant', () => {
+    const { getByText, container } = renderSelect('segmented');
+    expect(container.querySelector('select')).toBeNull();
+    expect(getByText('A')).toBeInTheDocument();
+    expect(getByText('B')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityValue/ReactionEntityValue.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityValue/ReactionEntityValue.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntityValue } from './ReactionEntityValue.tsx';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormValue } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const formMethods = {
+  getInputProps: () => ({ value: '', onChange: vi.fn() }),
+} as unknown as ReactionEntityNodeProps<ReactionFormValue>['formMethods'];
+
+const renderValue = (inputType: string, isViewOnly = false) =>
+  renderInReactionView(
+    <ReactionEntityValue
+      node={{ name: 'field', inputType } as unknown as ReactionFormValue}
+      formMethods={formMethods}
+    />,
+    { isViewOnly },
+  );
+
+describe('ReactionEntityValue', () => {
+  it('renders a text input for string fields', () => {
+    const { container } = renderValue('string');
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+    expect(input).not.toBeDisabled();
+  });
+
+  it('renders a textarea for textarea fields', () => {
+    const { container } = renderValue('textarea');
+    expect(container.querySelector('textarea')).not.toBeNull();
+  });
+
+  it('renders a numeric input for number fields', () => {
+    const { container } = renderValue('number');
+    expect(container.querySelector('input')).not.toBeNull();
+  });
+
+  it('disables the input in view-only mode', () => {
+    const { container } = renderValue('string', true);
+    expect(container.querySelector('input')).toBeDisabled();
+  });
+
+  it('renders nothing for an unknown input type', () => {
+    const { container } = renderValue('mystery');
+    expect(container.querySelector('input')).toBeNull();
+    expect(container.querySelector('textarea')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Continues the #662 view-component backfill (test-only, no production code):

- **`ReactionEntityValue`** — renders the correct control per `inputType` (text input / textarea / numeric input), renders nothing for an unknown type, and disables the control in view-only mode.
- **`ReactionEntitySelect`** — renders a native `<select>` with the options for the `dropdown` variant (disabled in view-only) and a segmented control for the non-dropdown variant.

Both render via `renderInReactionView` with a stub `getInputProps`; `ReactionValueLabelWrapper` resolves to the context's Dummy label component.

## Test

8 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds test-only coverage for two reaction entity node components, `ReactionEntityValue` and `ReactionEntitySelect`, using `renderInReactionView` with a minimal stub `getInputProps`. No production code is changed.

- **`ReactionEntityValue.test.tsx`**: 5 tests cover the three input-type branches (string/textarea/number), disabled-in-view-only, and the unknown-type null return.
- **`ReactionEntitySelect.test.tsx`**: 4 tests cover dropdown rendering, dropdown disabled-in-view-only, segmented-control option rendering, and segmented-control disabled-in-view-only (queried via `input[type=radio]`, addressing the previously flagged gap).

<h3>Confidence Score: 5/5</h3>

Test-only additions with no production code changes; safe to merge.

Both files are pure test additions. The stub formMethods, context wiring, and DOM assertions align correctly with the component implementations read from source. The segmented-control disabled assertion uses expect(radios.length).toBeGreaterThan(0) as a guard before forEach, so it fails loudly rather than passing vacuously if Mantine's radio structure ever changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityValue/ReactionEntityValue.test.tsx | New test file covering all five behaviors of ReactionEntityValue: string/textarea/number input rendering, view-only disabling, and null return for unknown types. Correctly uses renderInReactionView with a stub getInputProps. |
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntitySelect/ReacitonEntitySelect.test.tsx | New test file covering dropdown rendering, dropdown disabled-in-view-only, segmented control rendering, and segmented control disabled-in-view-only (via radio input assertions). Addresses the previously noted gap in view-only coverage for the segmented variant. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): assert segmented control is di..."](https://github.com/open-reaction-database/ord-app/commit/af46cc17074cb09233556c5ba5b52f2bcc1affa0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37795685)</sub>

<!-- /greptile_comment -->