### PR TITLE
test(ui): cover VariablesSidebar drawer (#662)

### DIFF
--- a/ui/src/features/templates/VariablesSidebar/VariablesSidebar.test.tsx
+++ b/ui/src/features/templates/VariablesSidebar/VariablesSidebar.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { VariablesSidebar } from './VariablesSidebar.tsx';
+import type { AppState } from 'store/configureAppStore.ts';
+
+const buildState = (isOpened: boolean): { preloadedState: AppState } => ({
+  preloadedState: {
+    features: { variablesSidebar: { isVariablesSidebarOpened: isOpened } },
+    entities: {
+      reactions: {
+        reactionsById: {
+          template_1: { id: 1, data: {}, variables: { v1: { name: 'reagent', path: [] } } },
+        },
+      },
+    },
+  } as unknown as AppState,
+});
+
+describe('VariablesSidebar', () => {
+  it('lists the template variables when the drawer is open', () => {
+    const { getByText } = renderWithProviders(<VariablesSidebar templateId="template_1" />, buildState(true));
+    expect(getByText('Variables')).toBeInTheDocument();
+    expect(getByText('@reagent')).toBeInTheDocument();
+  });
+
+  it('does not render the variable list while the drawer is closed', () => {
+    const { queryByText } = renderWithProviders(<VariablesSidebar templateId="template_1" />, buildState(false));
+    expect(queryByText('@reagent')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/templates/VariablesSidebar/VariablesSidebar.test.tsx
+++ b/ui/src/features/templates/VariablesSidebar/VariablesSidebar.test.tsx
@@ -38,8 +38,9 @@ describe('VariablesSidebar', () => {
     expect(getByText('@reagent')).toBeInTheDocument();
   });
 
-  it('does not render the variable list while the drawer is closed', () => {
+  it('does not render the drawer title or the variable list while closed', () => {
     const { queryByText } = renderWithProviders(<VariablesSidebar templateId="template_1" />, buildState(false));
+    expect(queryByText('Variables')).not.toBeInTheDocument();
     expect(queryByText('@reagent')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`VariablesSidebar`** — lists the template variables (as `@name` anchors) when the drawer is open (seeded via `preloadedState`: the `variablesSidebar` open flag + the template's `variables`), and renders nothing while closed.

## Test

2 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file for `VariablesSidebar`, covering the component in its open and closed drawer states via `preloadedState` seeding through `renderWithProviders`.

- The open-state test asserts both the `"Variables"` drawer title and the `@reagent` anchor are present.
- The closed-state test symmetrically asserts neither the title nor the variable anchor appears in the DOM.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no changes to production code; safe to merge.

The single changed file is a new test covering two well-defined states of VariablesSidebar. It uses the established renderWithProviders helper with correctly shaped preloadedState, and both the open and closed branches assert the full set of expected DOM nodes. No production code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/templates/VariablesSidebar/VariablesSidebar.test.tsx | New test file covering VariablesSidebar in both open and closed states; uses renderWithProviders with partial preloadedState correctly, asserts both drawer title and variable anchor in each state branch. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): also assert drawer title absen..."](https://github.com/open-reaction-database/ord-app/commit/bc9cec7d3b7ad2e8f8ae2e21c1dee5e1240d3707) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37925600)</sub>

<!-- /greptile_comment -->