### PR TITLE
test(ui): cover NotFoundPage and ReactionValidationList (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationList.test.tsx
+++ b/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationList.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionValidationList } from './ReactionValidationList.tsx';
+import type { ReactionValidation } from 'store/entities/reactions/reactions.types.ts';
+
+const validation = {
+  errors: [{ text: 'Reaction inputs are required' }],
+  warnings: [{ text: 'Consider adding a yield' }],
+} as unknown as ReactionValidation;
+
+describe('ReactionValidationList', () => {
+  it('renders the drawer with the error and warning messages when opened', () => {
+    const { getByText } = renderWithProviders(
+      <ReactionValidationList
+        opened
+        onClose={() => {}}
+        validation={validation}
+      />,
+    );
+    expect(getByText('Validation Results')).toBeInTheDocument();
+    expect(getByText('Reaction inputs are required')).toBeInTheDocument();
+    expect(getByText('Consider adding a yield')).toBeInTheDocument();
+  });
+
+  it('does not render the drawer contents when closed', () => {
+    const { queryByText } = renderWithProviders(
+      <ReactionValidationList
+        opened={false}
+        onClose={() => {}}
+        validation={validation}
+      />,
+    );
+    expect(queryByText('Reaction inputs are required')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationList.test.tsx
+++ b/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationList.test.tsx
@@ -18,10 +18,10 @@ import { renderWithProviders } from 'test/renderWithProviders.tsx';
 import { ReactionValidationList } from './ReactionValidationList.tsx';
 import type { ReactionValidation } from 'store/entities/reactions/reactions.types.ts';
 
-const validation = {
+const validation: ReactionValidation = {
   errors: [{ text: 'Reaction inputs are required' }],
   warnings: [{ text: 'Consider adding a yield' }],
-} as unknown as ReactionValidation;
+};
 
 describe('ReactionValidationList', () => {
   it('renders the drawer with the error and warning messages when opened', () => {

--- a/ui/src/pages/NotFound/NotFoundPage.test.tsx
+++ b/ui/src/pages/NotFound/NotFoundPage.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { NotFoundPage } from './NotFoundPage.tsx';
+
+// PageContainer pulls in the auth-aware UserMenu; stub it to a passthrough so this test stays
+// focused on the not-found content.
+vi.mock('common/components/PageContainer/PageContainer.tsx', () => ({
+  PageContainer: ({ children }: Readonly<{ children: ReactNode }>) => <div>{children}</div>,
+}));
+
+describe('NotFoundPage', () => {
+  it('defaults to a 404 with a generic message and a link to the datasets page', () => {
+    const { getByText, getByRole } = renderWithMantine(<NotFoundPage />);
+    expect(getByText('404')).toBeInTheDocument();
+    expect(getByText(/could not be found/)).toBeInTheDocument();
+    expect(getByRole('button', { name: /Datasets/ })).toBeInTheDocument();
+  });
+
+  it('shows the provided error code and message', () => {
+    const { getByText } = renderWithMantine(
+      <NotFoundPage rejectValue={{ errorCode: 403, errorMessage: 'You do not have access' }} />,
+    );
+    expect(getByText('403')).toBeInTheDocument();
+    expect(getByText('You do not have access')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill beyond the reaction view tree (test-only, no production code):

- **`NotFoundPage`** — defaults to a 404 with a generic message and a datasets link, and surfaces a provided error code/message (`PageContainer` stubbed to a passthrough to avoid the auth-aware `UserMenu`).
- **`ReactionValidationList`** — renders the drawer with the error and warning messages when opened; renders nothing when closed.

## Test

4 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 4 unit tests covering `NotFoundPage` and `ReactionValidationList` as part of the #662 test backfill. No production code is changed.

- **`NotFoundPage.test.tsx`** — two tests verify the default 404 state (code, message, datasets link) and that a supplied `rejectValue` surfaces the correct error code and message; `PageContainer` is stubbed to a passthrough `div` to avoid the auth-aware `UserMenu`.
- **`ReactionValidationList.test.tsx`** — two tests assert that the Mantine `Drawer` shows error/warning messages when `opened` and renders nothing when closed; the `ReactionValidation` fixture uses a plain type annotation (no double-cast) against the real interface.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no changes to production code; straightforward to review and safe to merge.

Both files are new test files that exercise existing, unchanged components. The fixture types are correctly annotated, the mocking strategy is standard Vitest (hoisted vi.mock), and the assertions map directly to the rendered output of the components under test.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationList.test.tsx | Adds two tests for ReactionValidationList — drawer content visible when opened, absent when closed. Fixture uses a plain type annotation against ReactionValidation (no double-cast). Uses renderWithProviders correctly for a component that dispatches Redux actions. |
| ui/src/pages/NotFound/NotFoundPage.test.tsx | Adds two tests for NotFoundPage — default 404 state and provided errorCode/errorMessage. Correctly stubs out the auth-aware PageContainer with a passthrough div to keep the test focused on not-found content. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): type the validation fixture in..."](https://github.com/open-reaction-database/ord-app/commit/c3f93520fc586525291f3664ca45760b88b6a95e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37880811)</sub>

<!-- /greptile_comment -->