### PR TITLE
test(ui): cover MeasurementsPreview, CrudeComponentView, ComponentDisplayRow (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRow.test.tsx
+++ b/ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRow.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ComponentDisplayRow } from './ComponentDisplayRow.tsx';
+import type { ReactionComponentBase } from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
+
+// The structure preview is exercised elsewhere; stub it so this test focuses on the row content.
+vi.mock('common/components/ReactionPreview/ReactionComponentPreview.tsx', () => ({
+  ReactionComponentPreview: () => <div data-testid="preview" />,
+}));
+
+const component = {
+  id: 'c1',
+  identifiers: [{ id: 'i1', type: 'SMILES', value: 'O' }],
+  reactionRole: 'REACTANT',
+} as unknown as ReactionComponentBase;
+
+describe('ComponentDisplayRow', () => {
+  it('renders the component identifiers, role, and rendered details', () => {
+    const { getByText } = renderInReactionView(
+      <ComponentDisplayRow
+        component={component}
+        renderDetails={() => '10 mL'}
+        componentPath={['inputs', 0]}
+      />,
+    );
+    expect(getByText('SMILES:')).toBeInTheDocument();
+    expect(getByText('O')).toBeInTheDocument();
+    expect(getByText('REACTANT')).toBeInTheDocument();
+    expect(getByText('10 mL')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/CrudeComponentView/CrudeComponentView.test.tsx
+++ b/ui/src/features/reactions/ReactionView/CrudeComponentView/CrudeComponentView.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { CrudeComponentView } from './CrudeComponentView.tsx';
+import type { ReactionCrudeComponent } from 'store/entities/reactions/reactionsInputs/reactionInputs.types.ts';
+
+const searchReaction = vi.fn((id: string) => ({ type: 'reactions/searchReaction/mock', payload: id }));
+vi.mock('store/entities/reactions/reactions.thunks.ts', async importActual => ({
+  ...((await importActual()) as Record<string, unknown>),
+  searchReaction: (id: string) => searchReaction(id),
+}));
+
+describe('CrudeComponentView', () => {
+  it('renders a link with the source reaction id and searches it on click', () => {
+    const { getByText } = renderWithProviders(
+      <CrudeComponentView crudeComponent={{ reactionId: 'rxn-123' } as ReactionCrudeComponent} />,
+    );
+    const link = getByText('rxn-123');
+    expect(link).toBeInTheDocument();
+    fireEvent.click(link);
+    expect(searchReaction).toHaveBeenCalledWith('rxn-123');
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Outcomes/MeasurementsPreview/MeasurementsPreview.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Outcomes/MeasurementsPreview/MeasurementsPreview.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { MeasurementsPreview } from './MeasurementsPreview.tsx';
+import type { ReactionProduct } from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
+
+const product = {
+  measurements: [
+    { id: 'm1', type: 'IDENTITY', analysis: { name: 'NMR' }, value: { type: 'String', value: 'clear liquid' } },
+    { id: 'm2', type: 'AREA', analysis: { name: 'HPLC' }, value: { type: '%', value: { value: 90 } } },
+  ],
+} as unknown as ReactionProduct;
+
+describe('MeasurementsPreview', () => {
+  it('renders each measurement type, analysis name, and value', () => {
+    const { getByText } = renderWithMantine(<MeasurementsPreview product={product} />);
+    expect(getByText('IDENTITY')).toBeInTheDocument();
+    expect(getByText('NMR')).toBeInTheDocument();
+    expect(getByText('clear liquid')).toBeInTheDocument();
+    expect(getByText('AREA')).toBeInTheDocument();
+    expect(getByText('HPLC')).toBeInTheDocument();
+    expect(getByText('90 %')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Continues the #662 view-component backfill (test-only, no production code):

- **`MeasurementsPreview`** — renders each measurement's type, analysis name, and formatted value (String and % variants).
- **`CrudeComponentView`** — renders the source reaction-id link and dispatches `searchReaction` on click (thunk mocked).
- **`ComponentDisplayRow`** — renders identifiers, role, and rendered details through the wrapper (structure preview stubbed).

## Test

3 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new test files covering `MeasurementsPreview`, `CrudeComponentView`, and `ComponentDisplayRow` — all test-only, with no changes to production code.

- **`MeasurementsPreview.test.tsx`**: Exercises both `String` and `%` measurement value branches; the `'90 %'` expectation correctly matches `renderValuePrecisionUnit({ value: 90, units: '%' })` output.
- **`CrudeComponentView.test.tsx`**: Mocks the `searchReaction` thunk at the module boundary, fires a click, and asserts the thunk was called with the correct reaction ID — a clean thunk-dispatch test pattern.
- **`ComponentDisplayRow.test.tsx`**: Uses `renderInReactionView` to satisfy the full context tree, stubs `ReactionComponentPreview` to keep the test focused, and asserts identifiers, role, and rendered details are visible; `SMILES:` expectation is valid because `KeyValueDisplay` appends the colon to its label prop.

<h3>Confidence Score: 5/5</h3>

Test-only additions with no changes to production code; safe to merge.

All three tests are well-scoped: fixtures match the source component logic, mocks are applied at the correct module boundary, and the render helpers used are consistent with the existing test suite patterns. No production paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionView/Outcomes/MeasurementsPreview/MeasurementsPreview.test.tsx | New test covering both String and % measurement value variants; fixture data and expected text match the component's rendering logic. |
| ui/src/features/reactions/ReactionView/CrudeComponentView/CrudeComponentView.test.tsx | New test that mocks the searchReaction thunk and verifies it is dispatched with the correct reaction ID on link click. |
| ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRow.test.tsx | New test rendering identifiers, role, and details through the full component tree; stubs ReactionComponentPreview to keep the test focused. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover MeasurementsPreview, Cru..."](https://github.com/open-reaction-database/ord-app/commit/5e539c9f8bc856cf224d9f33238a8efd31314b90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37801769)</sub>

<!-- /greptile_comment -->