### PR TITLE
test(ui): cover datasetTable columns name cell + handleMenu (#662)

### DIFF
--- a/ui/src/features/datasets/DatasetTable/datasetTable.columns.test.tsx
+++ b/ui/src/features/datasets/DatasetTable/datasetTable.columns.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { MouseEvent } from 'react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { columns, handleMenu } from './datasetTable.columns.tsx';
+import type { Dataset } from 'store/entities/datasets/datasets.types.ts';
+
+// MRT passes a rich props object to Cell; these renderers only read row.original.
+const renderCell = (columnId: string, original: Partial<Dataset>) => {
+  const column = columns.find(c => c.id === columnId);
+  if (!column?.Cell) throw new Error(`no Cell for column ${columnId}`);
+  const Cell = column.Cell as (props: { row: { original: Partial<Dataset> } }) => JSX.Element;
+  return renderWithMantine(<Cell row={{ original }} />);
+};
+
+describe('datasetTable.columns', () => {
+  it('renders the dataset name, falling back to "Dataset <id>" when unnamed', () => {
+    expect(renderCell('datasetName', { name: 'My Dataset', id: 1 }).getByText('My Dataset')).toBeInTheDocument();
+    expect(renderCell('datasetName', { id: 7 }).getByText('Dataset 7')).toBeInTheDocument();
+  });
+});
+
+describe('handleMenu', () => {
+  it('stops propagation and prevents default so the row click does not fire', () => {
+    const event = { stopPropagation: vi.fn(), preventDefault: vi.fn() } as unknown as MouseEvent;
+    handleMenu(event);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`datasetTable.columns`** — the `datasetName` `Cell` renders the dataset name and falls back to `"Dataset <id>"` when unnamed; `handleMenu` stops propagation and prevents default (so the row's menu click doesn't trigger row navigation).

## Test

2 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file for `datasetTable.columns` covering two previously-untested behaviours: the `datasetName` cell's name-or-fallback rendering and `handleMenu`'s event-propagation suppression. No production code is changed.

- **`datasetName` Cell** — tests that the named path renders the dataset name and the unnamed path falls back to `"Dataset <id>"`.
- **`handleMenu`** — verifies that `stopPropagation` and `preventDefault` are both called exactly once, confirming row navigation is not triggered by menu clicks.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no production code changes; safe to merge.

The PR adds a single new test file. The `renderCell` helper correctly scopes each RTL query to its own container, the two renders in the named-vs-fallback test use distinct text so there is no cross-contamination, and the `handleMenu` mock matches the production implementation exactly. `tsc -b` and lint are reported clean.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/datasets/DatasetTable/datasetTable.columns.test.tsx | New test file covering the `datasetName` Cell fallback rendering and `handleMenu` event-propagation behaviour; tests are well-scoped and use appropriate helpers. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover datasetTable columns nam..."](https://github.com/open-reaction-database/ord-app/commit/1b1b4d59f8d84dc91e00b6b791aab63da230dcf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37927487)</sub>

<!-- /greptile_comment -->