### PR TITLE
test(ui): cover Conditions, Identifiers, Setup view sections (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionView/Conditions/Conditions.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Conditions/Conditions.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { Conditions } from './Conditions.tsx';
+
+describe('Conditions', () => {
+  it('renders the conditions section with each condition-group heading', () => {
+    const { getByText } = renderInReactionView(<Conditions reactionId={1} />);
+    expect(getByText('Conditions')).toBeInTheDocument();
+    for (const heading of ['Temperature', 'Pressure', 'Stirring', 'Illumination', 'Electrochemistry', 'Flow']) {
+      expect(getByText(heading)).toBeInTheDocument();
+    }
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Identifiers/Identifiers.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Identifiers/Identifiers.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { Identifiers } from './Identifiers.tsx';
+
+describe('Identifiers', () => {
+  it('renders the identifiers section with the add button when editable', () => {
+    const { getByText, getByRole } = renderInReactionView(<Identifiers reactionId={1} />);
+    expect(getByText('Identifiers')).toBeInTheDocument();
+    expect(getByText(/Reaction identifiers define/)).toBeInTheDocument();
+    expect(getByRole('button', { name: /Identifier/ })).toBeInTheDocument();
+  });
+
+  it('hides the add button in view-only mode', () => {
+    const { queryByRole } = renderInReactionView(<Identifiers reactionId={1} />, { isViewOnly: true });
+    expect(queryByRole('button', { name: /Identifier/ })).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Setup/Setup.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Setup/Setup.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { Setup } from './Setup.tsx';
+
+describe('Setup', () => {
+  it('renders the setup section with the vessel and material fields', () => {
+    const { getByText } = renderInReactionView(<Setup reactionId={1} />);
+    expect(getByText('Setup')).toBeInTheDocument();
+    // KeyValueDisplay renders each label with a trailing colon.
+    expect(getByText('Vessel:')).toBeInTheDocument();
+    expect(getByText('Material:')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Continues the #662 view-component backfill (test-only, no production code):

- **`Conditions`** — renders the section title and every condition-group heading (Temperature / Pressure / Stirring / Illumination / Electrochemistry / Flow).
- **`Identifiers`** — renders the section + the add-Identifier button when editable, and hides it in view-only mode.
- **`Setup`** — renders the section with the vessel/material fields.

All render via `renderInReactionView` with the default empty reaction.

## Test

4 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three new render-smoke test files covering the `Conditions`, `Identifiers`, and `Setup` sections of `ReactionView`, continuing the #662 view-component test backfill. No production code is changed.

- **`Conditions.test.tsx`** — verifies the section title and all six condition-group headings (Temperature through Flow) appear in the default empty reaction.
- **`Identifiers.test.tsx`** — verifies the section title, the descriptive paragraph, and the add-Identifier button are present in editable mode, and that the button is absent when `isViewOnly: true` is passed to `renderInReactionView`.
- **`Setup.test.tsx`** — verifies the section title and the Vessel/Material label-with-colon entries rendered by `KeyValueDisplay` appear in the default empty reaction.

<h3>Confidence Score: 5/5</h3>

Test-only PR with no production code changes; all three new tests follow the established renderInReactionView helper pattern and assert against the real component implementations.

All three test files are additive-only. The assertions match the actual markup in Conditions.tsx, Identifiers.tsx, and Setup.tsx, and the view-only branch of Identifiers is exercised by the existing isViewOnly option in the render helper. No logic changes, no migration, no interface modifications.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionView/Conditions/Conditions.test.tsx | New smoke test verifying the Conditions section title and all six condition-group headings render; matches patterns from existing test files. |
| ui/src/features/reactions/ReactionView/Identifiers/Identifiers.test.tsx | Two tests: editable mode checks title + descriptive text + add-button presence; view-only mode confirms the add-button is absent via isViewOnly context option. |
| ui/src/features/reactions/ReactionView/Setup/Setup.test.tsx | Smoke test asserting the Setup title plus the Vessel/Material labels (with colon suffix from KeyValueDisplay) are present in the default empty reaction. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover Conditions, Identifiers,..."](https://github.com/open-reaction-database/ord-app/commit/292a8b1406a57604a9e6cd7ccff866b556c2e95b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37798938)</sub>

<!-- /greptile_comment -->