### PR TITLE
test(ui): cover TemplateHeader enumeration-readiness badge (#662)

### DIFF
--- a/ui/src/features/templates/TemplateHeader/TemplateHeader.test.tsx
+++ b/ui/src/features/templates/TemplateHeader/TemplateHeader.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { TemplateHeader } from './TemplateHeader.tsx';
+import type { AppState } from 'store/configureAppStore.ts';
+
+// The reaction preview and the action menu are exercised elsewhere; stub them so this test focuses
+// on the header's name + enumeration-readiness badge.
+vi.mock('common/components/ReactionPreview/ReactionPreview.tsx', () => ({
+  ReactionPreview: () => <div data-testid="reaction-preview" />,
+}));
+vi.mock('features/templates/TemplateHeaderActions/TemplateHeaderActions', () => ({
+  TemplateHeaderActions: () => <div data-testid="template-header-actions" />,
+}));
+
+const stateWithVariables = (variables: object): { preloadedState: AppState } => ({
+  preloadedState: {
+    entities: {
+      reactions: { reactionsById: { template_1: { id: 1, data: {}, name: 'My Template', variables } } },
+    },
+  } as unknown as AppState,
+});
+
+describe('TemplateHeader', () => {
+  it('shows the template name and a not-ready badge when there are no variables', () => {
+    const { getByText } = renderWithProviders(<TemplateHeader templateId="template_1" />, stateWithVariables({}));
+    expect(getByText('My Template')).toBeInTheDocument();
+    expect(getByText('Not Ready for Enumeration: No Variables')).toBeInTheDocument();
+  });
+
+  it('shows a valid badge once the template has at least one variable', () => {
+    const { getByText } = renderWithProviders(
+      <TemplateHeader templateId="template_1" />,
+      stateWithVariables({ v1: { name: 'reagent' } }),
+    );
+    expect(getByText('Template is valid')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`TemplateHeader`** — shows the template name + a "Not Ready for Enumeration: No Variables" badge when there are no variables, switching to "Template is valid" once the template has at least one variable (`ReactionPreview` and `TemplateHeaderActions` stubbed).

## Test

2 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new test file for the `TemplateHeader` component, covering both branches of the enumeration-readiness badge: the "Not Ready for Enumeration: No Variables" badge when the template has no variables, and the "Template is valid" badge when at least one variable is present.

- `ReactionPreview` and `TemplateHeaderActions` are correctly stubbed via `vi.mock` with paths that exactly match the imports in `TemplateHeader.tsx`, keeping the test focused on the badge + name display logic.
- The preloaded state shape (`entities.reactions.reactionsById`) aligns with what `selectReactionById` reads, and the `stateWithVariables` helper is passed correctly as the `ProvidersOptions` argument to `renderWithProviders`.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no production code changes; safe to merge.

The change is a single new test file. Mock paths match the source imports, the preloaded state shape matches the selector's access pattern, and both badge states are directly asserted. No production behavior is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/templates/TemplateHeader/TemplateHeader.test.tsx | New test file covering the enumeration-readiness badge in TemplateHeader with two cases (no variables → not-ready badge; ≥1 variable → valid badge). Mocks are correctly path-matched to the source imports, state shape aligns with the selector, and the helper uses renderWithProviders correctly. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover TemplateHeader enumerati..."](https://github.com/open-reaction-database/ord-app/commit/60630a7919776153fc10428ffe83e16789db6856) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37923954)</sub>

<!-- /greptile_comment -->