### PR TITLE
test(ui): cover Observation, entity Group + Date nodes (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityDate/ReactionEntityDate.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityDate/ReactionEntityDate.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntityDate } from './ReactionEntityDate.tsx';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormDate } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const formMethods = {
+  getInputProps: () => ({ value: null, onChange: vi.fn() }),
+} as unknown as ReactionEntityNodeProps<ReactionFormDate>['formMethods'];
+
+const renderDate = (isViewOnly = false) =>
+  renderInReactionView(
+    <ReactionEntityDate
+      node={{ name: 'date', wrapperConfig: {} } as unknown as ReactionFormDate}
+      formMethods={formMethods}
+    />,
+    { isViewOnly },
+  );
+
+describe('ReactionEntityDate', () => {
+  it('renders a date input for a valid/empty value', () => {
+    const { getByPlaceholderText } = renderDate();
+    expect(getByPlaceholderText('Date')).toBeInTheDocument();
+  });
+
+  it('disables the date input in view-only mode', () => {
+    const { getByPlaceholderText } = renderDate(true);
+    expect(getByPlaceholderText('Date')).toBeDisabled();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityGroup/ReactionEntityGroup.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityGroup/ReactionEntityGroup.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { ReactionEntityGroup } from './ReactionEntityGroup.tsx';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormGroup } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+// Keep the group off the recursive node registry (which pulls in the Ketcher/d3 editor).
+vi.mock('../ReactionEntityBaseNode/ReactionEntityBaseNode.tsx', () => ({
+  ReactionEntityBaseNode: ({ node }: Readonly<{ node: { type?: string } }>) => (
+    <div data-testid="base-node">{node?.type ?? 'node'}</div>
+  ),
+}));
+
+const formMethods = {} as ReactionEntityNodeProps<ReactionFormGroup>['formMethods'];
+
+describe('ReactionEntityGroup', () => {
+  it('renders one base node per grouped field', () => {
+    const node = { fields: [{ type: 'a' }, { type: 'b' }] } as unknown as ReactionFormGroup;
+    const { getAllByTestId } = renderWithMantine(
+      <ReactionEntityGroup
+        node={node}
+        formMethods={formMethods}
+      />,
+    );
+    expect(getAllByTestId('base-node')).toHaveLength(2);
+  });
+
+  it('renders no base nodes when the group is empty', () => {
+    const node = { fields: [] } as unknown as ReactionFormGroup;
+    const { queryByTestId } = renderWithMantine(
+      <ReactionEntityGroup
+        node={node}
+        formMethods={formMethods}
+      />,
+    );
+    expect(queryByTestId('base-node')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Observation/Observation.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Observation/Observation.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { Observation } from './Observation.tsx';
+
+describe('Observation', () => {
+  it('renders the observations section with the add button when editable', () => {
+    const { getByText, getByRole } = renderInReactionView(<Observation reactionId={1} />);
+    expect(getByText('Observations')).toBeInTheDocument();
+    expect(getByText(/Observations are time-stamped comments/)).toBeInTheDocument();
+    expect(getByRole('button', { name: /Observation/ })).toBeInTheDocument();
+  });
+
+  it('hides the add button in view-only mode', () => {
+    const { queryByRole } = renderInReactionView(<Observation reactionId={1} />, { isViewOnly: true });
+    expect(queryByRole('button', { name: /Observation/ })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Continues the #662 view-component backfill (test-only, no production code):

- **`Observation`** — renders the section + the add-Observation button when editable, and hides it in view-only mode.
- **`ReactionEntityGroup`** — renders one base node per grouped field (base node stubbed to stay off the Ketcher/d3 registry).
- **`ReactionEntityDate`** — renders a date input for a valid/empty value and disables it in view-only mode.

## Test

6 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Test-only PR adding 6 new Vitest tests that backfill view-component coverage for `Observation`, `ReactionEntityGroup`, and `ReactionEntityDate`. No production code is changed.

- **`Observation.test.tsx`** — verifies the section heading, description, and add-button render in editable mode, and that the button is absent in view-only mode, using `renderInReactionView` with a store-seeded empty reaction.
- **`ReactionEntityGroup.test.tsx`** — confirms the component renders one `ReactionEntityBaseNode` per entry in `fields` (and none for an empty array); stubs `ReactionEntityBaseNode` to avoid the Ketcher/d3 registry.
- **`ReactionEntityDate.test.tsx`** — checks that the `DateInput` with placeholder `"Date"` appears for a `null` value and is disabled in view-only mode; the invalid-date fallback branch is not covered, consistent with the stated test scope.

<h3>Confidence Score: 5/5</h3>

All three files are new test-only additions with no changes to production code; safe to merge.

The tests are well-scoped, use the project's established render helpers correctly, and the ReactionEntityBaseNode mock cleanly isolates the group test from the Ketcher/d3 editor. Test logic aligns with the component implementations read during this review.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionView/Observation/Observation.test.tsx | New test file: 2 tests covering edit and view-only rendering of the Observation section via renderInReactionView with an empty reaction seeded into the store. |
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityGroup/ReactionEntityGroup.test.tsx | New test file: 2 tests verifying one base node is rendered per field (and zero nodes for an empty group), with ReactionEntityBaseNode correctly mocked to avoid pulling in the Ketcher/d3 registry. |
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityDate/ReactionEntityDate.test.tsx | New test file: 2 tests for the valid/null value branch (DateInput with placeholder 'Date') and the disabled state in view-only mode; the invalid-date fallback branch is not covered but that omission is intentional per the test names. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover Observation, entity Grou..."](https://github.com/open-reaction-database/ord-app/commit/b8fd4a59bd96b0c5594584f9c03184bc788c6035) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37799783)</sub>

<!-- /greptile_comment -->