### PR TITLE
test(ui): cover the final view components — Custom/List/Data/OutcomeListItem (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityCustom/ReactionEntityCustom.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityCustom/ReactionEntityCustom.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { ReactionEntityCustom } from './ReactionEntityCustom.tsx';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormCustom } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const Custom = ({ name }: Readonly<{ name: string }>) => <div data-testid="custom">{name}</div>;
+const formMethods = {} as ReactionEntityNodeProps<ReactionFormCustom>['formMethods'];
+
+describe('ReactionEntityCustom', () => {
+  it('renders the node-supplied Component with the node name', () => {
+    const node = { name: 'my-field', Component: Custom } as unknown as ReactionFormCustom;
+    const { getByTestId } = renderWithMantine(
+      <ReactionEntityCustom
+        node={node}
+        formMethods={formMethods}
+      />,
+    );
+    expect(getByTestId('custom')).toHaveTextContent('my-field');
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityData/ReactionEntityData.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityData/ReactionEntityData.test.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntityData } from './ReactionEntityData.tsx';
+import { AppDataType } from 'store/entities/reactions/reactionData/reactionData.types.ts';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormData } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const node = {
+  fieldName: 'data',
+  nameFieldName: 'name',
+  wrapperConfig: { label: 'Data' },
+} as unknown as ReactionFormData;
+const formMethods = {
+  getInputProps: (field: string) =>
+    field === 'name'
+      ? { value: '', onChange: vi.fn() }
+      : { value: { type: AppDataType.Text, value: '' }, onChange: vi.fn() },
+} as unknown as ReactionEntityNodeProps<ReactionFormData>['formMethods'];
+
+describe('ReactionEntityData', () => {
+  it('renders the data-type selector and a text value control for Text data', () => {
+    const { container, getByText } = renderInReactionView(
+      <ReactionEntityData
+        node={node}
+        formMethods={formMethods}
+      />,
+    );
+    // Segmented control exposes each data type as a radio option.
+    expect(getByText('Text')).toBeInTheDocument();
+    expect(getByText('Number')).toBeInTheDocument();
+    // The value control for the Text type is a text input (the segmented control uses radios).
+    expect(container.querySelector('input:not([type="radio"])')).not.toBeNull();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityData/ReactionEntityData.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityData/ReactionEntityData.test.tsx
@@ -34,7 +34,7 @@ const formMethods = {
 
 describe('ReactionEntityData', () => {
   it('renders the data-type selector and a text value control for Text data', () => {
-    const { container, getByText } = renderInReactionView(
+    const { getByText, getByRole } = renderInReactionView(
       <ReactionEntityData
         node={node}
         formMethods={formMethods}
@@ -43,7 +43,7 @@ describe('ReactionEntityData', () => {
     // Segmented control exposes each data type as a radio option.
     expect(getByText('Text')).toBeInTheDocument();
     expect(getByText('Number')).toBeInTheDocument();
-    // The value control for the Text type is a text input (the segmented control uses radios).
-    expect(container.querySelector('input:not([type="radio"])')).not.toBeNull();
+    // The value control for the Text type is a text input (role=textbox; the selector uses radios).
+    expect(getByRole('textbox')).toBeInTheDocument();
   });
 });

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityList/ReactionEntityList.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityList/ReactionEntityList.test.tsx
@@ -25,6 +25,7 @@ const makeNode = () =>
   ({
     name: 'items',
     title: { label: 'Items' },
+    getKey: (_item: unknown, index: number) => index,
     useSelectItems: () => [],
     ItemDisplay: () => null,
     addItem: { label: 'Add', useCreate: () => () => {} },

--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityList/ReactionEntityList.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityList/ReactionEntityList.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntityList } from './ReactionEntityList.tsx';
+import type { ReactionEntityNodeProps } from '../reactionEntityNode.types.ts';
+import type { ReactionFormList } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
+
+const formMethods = {} as ReactionEntityNodeProps<ReactionFormList>['formMethods'];
+
+const makeNode = () =>
+  ({
+    name: 'items',
+    title: { label: 'Items' },
+    useSelectItems: () => [],
+    ItemDisplay: () => null,
+    addItem: { label: 'Add', useCreate: () => () => {} },
+  }) as unknown as ReactionFormList;
+
+describe('ReactionEntityList', () => {
+  it('renders the list title and the add button when editable', () => {
+    const { getByText } = renderInReactionView(
+      <ReactionEntityList
+        node={makeNode()}
+        formMethods={formMethods}
+      />,
+    );
+    expect(getByText('Items')).toBeInTheDocument();
+    expect(getByText('Add')).toBeInTheDocument();
+  });
+
+  it('hides the add button in view-only mode', () => {
+    const { queryByText } = renderInReactionView(
+      <ReactionEntityList
+        node={makeNode()}
+        formMethods={formMethods}
+      />,
+      {
+        isViewOnly: true,
+      },
+    );
+    expect(queryByText('Add')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItem.test.tsx
+++ b/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItem.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { Accordion } from '@mantine/core';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { OutcomeListItem } from './OutcomeListItem.tsx';
+import type { ReactionOutcome } from 'store/entities/reactions/reactionsOutcomes/reactionOutcomes.types.ts';
+
+describe('OutcomeListItem', () => {
+  it('renders the outcome header within the accordion', () => {
+    const outcome = { id: 'o1', products: [], analyses: {} } as unknown as ReactionOutcome;
+    const { getByText } = renderInReactionView(
+      <Accordion defaultValue="o1">
+        <OutcomeListItem
+          reactionId={1}
+          outcome={outcome}
+          outcomeIndex={0}
+        />
+      </Accordion>,
+    );
+    expect(getByText('Outcome')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Completes the #662 view-component test backfill (test-only, no production code):

- **`ReactionEntityCustom`** — renders the node-supplied `Component` with the node name.
- **`ReactionEntityList`** — renders the list title and the add button when editable; hides it in view-only mode.
- **`ReactionEntityData`** — renders the data-type segmented selector and a text value control for `Text` data.
- **`OutcomeListItem`** — renders the outcome header inside the accordion.

With this PR, **every component under `ReactionView/` and `reactionEntityNode/` now has a test.**

## Test

5 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 5 new Vitest tests completing the `ReactionView/` and `reactionEntityNode/` test backfill (issue #662). No production code is changed.

- **`ReactionEntityCustom`** — verifies the node-supplied `Component` receives `node.name` as a prop.
- **`ReactionEntityList`** — covers both editable (add button visible) and view-only (add button hidden) render modes; the mock now includes `getKey` from the previous review cycle.
- **`ReactionEntityData`** — checks the segmented data-type selector and the `textbox` role for `Text` data; the previously flagged `:not([type="radio"])` selector has been replaced with the role-based `getByRole('textbox')`.
- **`OutcomeListItem`** — smoke-tests the accordion header by asserting the "Outcome" title renders.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no production code changes; safe to merge.

All four files are new test files. Both issues flagged in the previous review round — the missing getKey on the ReactionEntityList mock and the Mantine-implementation-coupled :not([type="radio"]) selector in ReactionEntityData — have been addressed. The mocks are correct, context dependencies are satisfied by renderInReactionView, and no production behaviour is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityCustom/ReactionEntityCustom.test.tsx | New test for ReactionEntityCustom — verifies the node-supplied Component receives the node name. Clean and minimal. |
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityData/ReactionEntityData.test.tsx | New test for ReactionEntityData — checks the segmented type selector and text input for the Text data type. Previously flagged :not([type="radio"]) selector replaced with role-based getByRole('textbox'). |
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/ReactionEntityList/ReactionEntityList.test.tsx | New tests for ReactionEntityList — covers editable (add button shown) and view-only (add button hidden) modes. Previously missing getKey has been added to the mock. |
| ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItem.test.tsx | New smoke test for OutcomeListItem — wraps the component in an Accordion and verifies the "Outcome" header text renders. The renderInReactionView helper satisfies all required context dependencies. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): address Greptile on final view..."](https://github.com/open-reaction-database/ord-app/commit/c35e249f7688f4bf23a128dd257d3d62307ebecb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37804483)</sub>

<!-- /greptile_comment -->