### PR TITLE
test(ui): cover the ReactionPreview component group (#662)

### DIFF
--- a/ui/src/common/components/ReactionPreview/ReactionInputPreview.test.tsx
+++ b/ui/src/common/components/ReactionPreview/ReactionInputPreview.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView, emptyReactionData } from 'test/renderInReactionView.tsx';
+import { ReactionInputPreview } from './ReactionInputPreview.tsx';
+import type { AppReaction } from 'store/entities/reactions/reactions.types.ts';
+
+vi.mock('common/components/ReactionPreview/ReactionComponentPreview.tsx', () => ({
+  ReactionComponentPreview: () => <div data-testid="component-preview" />,
+}));
+
+describe('ReactionInputPreview', () => {
+  it('renders the input name badge and a placeholder preview when it has no components', () => {
+    const reaction = {
+      ...emptyReactionData(),
+      inputs: { in1: { id: 'in1', name: 'My Input', components: [] } },
+    } as unknown as AppReaction;
+    const { getByText, getByTestId } = renderInReactionView(
+      <ReactionInputPreview
+        reactionId={1}
+        inputId="in1"
+      />,
+      {
+        reactionId: 1,
+        reaction,
+      },
+    );
+    expect(getByText('My Input')).toBeInTheDocument();
+    expect(getByTestId('component-preview')).toBeInTheDocument();
+  });
+});

--- a/ui/src/common/components/ReactionPreview/ReactionOutcomePreview.test.tsx
+++ b/ui/src/common/components/ReactionPreview/ReactionOutcomePreview.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView, emptyReactionData } from 'test/renderInReactionView.tsx';
+import { ReactionOutcomePreview } from './ReactionOutcomePreview.tsx';
+import type { AppReaction } from 'store/entities/reactions/reactions.types.ts';
+
+vi.mock('common/components/ReactionPreview/ReactionComponentPreview.tsx', () => ({
+  ReactionComponentPreview: () => <div data-testid="component-preview" />,
+}));
+
+const reactionWith = (outcome: object) =>
+  ({ ...emptyReactionData(), outcomes: [{ id: 'o1', products: [], ...outcome }] }) as unknown as AppReaction;
+
+describe('ReactionOutcomePreview', () => {
+  it('labels the outcome with its reaction time and conversion when present', () => {
+    const reaction = reactionWith({ reactionTime: { value: 5, units: 'HOUR' }, conversion: { value: 90 } });
+    const { getByText } = renderInReactionView(
+      <ReactionOutcomePreview
+        reactionId={1}
+        outcomeIndex={0}
+      />,
+      {
+        reactionId: 1,
+        reaction,
+      },
+    );
+    expect(getByText(/Outcome \(5 h, 90% conversion\)/)).toBeInTheDocument();
+  });
+
+  it('shows a bare "Outcome" label when there is no time or conversion', () => {
+    const reaction = reactionWith({});
+    const { getByText } = renderInReactionView(
+      <ReactionOutcomePreview
+        reactionId={1}
+        outcomeIndex={0}
+      />,
+      {
+        reactionId: 1,
+        reaction,
+      },
+    );
+    expect(getByText('Outcome')).toBeInTheDocument();
+  });
+});

--- a/ui/src/common/components/ReactionPreview/ReactionPreview.test.tsx
+++ b/ui/src/common/components/ReactionPreview/ReactionPreview.test.tsx
@@ -33,7 +33,7 @@ describe('ReactionPreview', () => {
     expect(getByText('There are no Inputs and Outcomes yet')).toBeInTheDocument();
   });
 
