### PR TITLE
test(ui): cover createReactionEntityTitle prop merge (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityTitle/reactionEntityTitle.utils.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityTitle/reactionEntityTitle.utils.test.tsx
@@ -16,11 +16,20 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderWithMantine } from 'test/renderWithMantine.tsx';
 import { createReactionEntityTitle } from './reactionEntityTitle.utils.tsx';
+import type { ReactionId } from 'store/entities/reactions/reactions.types.ts';
+import type { ReactionPathComponents } from 'common/types/reaction/reactionPathComponents.ts';
 
 // Capture the props the factory forwards to the underlying title component.
 vi.mock('./ReactionEntityTitle.tsx', () => ({
-  ReactionEntityTitle: (props: Readonly<{ entityName?: string; reactionId?: number; hasDelete?: boolean }>) => (
-    <div data-testid="title">{`${props.entityName}:${props.reactionId}:${props.hasDelete}`}</div>
+  ReactionEntityTitle: (
+    props: Readonly<{
+      entityName?: string;
+      reactionId?: ReactionId;
+      hasDelete?: boolean;
+      pathComponents?: ReactionPathComponents;
+    }>,
+  ) => (
+    <div data-testid="title">{`${props.entityName}:${props.reactionId}:${props.hasDelete}:${props.pathComponents?.join('.')}`}</div>
   ),
 }));
 
@@ -33,7 +42,8 @@ describe('createReactionEntityTitle', () => {
         pathComponents={['inputs', 0]}
       />,
     );
-    // entityName + hasDelete come from the constructor; reactionId from the render-time props.
-    expect(getByTestId('title')).toHaveTextContent('Input:5:true');
+    // entityName + hasDelete come from the constructor; reactionId + pathComponents from the
+    // render-time props — all forwarded to the underlying title.
+    expect(getByTestId('title')).toHaveTextContent('Input:5:true:inputs.0');
   });
 });

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityTitle/reactionEntityTitle.utils.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityTitle/reactionEntityTitle.utils.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { createReactionEntityTitle } from './reactionEntityTitle.utils.tsx';
+
+// Capture the props the factory forwards to the underlying title component.
+vi.mock('./ReactionEntityTitle.tsx', () => ({
+  ReactionEntityTitle: (props: Readonly<{ entityName?: string; reactionId?: number; hasDelete?: boolean }>) => (
+    <div data-testid="title">{`${props.entityName}:${props.reactionId}:${props.hasDelete}`}</div>
+  ),
+}));
+
+describe('createReactionEntityTitle', () => {
+  it('merges the fixed constructor props with the per-render props', () => {
+    const Title = createReactionEntityTitle({ hasDelete: true, entityName: 'Input' });
+    const { getByTestId } = renderWithMantine(
+      <Title
+        reactionId={5}
+        pathComponents={['inputs', 0]}
+      />,
+    );
+    // entityName + hasDelete come from the constructor; reactionId from the render-time props.
+    expect(getByTestId('title')).toHaveTextContent('Input:5:true');
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`createReactionEntityTitle`** — verifies the factory merges the fixed constructor props (`entityName`/`hasDelete`) with the per-render props (`reactionId`) onto the underlying `ReactionEntityTitle` (stubbed to capture the forwarded props).

## Test

1 new test passes; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single test file covering `createReactionEntityTitle`, verifying that the factory correctly merges fixed constructor props (`entityName`, `hasDelete`) with per-render props (`reactionId`, `pathComponents`) and forwards all of them to the underlying `ReactionEntityTitle` component.

- The mock stubs `ReactionEntityTitle` to render all four props as text, and the assertion confirms `Input:5:true:inputs.0` — covering every forwarded prop in one assertion.
- The mock correctly types `reactionId` as `ReactionId` and `pathComponents` as `ReactionPathComponents`, keeping the stub aligned with the real component contract.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no production code changes; safe to merge.

The change is a single new test file. It correctly stubs the underlying component, uses the proper imported types throughout, and asserts all four forwarded props. The previous review concerns (ReactionId type narrowing and pathComponents coverage) are both addressed in this version.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/ReactionEntityTitle/reactionEntityTitle.utils.test.tsx | New test file verifying createReactionEntityTitle merges constructor props (entityName, hasDelete) with per-render props (reactionId, pathComponents) onto the underlying component; mock uses correct ReactionId type and asserts all four forwarded props. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): type stub reactionId as Reacti..."](https://github.com/open-reaction-database/ord-app/commit/afa9c5d2a3bae2c220cc8fe46b8e46d5de6be55e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37929900)</sub>

<!-- /greptile_comment -->