### PR TITLE
test(ui): cover useReactionEntityValidation unique-name rule (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/reactionEntityToValidation.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/reactionEntityToValidation.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import type { ReactNode } from 'react';
+import { rootReducer } from 'store/rootReducer.ts';
+import type { AppState } from 'store/configureAppStore.ts';
+import { useReactionEntityValidation } from './reactionEntityToValidation.ts';
+import { ReactionNodeEntity } from 'store/entities/reactions/reactions.types.ts';
+
+const store = configureStore({
+  reducer: rootReducer,
+  preloadedState: {
+    entities: {
+      reactions: {
+        reactionsById: {
+          1: { id: 1, data: { inputs: { in1: { id: 'in1', name: 'Existing' }, in2: { id: 'in2', name: 'Other' } } } },
+        },
+      },
+    },
+  } as unknown as AppState,
+});
+
+const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => <Provider store={store}>{children}</Provider>;
+
+const renderValidate = (entity: ReactionNodeEntity, pathComponents: Array<string>) =>
+  renderHook(() => useReactionEntityValidation(1, pathComponents, entity), { wrapper }).result.current;
+
+describe('useReactionEntityValidation', () => {
+  it('rejects a name that duplicates another sibling entity', () => {
+    const validate = renderValidate(ReactionNodeEntity.Inputs, ['inputs', 'in2']);
+    expect(validate({ name: 'Existing' }).name).toBeTruthy();
+  });
+
+  it('accepts a unique name, and the entity keeping its own name', () => {
+    const validate = renderValidate(ReactionNodeEntity.Inputs, ['inputs', 'in2']);
+    expect(validate({ name: 'Brand New' }).name).toBeFalsy();
+    // 'Other' is in2's own current name, so it is excluded from the uniqueness set.
+    expect(validate({ name: 'Other' }).name).toBeFalsy();
+  });
+
+  it('falls back to an empty (always-valid) schema for entities without a rule', () => {
+    const validate = renderValidate(ReactionNodeEntity.Outcomes, ['outcomes', '0']);
+    expect(validate({ name: 'anything' })).toEqual({});
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/reactionEntityToValidation.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/reactionEntityToValidation.test.tsx
@@ -47,10 +47,14 @@ describe('useReactionEntityValidation', () => {
     expect(validate({ name: 'Existing' }).name).toBeTruthy();
   });
 
-  it('accepts a unique name, and the entity keeping its own name', () => {
+  it('accepts a genuinely new, unique name', () => {
     const validate = renderValidate(ReactionNodeEntity.Inputs, ['inputs', 'in2']);
     expect(validate({ name: 'Brand New' }).name).toBeFalsy();
-    // 'Other' is in2's own current name, so it is excluded from the uniqueness set.
+  });
+
+  it("excludes the entity's own current name from the uniqueness set", () => {
+    const validate = renderValidate(ReactionNodeEntity.Inputs, ['inputs', 'in2']);
+    // 'Other' is in2's own current name, so re-using it is allowed.
     expect(validate({ name: 'Other' }).name).toBeFalsy();
   });
 


### PR DESCRIPTION
## What

Covers the yup-based entity validation hook (`useReactionEntityValidation` / `reactionEntityToValidation`), the last untested piece of the #662 tail (test-only, no production code):

- rejects a name that duplicates a sibling entity,
- accepts a unique name **and** the entity keeping its own current name (own name excluded from the uniqueness set),
- falls back to an always-valid empty schema for entities without a rule.

Exercised via `renderHook` with a seeded store.

## Test

3 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file for `useReactionEntityValidation` / `reactionEntityToValidation`, covering the uniqueness rule for named entities and the always-valid fallback for entity types without a rule. No production code is changed.

- Three behaviour cases for `ReactionNodeEntity.Inputs`: rejects a duplicate name, accepts a genuinely new name, and accepts the entity's own current name (self-exclusion from the uniqueness set).
- One fallback case for `ReactionNodeEntity.Outcomes`: confirms that entities with no registered rule receive an empty schema that never produces errors.

<h3>Confidence Score: 5/5</h3>

Test-only addition; no production code is touched and all four cases exercise the real selector/store path correctly.

The preloaded state structure matches the selectReactionById selector path, the entity-ID self-exclusion logic is covered, and the fallback path relies on useDefaultValidate which ignores its arguments — all verified against the implementation.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/reactionEntityToValidation.test.tsx | New test file covering useReactionEntityValidation: duplicate-name rejection, unique-name acceptance, own-name exclusion, and fallback-schema cases — all correctly exercising the real selector/store path with a minimal preloaded state. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): split the validation acceptanc..."](https://github.com/open-reaction-database/ord-app/commit/4abd836b425907a61fe95bd25e991817fd3d95a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37805412)</sub>

<!-- /greptile_comment -->