-  it('renders an input card and the arrow when the reaction has inputs', () => {
+  it('renders an input card when the reaction has inputs', () => {
     const data = {
       ...emptyReactionData(),
       inputs: { in1: { id: 'in1', name: 'Input A', components: [] } },

--- a/ui/src/common/components/ReactionPreview/ReactionPreview.test.tsx
+++ b/ui/src/common/components/ReactionPreview/ReactionPreview.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView, emptyReactionData } from 'test/renderInReactionView.tsx';
+import { ReactionPreview } from './ReactionPreview.tsx';
+import type { AppReaction, ReactionOrTemplate } from 'store/entities/reactions/reactions.types.ts';
+
+vi.mock('common/components/ReactionPreview/ReactionComponentPreview.tsx', () => ({
+  ReactionComponentPreview: () => <div data-testid="component-preview" />,
+}));
+
+describe('ReactionPreview', () => {
+  it('shows the empty placeholder when the reaction has no inputs or outcomes', () => {
+    const data = emptyReactionData();
+    const reaction = { id: 1, data, summary: { conditions: '' } } as unknown as ReactionOrTemplate;
+    const { getByText } = renderInReactionView(<ReactionPreview reaction={reaction} />, {
+      reactionId: 1,
+      reaction: data,
+    });
+    expect(getByText('There are no Inputs and Outcomes yet')).toBeInTheDocument();
+  });
+
+  it('renders an input card and the arrow when the reaction has inputs', () => {
+    const data = {
+      ...emptyReactionData(),
+      inputs: { in1: { id: 'in1', name: 'Input A', components: [] } },
+    } as unknown as AppReaction;
+    const reaction = { id: 1, data, summary: { conditions: '' } } as unknown as ReactionOrTemplate;
+    const { getByText } = renderInReactionView(<ReactionPreview reaction={reaction} />, {
+      reactionId: 1,
+      reaction: data,
+    });
+    expect(getByText('Input A')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill to the `common/components/ReactionPreview` group (test-only, no production code; `ReactionComponentPreview` stubbed):

- **`ReactionInputPreview`** — renders the input-name badge + a placeholder preview for a component-less input.
- **`ReactionOutcomePreview`** — labels the outcome with its reaction time + conversion when present, and a bare "Outcome" otherwise.
- **`ReactionPreview`** — shows the empty placeholder when there are no inputs/outcomes, and renders an input card when inputs are present.

## Test

5 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 5 new Vitest tests covering the `ReactionInputPreview`, `ReactionOutcomePreview`, and `ReactionPreview` components as part of the ongoing #662 test backfill. No production code is changed.

- **`ReactionInputPreview.test.tsx`** — seeds a no-component input in the Redux store and asserts the name badge and mocked placeholder are rendered.
- **`ReactionOutcomePreview.test.tsx`** — covers both the formatted label path (`reactionTime` + conversion) and the bare `"Outcome"` fallback, with assertions that align directly with the component's label-building logic.
- **`ReactionPreview.test.tsx`** — verifies the empty-state placeholder text and confirms an input card appears when the store contains inputs.

<h3>Confidence Score: 5/5</h3>

Test-only change with no production code modifications; safe to merge.

All three new test files add purely additive coverage using the established renderInReactionView harness. The assertions have been verified against the actual component logic — store selectors, label-building, and conditional rendering — and are correct. No production paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/ReactionPreview/ReactionInputPreview.test.tsx | Adds a single smoke test that seeds the Redux store with a no-component input, mocks ReactionComponentPreview, and asserts the name badge and placeholder are rendered. Logic and assertions are correct. |
| ui/src/common/components/ReactionPreview/ReactionOutcomePreview.test.tsx | Adds two tests covering the outcome label: one with reactionTime + conversion (asserts the formatted string), one with neither (asserts bare "Outcome"). Assertions align with the component's label-building logic. |
| ui/src/common/components/ReactionPreview/ReactionPreview.test.tsx | Adds two tests: empty placeholder when no inputs/outcomes, and input card rendering when inputs are present. Both tests correctly seed the store and match rendered text. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): align ReactionPreview test nam..."](https://github.com/open-reaction-database/ord-app/commit/0857365849619ba789e0e0e3b9dd03116bac17bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37884569)</sub>

<!-- /greptile_comment -->