### PR TITLE
test(ui): cover ReactionContent view-mode branching (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/ReactionTabs/ReactionContent.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionTabs/ReactionContent.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionContent } from './ReactionContent.tsx';
+
+// In "tabs" mode the content is the tabbed editor, which pulls in the Ketcher/d3 node registry;
+// stub it so this test exercises ReactionContent's own view-mode branching.
+vi.mock('./ReactionTabs', () => ({ ReactionTabs: () => <div data-testid="reaction-tabs" /> }));
+
+describe('ReactionContent', () => {
+  it('renders the tabbed editor in "tabs" mode', () => {
+    const { getByTestId, queryByText } = renderInReactionView(
+      <ReactionContent
+        reactionId={1}
+        viewMode="tabs"
+      />,
+      {
+        reactionId: 1,
+      },
+    );
+    expect(getByTestId('reaction-tabs')).toBeInTheDocument();
+    // The flat section list is not rendered in tabs mode.
+    expect(queryByText('Conditions')).not.toBeInTheDocument();
+  });
+
+  it('renders the flat section list in "list" mode', () => {
+    const { getByText, queryByTestId } = renderInReactionView(
+      <ReactionContent
+        reactionId={1}
+        viewMode="list"
+      />,
+      {
+        reactionId: 1,
+      },
+    );
+    expect(queryByTestId('reaction-tabs')).not.toBeInTheDocument();
+    // A few of the stacked view sections render their titles.
+    expect(getByText('Conditions')).toBeInTheDocument();
+    expect(getByText('Setup')).toBeInTheDocument();
+    expect(getByText('Identifiers')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`ReactionContent`** — renders the tabbed editor in `tabs` mode (`ReactionTabs` stubbed to avoid the Ketcher/d3 node registry) and the flat stacked section list in `list` mode (asserts a few section titles render and the tabs are absent).

## Test

2 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two Vitest unit tests for `ReactionContent` that cover its `viewMode` branching: one asserts the stubbed `ReactionTabs` element is rendered in `"tabs"` mode and the flat section list is absent; the other asserts the inverse in `"list"` mode and spot-checks three section titles.

- `ReactionTabs` is stubbed via `vi.mock` at the module level so Vitest's hoist machinery works correctly and the Ketcher/d3 node registry is never touched.
- Tests use the shared `renderInReactionView` helper (store + context providers), keeping the pattern consistent with the rest of the test suite.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no changes to production code; safe to merge.

The change is a single new test file. The mock is correctly placed at module scope so Vitest's hoisting applies. The "tabs" test verifies the stub renders and the flat list is absent; the "list" test verifies the inverse. The automatic JSX runtime ("jsx": "react-jsx") means the JSX in the mock factory requires no explicit React import. No production code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/ReactionTabs/ReactionContent.test.tsx | New test file covering both "tabs" and "list" view-mode branches of ReactionContent; ReactionTabs is correctly stubbed via vi.mock to prevent Ketcher/d3 node-registry side-effects during testing. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover ReactionContent view-mod..."](https://github.com/open-reaction-database/ord-app/commit/6639f2c20b8403556cc42b675a4a898f3e1c9a31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37907855)</sub>

<!-- /greptile_comment -->