### PR TITLE
test(ui): cover MeasurementValueControl + MeasurementsBasedOn (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { MeasurementValueControl } from './MeasurementValueControl.tsx';
+import { ReactionMeasurementValueType } from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
+import type { ReactionEntityNodeProps } from 'features/reactions/ReactionEntities/reactionEntityNode/reactionEntityNode.types.ts';
+
+const formMethods = {
+  getInputProps: () => ({
+    value: { type: ReactionMeasurementValueType.Number, value: { value: null, precision: null } },
+    onChange: vi.fn(),
+  }),
+} as unknown as ReactionEntityNodeProps['formMethods'];
+
+const renderControl = (isViewOnly = false) =>
+  renderInReactionView(
+    <MeasurementValueControl
+      name="measurement"
+      formMethods={formMethods}
+    />,
+    { isViewOnly },
+  );
+
+describe('MeasurementValueControl', () => {
+  it('renders the value and precision inputs for a numeric measurement', () => {
+    const { getByPlaceholderText } = renderControl();
+    expect(getByPlaceholderText('Value')).toBeInTheDocument();
+    expect(getByPlaceholderText('Precision')).toBeInTheDocument();
+  });
+
+  it('disables the inputs in view-only mode', () => {
+    const { getByPlaceholderText } = renderControl(true);
+    expect(getByPlaceholderText('Value')).toBeDisabled();
+    expect(getByPlaceholderText('Precision')).toBeDisabled();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementsBasedOn.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementsBasedOn.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView, emptyReactionData } from 'test/renderInReactionView.tsx';
+import { MeasurementsBasedOn } from './MeasurementsBasedOn.tsx';
+import type { AppReaction } from 'store/entities/reactions/reactions.types.ts';
+import type { ReactionEntityNodeProps } from 'features/reactions/ReactionEntities/reactionEntityNode/reactionEntityNode.types.ts';
+
+const formMethods = {
+  getInputProps: () => ({ value: null, onChange: vi.fn() }),
+} as unknown as ReactionEntityNodeProps['formMethods'];
+
+const reaction = {
+  ...emptyReactionData(),
+  outcomes: [{ id: 'o1', products: [], analyses: { a1: { id: 'a1', name: 'NMR' } } }],
+} as unknown as AppReaction;
+
+const renderBasedOn = (isViewOnly = false) =>
+  renderInReactionView(
+    <MeasurementsBasedOn
+      name="basedOn"
+      formMethods={formMethods}
+    />,
+    {
+      reactionId: 1,
+      reaction,
+      pathComponents: ['outcomes', 0, 'measurements', 0],
+      isViewOnly,
+    },
+  );
+
+describe('MeasurementsBasedOn', () => {
+  it('renders the analysis select', () => {
+    const { getByPlaceholderText } = renderBasedOn();
+    expect(getByPlaceholderText('Select analysis')).toBeInTheDocument();
+  });
+
+  it('disables the select in view-only mode', () => {
+    const { getByPlaceholderText } = renderBasedOn(true);
+    expect(getByPlaceholderText('Select analysis')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill to the measurement form-custom controls (test-only, no production code):

- **`MeasurementValueControl`** — renders the value/precision inputs for a numeric measurement and disables them in view-only mode.
- **`MeasurementsBasedOn`** — renders the analysis select (sourced from the outcome's `analyses`) and disables it in view-only mode.

## Test

4 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 4 new unit tests as part of the #662 test backfill — no production code is touched. The tests exercise two measurement form controls (`MeasurementValueControl` and `MeasurementsBasedOn`) using the existing `renderInReactionView` helper.

- **`MeasurementValueControl.test.tsx`**: Mocks `formMethods` with a `Number`-type measurement value, confirms "Value" and "Precision" inputs render, and verifies both are disabled when `isViewOnly` is set.
- **`MeasurementsBasedOn.test.tsx`**: Seeds a reaction store with one NMR analysis, confirms the "Select analysis" placeholder is present, and verifies the select becomes disabled in view-only mode. Path routing through `pathComponents: ['outcomes', 0, 'measurements', 0]` correctly resolves to the seeded analyses object.

<h3>Confidence Score: 5/5</h3>

Test-only change with no production code modifications; safe to merge.

Both test files follow the established renderInReactionView pattern, mock only the narrow surface each component needs, and exercise exactly the two behaviors (render + view-only disable) the components expose. The store is seeded correctly and the path routing through pathComponents aligns with what MeasurementsBasedOn expects. No production code is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.test.tsx | New test file: two smoke tests verify that "Value" and "Precision" inputs render and are disabled in view-only mode for a numeric measurement value. |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementsBasedOn.test.tsx | New test file: two smoke tests seed a reaction with one NMR analysis, verify the "Select analysis" placeholder renders, and confirm it becomes disabled in view-only mode. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover MeasurementValueControl ..."](https://github.com/open-reaction-database/ord-app/commit/edb40ac1d5382c0204d0ea01b7b3e717128cbbf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37887796)</sub>

<!-- /greptile_comment -->