### PR TITLE
test(ui): cover ComponentDisplayRowCustomActions, DateTime, VPU (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityDateTime/ReactionEntityDateTime.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityDateTime/ReactionEntityDateTime.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntityDateTime } from './ReactionEntityDateTime.tsx';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormDateTime } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const formMethods = {
+  getInputProps: () => ({ value: null, onChange: vi.fn() }),
+} as unknown as ReactionEntityNodeProps<ReactionFormDateTime>['formMethods'];
+
+const renderDateTime = (isViewOnly = false) =>
+  renderInReactionView(
+    <ReactionEntityDateTime
+      node={{ name: 'when', wrapperConfig: {} } as unknown as ReactionFormDateTime}
+      formMethods={formMethods}
+    />,
+    { isViewOnly },
+  );
+
+describe('ReactionEntityDateTime', () => {
+  it('renders the datetime picker with a "Now" shortcut when editable', () => {
+    const { getByText, container } = renderDateTime();
+    // Mantine's DateTimePicker renders a button + hidden input rather than a placeholdered input.
+    expect(container.querySelector('input')).not.toBeNull();
+    expect(getByText('Now')).toBeInTheDocument();
+  });
+
+  it('hides the "Now" shortcut in view-only mode', () => {
+    const { queryByText } = renderDateTime(true);
+    expect(queryByText('Now')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityVPU/ReactionEntityVPU.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityVPU/ReactionEntityVPU.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntityVPU } from './ReactionEntityVPU.tsx';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormValuePrecisionUnit } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const formMethods = {
+  getInputProps: () => ({ value: undefined, onChange: vi.fn() }),
+} as unknown as ReactionEntityNodeProps<ReactionFormValuePrecisionUnit>['formMethods'];
+
+const renderVPU = (isViewOnly = false) =>
+  renderInReactionView(
+    <ReactionEntityVPU
+      node={{ name: 'amount', options: ['mL', 'L'] } as unknown as ReactionFormValuePrecisionUnit}
+      formMethods={formMethods}
+    />,
+    { isViewOnly },
+  );
+
+describe('ReactionEntityVPU', () => {
+  it('renders the value and precision inputs', () => {
+    const { getByPlaceholderText } = renderVPU();
+    expect(getByPlaceholderText('Value')).toBeInTheDocument();
+    expect(getByPlaceholderText('Precision')).toBeInTheDocument();
+  });
+
+  it('disables the inputs in view-only mode', () => {
+    const { getByPlaceholderText } = renderVPU(true);
+    expect(getByPlaceholderText('Value')).toBeDisabled();
+    expect(getByPlaceholderText('Precision')).toBeDisabled();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRowCustomActions.test.tsx
+++ b/ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRowCustomActions.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ComponentDisplayRowCustomActions } from './ComponentDisplayRowCustomActions.tsx';
+import type { ReactionComponentBase } from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
+
+// The structure preview is exercised elsewhere; stub it so this test focuses on the row layout.
+vi.mock('common/components/ReactionPreview/ReactionComponentPreview.tsx', () => ({
+  ReactionComponentPreview: () => <div data-testid="preview" />,
+}));
+
+const component = {
+  id: 'c1',
+  identifiers: [{ id: 'i1', type: 'SMILES', value: 'O' }],
+  reactionRole: 'REACTANT',
+} as unknown as ReactionComponentBase;
+
+describe('ComponentDisplayRowCustomActions', () => {
+  it('renders the identifiers, reaction role, rendered details, and actions', () => {
+    const { getByText } = renderWithProviders(
+      <ComponentDisplayRowCustomActions
+        component={component}
+        renderDetails={() => '10 mL'}
+        actions={<span>row-actions</span>}
+      />,
+    );
+    expect(getByText('SMILES:')).toBeInTheDocument();
+    expect(getByText('O')).toBeInTheDocument();
+    expect(getByText('REACTANT')).toBeInTheDocument();
+    expect(getByText('10 mL')).toBeInTheDocument();
+    expect(getByText('row-actions')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Continues the #662 view-component backfill (test-only, no production code):

- **`ComponentDisplayRowCustomActions`** — renders the component identifiers, reaction role, rendered details, and the actions slot (structure preview stubbed).
- **`ReactionEntityDateTime`** — renders the picker with the "Now" shortcut when editable and hides it in view-only mode.
- **`ReactionEntityVPU`** — renders the value/precision inputs and disables them in view-only mode.

## Test

5 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a test-only PR adding five new Vitest smoke tests for `ComponentDisplayRowCustomActions`, `ReactionEntityDateTime`, and `ReactionEntityVPU` as part of the ongoing view-component backfill (#662). No production code is changed.

- **`ComponentDisplayRowCustomActions.test.tsx`** — single test verifies identifiers, reaction role, details, and actions slot render correctly; `ReactionComponentPreview` is stubbed via `vi.mock` and `renderWithProviders` is correctly preferred over `renderInReactionView` since this component doesn't consume `reactionContext`.
- **`ReactionEntityDateTime.test.tsx`** — two tests cover the editable path (input + "Now" anchor visible) and the view-only path ("Now" hidden); the `value: null` stub correctly exercises the `value === null` guard in `isDateValid`, keeping the component on the `DateTimePicker` branch.
- **`ReactionEntityVPU.test.tsx`** — two tests confirm the Value/Precision inputs render and are disabled in view-only mode; the `options: ['mL', 'L']` fixture is valid per the `SelectOptions = Array<SelectOption>` type that accepts plain strings.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no production code changes; safe to merge.

All three test files are purely additive, the fixtures are correctly typed via `as unknown` casts consistent with the existing test pattern in this repo, mock paths match the actual imports in the production components, and the render helpers are chosen appropriately for each component's context requirements. No existing tests are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRowCustomActions.test.tsx | New test: renders identifiers, reaction role, details, and actions slot; mocks ReactionComponentPreview correctly; uses renderWithProviders appropriately since the component doesn't need reaction context |
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityDateTime/ReactionEntityDateTime.test.tsx | New test: covers editable and view-only modes; formMethods stub (value: null) exercises the isDateValid=true path correctly via the value === null guard in the component |
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityVPU/ReactionEntityVPU.test.tsx | New test: verifies Value/Precision inputs render and are disabled in view-only mode; node fixture provides valid SelectOptions (string array) matching the type definition |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover ComponentDisplayRowCusto..."](https://github.com/open-reaction-database/ord-app/commit/c7cb9961229bba76b95a0767c9a3c1021fa52a95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37800751)</sub>

<!-- /greptile_comment -->