### PR TITLE
test(ui): cover ReactionEntityBaseNode + Inputs component list (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityBaseNode/ReactionEntityBaseNode.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityBaseNode/ReactionEntityBaseNode.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { ReactionEntityBaseNode } from './ReactionEntityBaseNode.tsx';
+import { nodeToComponentContext } from '../reactionEntityNode.context.ts';
+import { ReactionFormNodeType } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+import type { ReactionNodeToComponent, ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+
+const Stub = () => <div data-testid="mapped">mapped</div>;
+const nodeToComponent = { [ReactionFormNodeType.value]: Stub } as unknown as ReactionNodeToComponent;
+const formMethods = {} as ReactionEntityNodeProps['formMethods'];
+
+const renderNode = (type: ReactionFormNodeType) =>
+  renderWithMantine(
+    <nodeToComponentContext.Provider value={nodeToComponent}>
+      <ReactionEntityBaseNode
+        node={{ type } as ReactionEntityNodeProps['node']}
+        formMethods={formMethods}
+      />
+    </nodeToComponentContext.Provider>,
+  );
+
+describe('ReactionEntityBaseNode', () => {
+  it('renders the component mapped to the node type', () => {
+    const { getByTestId } = renderNode(ReactionFormNodeType.value);
+    expect(getByTestId('mapped')).toBeInTheDocument();
+  });
+
+  it('renders nothing for a node type with no mapped component', () => {
+    const { queryByTestId } = renderNode(ReactionFormNodeType.block);
+    expect(queryByTestId('mapped')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputComponentsListItem/InputComponentsListItem.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputComponentsListItem/InputComponentsListItem.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { Accordion } from '@mantine/core';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { InputComponentsListItem } from './InputComponentsListItem.tsx';
+import type { ReactionInputWithoutName } from 'store/entities/reactions/reactionsInputs/reactionInputs.types.ts';
+
+// Structure preview is exercised elsewhere; stub it so the rows stay simple.
+vi.mock('common/components/ReactionPreview/ReactionComponentPreview.tsx', () => ({
+  ReactionComponentPreview: () => <div data-testid="preview" />,
+}));
+
+const renderItem = (input: ReactionInputWithoutName) =>
+  renderInReactionView(
+    <Accordion defaultValue="in1">
+      <InputComponentsListItem
+        input={input}
+        name="Input 1"
+        pathComponents={['inputs', 'in1']}
+        historyPathComponents={[]}
+      />
+    </Accordion>,
+  );
+
+describe('InputComponentsListItem', () => {
+  it('shows the empty state when the input has no components', () => {
+    renderItem({ id: 'in1', components: [] } as unknown as ReactionInputWithoutName);
+    expect(document.body).toHaveTextContent('Input 1');
+    expect(document.body).toHaveTextContent('There are no Components yet');
+  });
+
+  it('renders a component row with its details when components are present', () => {
+    const input = {
+      id: 'in1',
+      components: [
+        {
+          id: 'c1',
+          identifiers: [{ id: 'i1', type: 'SMILES', value: 'O' }],
+          reactionRole: 'REACTANT',
+          amount: { value: 10, units: 'MILLILITER' },
+        },
+      ],
+    } as unknown as ReactionInputWithoutName;
+    const { getByText } = renderItem(input);
+    expect(getByText('SMILES:')).toBeInTheDocument();
+    expect(getByText('REACTANT')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputComponentsListItem/InputComponentsListItem.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputComponentsListItem/InputComponentsListItem.test.tsx
@@ -38,9 +38,9 @@ const renderItem = (input: ReactionInputWithoutName) =>
 
 describe('InputComponentsListItem', () => {
   it('shows the empty state when the input has no components', () => {
-    renderItem({ id: 'in1', components: [] } as unknown as ReactionInputWithoutName);
-    expect(document.body).toHaveTextContent('Input 1');
-    expect(document.body).toHaveTextContent('There are no Components yet');
+    const { getByText } = renderItem({ id: 'in1', components: [] } as unknown as ReactionInputWithoutName);
+    expect(getByText('Input 1')).toBeInTheDocument();
+    expect(getByText('There are no Components yet')).toBeInTheDocument();
   });
 
   it('renders a component row with its details when components are present', () => {

--- a/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputsComponentsList.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputsComponentsList.test.tsx
@@ -23,7 +23,7 @@ const inputs = [{ id: 'in1', name: 'Input 1', components: [] }] as unknown as Ar
 describe('InputsComponentsList', () => {
   it('renders the column headers and one accordion item per input', () => {
     const { getByText } = renderInReactionView(<InputsComponentsList inputs={inputs} />);
-    for (const header of ['Identifiers', 'Preview', 'Role', 'Amount']) {
+    for (const header of ['Input', 'Identifiers', 'Preview', 'Role', 'Amount']) {
       expect(getByText(header)).toBeInTheDocument();
     }
     expect(getByText('Input 1')).toBeInTheDocument();

--- a/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputsComponentsList.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputsComponentsList.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { InputsComponentsList } from './InputsComponentsList.tsx';
+import type { ReactionInput } from 'store/entities/reactions/reactionsInputs/reactionInputs.types.ts';
+
+const inputs = [{ id: 'in1', name: 'Input 1', components: [] }] as unknown as Array<ReactionInput>;
+
+describe('InputsComponentsList', () => {
+  it('renders the column headers and one accordion item per input', () => {
+    const { getByText } = renderInReactionView(<InputsComponentsList inputs={inputs} />);
+    for (const header of ['Identifiers', 'Preview', 'Role', 'Amount']) {
+      expect(getByText(header)).toBeInTheDocument();
+    }
+    expect(getByText('Input 1')).toBeInTheDocument();
+    // An input with no components shows the empty state.
+    expect(getByText('There are no Components yet')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Continues the #662 view-component backfill (test-only, no production code):

- **`ReactionEntityBaseNode`** — dispatches to the component mapped to the node type via `nodeToComponentContext`, and renders nothing for an unmapped type.
- **`InputsComponentsList`** — renders the column headers and one accordion item per input (empty-state for a component-less input).
- **`InputComponentsListItem`** — shows the empty state when there are no components, and renders a component row (identifiers + role) when present (structure preview stubbed).

## Test

5 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds five new unit tests covering `ReactionEntityBaseNode`, `InputsComponentsList`, and `InputComponentsListItem` — all test-only, no production code changes.

- **`ReactionEntityBaseNode.test.tsx`**: Verifies that the component dispatches to the mapped stub for a known node type and returns nothing for an unmapped type, using a minimal context provider.
- **`InputsComponentsList.test.tsx`**: Asserts all five column headers (`Input`, `Identifiers`, `Preview`, `Role`, `Amount`) are rendered and that a zero-component input shows the empty state.
- **`InputComponentsListItem.test.tsx`**: Covers the empty-component accordion panel and a component row with an identifier and role; `ReactionComponentPreview` is correctly mocked via `vi.mock` to isolate the structure-preview dependency.

<h3>Confidence Score: 5/5</h3>

Pure test additions with no production code changes; safe to merge.

All three files are new test-only additions. The assertions match what the source components actually render, the accordion open-state is correctly seeded via defaultValue, context dependencies are properly stubbed, and ReactionComponentPreview is mocked where it would otherwise reach into Redux/Ketcher. No production behaviour is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityBaseNode/ReactionEntityBaseNode.test.tsx | New test file covering mapped-type rendering and null-return for unmapped types; correctly uses renderWithMantine and a context provider stub. |
| ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputsComponentsList.test.tsx | New test covering all five column headers and the empty-component-state accordion item; all headers including 'Input' are asserted. |
| ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputComponentsListItem/InputComponentsListItem.test.tsx | New test file with two cases (empty state and component row); both use scoped queries from renderItem, and ReactionComponentPreview is correctly mocked. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): address Greptile on Inputs lis..."](https://github.com/open-reaction-database/ord-app/commit/723e1986b3fc77a73ea67959a58196fddc241cb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37802880)</sub>

<!-- /greptile_comment -->