### PR TITLE
test(ui): cover ReactionValidationResult badge counts (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationResult.test.tsx
+++ b/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationResult.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { ReactionValidationResult } from './ReactionValidationResult.tsx';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const stateWith = (record: object): { preloadedState: AppState } => ({
+  preloadedState: {
+    entities: { reactions: { reactionsById: { 1: { id: 1, data: {}, ...record } } } },
+  } as unknown as AppState,
+});
+
+describe('ReactionValidationResult', () => {
+  it('shows pluralized error and warning counts when the reaction is invalid', () => {
+    const { getByText } = renderWithProviders(
+      <ReactionValidationResult reactionId={1} />,
+      stateWith({ is_valid: false, validation: { errors: [{ text: 'a' }, { text: 'b' }], warnings: [{ text: 'c' }] } }),
+    );
+    expect(getByText('2 errors')).toBeInTheDocument();
+    expect(getByText('1 warning')).toBeInTheDocument();
+  });
+
+  it('does not show an error count when the reaction is valid', () => {
+    const { queryByText } = renderWithProviders(
+      <ReactionValidationResult reactionId={1} />,
+      stateWith({ is_valid: true, validation: null }),
+    );
+    expect(queryByText(/error/)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationResult.test.tsx
+++ b/ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationResult.test.tsx
@@ -34,11 +34,12 @@ describe('ReactionValidationResult', () => {
     expect(getByText('1 warning')).toBeInTheDocument();
   });
 
-  it('does not show an error count when the reaction is valid', () => {
+  it('shows neither an error nor a warning count when the reaction is valid', () => {
     const { queryByText } = renderWithProviders(
       <ReactionValidationResult reactionId={1} />,
       stateWith({ is_valid: true, validation: null }),
     );
     expect(queryByText(/error/)).not.toBeInTheDocument();
+    expect(queryByText(/warning/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`ReactionValidationResult`** — with the reaction record's `is_valid`/`validation` seeded, asserts the badge shows pluralized error/warning counts when invalid (`2 errors`, `1 warning`) and shows no error count when valid.

## Test

2 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a dedicated test file for `ReactionValidationResult` with two targeted scenarios that verify badge count rendering end-to-end through the Redux store.

- **Invalid reaction test**: seeds the store with `is_valid: false` and two errors/one warning; asserts the exact strings `"2 errors"` and `"1 warning"` are rendered by the `ReactionValidationBadge` via `amountText`.
- **Valid reaction test**: seeds with `is_valid: true, validation: null`; symmetrically asserts that neither `/error/` nor `/warning/` text appears, covering the previously noted gap from the prior review thread.

<h3>Confidence Score: 5/5</h3>

Test-only change with no production code touched; safe to merge.

The change is purely additive test coverage. The two scenarios map correctly to the component's branching logic in ReactionValidationBadge (hasDataToDisplay truthy vs. null validation), the validation fixture shape matches the ReactionValidation type used in ReactionValidationList.test.tsx, and the prior review thread concern about missing symmetric /warning/ assertion has been addressed in this version.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionHeader/ReactionValidationResult/ReactionValidationResult.test.tsx | New test file covering two scenarios: invalid reaction with 2 errors/1 warning displays correct pluralized counts, and valid reaction with null validation shows no error/warning text. Both assertions are correct and match the component's rendering logic. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): also assert no warning count f..."](https://github.com/open-reaction-database/ord-app/commit/776dfeb2376aac8f83481291fef244a2015253e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37920390)</sub>

<!-- /greptile_comment -->