### PR TITLE
test(ui): cover UpdatePersonInfo and VariablesMatching (#662)

### DIFF
--- a/ui/src/features/enumeration/EnumerationSetup/VariablesMatching/VariablesMatching.test.tsx
+++ b/ui/src/features/enumeration/EnumerationSetup/VariablesMatching/VariablesMatching.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView, emptyReactionData } from 'test/renderInReactionView.tsx';
+import { VariablesMatching } from './VariablesMatching.tsx';
+import type { EnumerationForm } from '../enumerationSetup.types.ts';
+
+const form = {
+  values: {
+    templateId: 1,
+    matching: [{ variable: 'reagent' }],
+    templateCSV: { headers: ['col1', 'col2'] },
+  },
+  getInputProps: () => ({ value: '', onChange: vi.fn() }),
+} as unknown as EnumerationForm;
+
+describe('VariablesMatching', () => {
+  it('renders a matching row per template variable when the template and headers are available', () => {
+    const { getByText } = renderInReactionView(<VariablesMatching form={form} />, {
+      reactionId: 1,
+      reaction: emptyReactionData(),
+    });
+    expect(getByText('Matching')).toBeInTheDocument();
+    expect(getByText('Template Fields')).toBeInTheDocument();
+    expect(getByText('Uploaded File Fields')).toBeInTheDocument();
+    expect(getByText('@reagent')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/provenance/UpdatePersonInfo.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/provenance/UpdatePersonInfo.test.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent } from '@testing-library/react';
 import { renderInReactionView } from 'test/renderInReactionView.tsx';
 import { UpdatePersonInfo } from './UpdatePersonInfo.tsx';
@@ -37,13 +37,26 @@ const renderButton = (isViewOnly = false) =>
     { isViewOnly },
   );
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('UpdatePersonInfo', () => {
   it('renders the action button and merges the user info on click when editable', () => {
     const { getByRole } = renderButton();
     const button = getByRole('button', { name: 'Use my info' });
     expect(button).toBeInTheDocument();
     fireEvent.click(button);
-    expect(setValues).toHaveBeenCalled();
+    expect(setValues).toHaveBeenCalledTimes(1);
+    // setValues receives an updater; applying it to an empty form should populate the person at the
+    // node's path from the mocked user (name/email, and orcid_id mapped to the proto `orcid` key).
+    const updater = setValues.mock.calls[0][0] as (prev: object) => unknown;
+    const result = updater({}) as { provenance: { recordCreated: { person: object } } };
+    expect(result.provenance.recordCreated.person).toEqual({
+      name: 'Me',
+      email: 'me@example.com',
+      orcid: '0000-0001',
+    });
   });
 
   it('renders nothing in view-only mode', () => {

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/provenance/UpdatePersonInfo.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/provenance/UpdatePersonInfo.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { UpdatePersonInfo } from './UpdatePersonInfo.tsx';
+import type { ReactionEntityNodeProps } from 'features/reactions/ReactionEntities/reactionEntityNode/reactionEntityNode.types.ts';
+
+// selectSelf is a (state) => user selector; return a populated user so the click handler has data.
+vi.mock('store/entities/users/users.selectors.ts', () => ({
+  selectSelf: () => ({ name: 'Me', email: 'me@example.com', orcid_id: '0000-0001' }),
+}));
+
+const setValues = vi.fn();
+const formMethods = { setValues } as unknown as ReactionEntityNodeProps['formMethods'];
+
+const renderButton = (isViewOnly = false) =>
+  renderInReactionView(
+    <UpdatePersonInfo
+      name="provenance.recordCreated.person"
+      formMethods={formMethods}
+      text="Use my info"
+    />,
+    { isViewOnly },
+  );
+
+describe('UpdatePersonInfo', () => {
+  it('renders the action button and merges the user info on click when editable', () => {
+    const { getByRole } = renderButton();
+    const button = getByRole('button', { name: 'Use my info' });
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(setValues).toHaveBeenCalled();
+  });
+
+  it('renders nothing in view-only mode', () => {
+    const { queryByRole } = renderButton(true);
+    expect(queryByRole('button', { name: 'Use my info' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`UpdatePersonInfo`** — renders the action button and merges the current user's info via `setValues` on click; renders nothing in view-only mode (`selectSelf` mocked to a populated user).
- **`VariablesMatching`** — renders a matching row per template variable when the template and uploaded-file headers are available.

## Test

3 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three test cases covering `UpdatePersonInfo` and `VariablesMatching` as part of the #662 test backfill. No production code is changed.

- **`UpdatePersonInfo`**: verifies the button renders in editable mode, fires `setValues` on click, and asserts the full merged payload shape (including the `orcid_id` → `orcid` key mapping); a `beforeEach(() => vi.clearAllMocks())` keeps the spy isolated; and confirms the component returns `null` in view-only mode.
- **`VariablesMatching`**: seeds the Redux store with a reaction at `reactionId: 1` (matching `templateId: 1` in the form fixture) so the `canMatch` guard passes and the `@reagent` matching row is rendered; asserts the column header labels are also present.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no changes to production code; safe to merge.

Both new test files are well-structured: spy isolation is handled with `beforeEach`, the `UpdatePersonInfo` test verifies the full updater output rather than just call count, and the `VariablesMatching` test correctly coordinates `templateId` with the store seed via `reactionId`.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/provenance/UpdatePersonInfo.test.tsx | New test: renders the action button, verifies the `setValues` updater's full output shape on click, and confirms the component renders nothing in view-only mode. `vi.clearAllMocks()` in `beforeEach` keeps the spy clean between tests. |
| ui/src/features/enumeration/EnumerationSetup/VariablesMatching/VariablesMatching.test.tsx | New test: seeds the store with a reaction at `reactionId: 1` (matching `templateId: 1` in the form mock) so `selectReactionById(1)` returns a truthy template and all three `canMatch` conditions are satisfied, rendering the `@reagent` row. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): clear setValues spy + assert m..."](https://github.com/open-reaction-database/ord-app/commit/90a199046c7721767513c4fa6e7f1e558e372edb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37895970)</sub>

<!-- /greptile_comment -->