### PR TITLE
test(ui): cover EntityListItem and ProductsComponentsList (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/EntityListItem/EntityListItem.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/EntityListItem/EntityListItem.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { EntityListItem } from './EntityListItem.tsx';
+
+interface Analysis {
+  type: string;
+}
+
+describe('EntityListItem', () => {
+  it('renders a "<title> <key>" heading and the required fields for a string title', () => {
+    const { getByText } = renderInReactionView(
+      <EntityListItem<Analysis>
+        entityKey="a1"
+        entity={{ type: 'NMR' }}
+        entityField="analyses"
+        title="Analysis"
+        requiredFields={[{ label: 'Type', render: entity => entity.type }]}
+        historyPathComponents={[]}
+      />,
+      { pathComponents: ['outcomes', 0] },
+    );
+    expect(getByText('Analysis a1')).toBeInTheDocument();
+    expect(getByText('Type:')).toBeInTheDocument();
+    expect(getByText('NMR')).toBeInTheDocument();
+  });
+
+  it('uses a function title when provided', () => {
+    const { getByText } = renderInReactionView(
+      <EntityListItem<Analysis>
+        entityKey={0}
+        entity={{ type: 'HPLC' }}
+        entityField="analyses"
+        title={entity => `Custom ${entity.type}`}
+        requiredFields={[]}
+        historyPathComponents={[]}
+      />,
+      { pathComponents: ['outcomes', 0] },
+    );
+    expect(getByText('Custom HPLC')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/EntityListItem/EntityListItem.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/EntityListItem/EntityListItem.test.tsx
@@ -39,6 +39,21 @@ describe('EntityListItem', () => {
     expect(getByText('NMR')).toBeInTheDocument();
   });
 
+  it('offsets a numeric key by one for a string title (1-based display)', () => {
+    const { getByText } = renderInReactionView(
+      <EntityListItem<Analysis>
+        entityKey={0}
+        entity={{ type: 'NMR' }}
+        entityField="analyses"
+        title="Measurement"
+        requiredFields={[]}
+        historyPathComponents={[]}
+      />,
+      { pathComponents: ['outcomes', 0] },
+    );
+    expect(getByText('Measurement 1')).toBeInTheDocument();
+  });
+
   it('uses a function title when provided', () => {
     const { getByText } = renderInReactionView(
       <EntityListItem<Analysis>

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/outcomes/ProductComponentsList.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/outcomes/ProductComponentsList.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView, emptyReactionData } from 'test/renderInReactionView.tsx';
+import { ProductsComponentsList } from './ProductComponentsList.tsx';
+import type { AppReaction } from 'store/entities/reactions/reactions.types.ts';
+
+const reaction = {
+  ...emptyReactionData(),
+  outcomes: [{ id: 'o1', products: [], analyses: {} }],
+} as unknown as AppReaction;
+
+const renderList = (isViewOnly = false) =>
+  renderInReactionView(<ProductsComponentsList />, {
+    reactionId: 1,
+    reaction,
+    pathComponents: ['outcomes', 0],
+    isViewOnly,
+  });
+
+describe('ProductsComponentsList', () => {
+  it('renders the Products title and the add-Product button when editable', () => {
+    const { getByText } = renderList();
+    expect(getByText('Products')).toBeInTheDocument();
+    expect(getByText('Product')).toBeInTheDocument();
+  });
+
+  it('hides the add-Product button in view-only mode', () => {
+    const { queryByText } = renderList(true);
+    expect(queryByText('Product')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`EntityListItem`** — renders the `"<title> <key>"` heading (both string and function titles) plus the required fields.
- **`ProductsComponentsList`** — renders the Products title + the add-Product button when editable, and hides it in view-only mode.

## Test

4 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 4 new Vitest tests to backfill coverage for `EntityListItem` and `ProductsComponentsList` — no production code is touched.

- **`EntityListItem`**: covers the string-key/string-title path, the numeric-key 1-based offset path (previously unexercised), and the function-title path.
- **`ProductsComponentsList`**: verifies the "Products" title and add-Product button appear in editable mode, and that the button is hidden in view-only mode, using a correctly preloaded store fixture.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no production code changes; all new tests exercise real component logic against the existing render helper.

Both new test files correctly model the components they target: the EntityListItem tests cover all three branches of the titleText computation (string key, numeric key with 1-based offset, and function title), and the ProductsComponentsList tests use a properly shaped store fixture to verify editable vs view-only rendering. No production code is modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/EntityListItem/EntityListItem.test.tsx | New test file with 3 tests covering string-key/string-title, numeric-key/string-title (1-based offset), and function-title paths of EntityListItem — all correctly exercised against the source component logic. |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/outcomes/ProductComponentsList.test.tsx | New test file with 2 tests verifying ProductsComponentsList renders the "Products" title and "Product" add-button in editable mode, and hides the button in view-only mode; store preload and path setup align with how the component selects its data. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): cover numeric-key +1 offset in..."](https://github.com/open-reaction-database/ord-app/commit/05558a5ecc260a397c1d99b39be2c315227e4d1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37903586)</sub>

<!-- /greptile_comment -->