### PR TITLE
test(ui): cover MeasurementMasses and EnumerationResult (#662)

### DIFF
--- a/ui/src/features/enumeration/EnumerationResult/EnumerationResult.test.tsx
+++ b/ui/src/features/enumeration/EnumerationResult/EnumerationResult.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { EnumerationResult } from './EnumerationResult.tsx';
+import type { EnumerationProgress } from 'store/entities/enumeration/enumeration.types.ts';
+
+const progress = (overrides: object) =>
+  ({ resultDatasetId: 0, reactions: [], errors: [], ...overrides }) as unknown as Required<EnumerationProgress>;
+
+describe('EnumerationResult', () => {
+  it('reports the number of reactions created on success', () => {
+    const { getByText } = renderWithMantine(
+      <EnumerationResult
+        enumerationProgress={progress({ resultDatasetId: 5, reactions: [{}, {}] })}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(getByText('Reactions created: 2')).toBeInTheDocument();
+  });
+
+  it('lists failed lines and shows "No reactions created" when none succeeded', () => {
+    const { getByText } = renderWithMantine(
+      <EnumerationResult
+        enumerationProgress={progress({ errors: [{ line: 3, message: 'invalid SMILES' }] })}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(getByText('No reactions created')).toBeInTheDocument();
+    expect(getByText('Failed to create lines:')).toBeInTheDocument();
+    expect(getByText('Line 3:')).toBeInTheDocument();
+    expect(getByText('invalid SMILES')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/enumeration/EnumerationResult/EnumerationResult.test.tsx
+++ b/ui/src/features/enumeration/EnumerationResult/EnumerationResult.test.tsx
@@ -19,7 +19,7 @@ import { EnumerationResult } from './EnumerationResult.tsx';
 import type { EnumerationProgress } from 'store/entities/enumeration/enumeration.types.ts';
 
 const progress = (overrides: object) =>
-  ({ resultDatasetId: 0, reactions: [], errors: [], ...overrides }) as unknown as Required<EnumerationProgress>;
+  ({ resultDatasetId: null, reactions: [], errors: [], ...overrides }) as unknown as Required<EnumerationProgress>;
 
 describe('EnumerationResult', () => {
   it('reports the number of reactions created on success', () => {

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementMasses.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementMasses.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { MeasurementMasses } from './MeasurementMasses.tsx';
+import type { ReactionEntityNodeProps } from 'features/reactions/ReactionEntities/reactionEntityNode/reactionEntityNode.types.ts';
+
+const formMethods = {
+  getInputProps: () => ({ value: [10, 20], onChange: vi.fn() }),
+} as unknown as ReactionEntityNodeProps['formMethods'];
+
+const renderMasses = (isViewOnly = false) =>
+  renderInReactionView(
+    <MeasurementMasses
+      name="masses"
+      formMethods={formMethods}
+    />,
+    { isViewOnly },
+  );
+
+describe('MeasurementMasses', () => {
+  it('renders the tags input with the current mass values and helper text', () => {
+    const { getByText, getByPlaceholderText } = renderMasses();
+    expect(getByPlaceholderText('Type to add unique')).toBeInTheDocument();
+    expect(getByText('Only numbers are allowed.')).toBeInTheDocument();
+    expect(getByText('10')).toBeInTheDocument();
+    expect(getByText('20')).toBeInTheDocument();
+  });
+
+  it('disables the input in view-only mode', () => {
+    const { getByPlaceholderText } = renderMasses(true);
+    expect(getByPlaceholderText('Type to add unique')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`MeasurementMasses`** — renders the EIC-masses `TagsInput` with the current values + helper text, and disables it in view-only mode.
- **`EnumerationResult`** — reports the reactions-created count on success, and lists failed lines (with "No reactions created") when none succeeded.

## Test

4 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds four new Vitest tests as part of the #662 backfill — two for `EnumerationResult` and two for `MeasurementMasses` — with no changes to production code.

- **`EnumerationResult`**: tests verify the success path (reaction count heading) and the all-failed path (no-dataset heading + per-line error list); the `progress` factory correctly defaults `resultDatasetId` to `null`, matching the `number | null` type.
- **`MeasurementMasses`**: tests verify the `TagsInput` renders numeric tag values and helper text in the default state, and that the input is disabled when the reaction context is view-only.

<h3>Confidence Score: 5/5</h3>

Test-only change with no modifications to production code; assertions are accurate against the current component implementations.

Both test files faithfully mirror their components' rendering logic, use the correct type defaults, and stub only the methods actually called. No production paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/enumeration/EnumerationResult/EnumerationResult.test.tsx | New tests covering the success (reactions-created count) and failure (no-dataset + error listing) rendering paths of EnumerationResult; factory defaults match the type definition. |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementMasses.test.tsx | New tests covering TagsInput rendering with numeric values and placeholder/description text, plus disabled state in view-only mode; formMethods stub is minimal and correct for what the component calls. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): use null sentinel for resultDa..."](https://github.com/open-reaction-database/ord-app/commit/ee14674345ea4688873a72ee27d326186d97a258) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37891569)</sub>

<!-- /greptile_comment -->