### PR TITLE
test(ui): cover ReactionNodeValidationResultDisplay path filtering (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionInteractions/ReactionNodeValidationResult/ReactionNodeValidationResult.test.tsx
+++ b/ui/src/features/reactions/ReactionInteractions/ReactionNodeValidationResult/ReactionNodeValidationResult.test.tsx
@@ -48,4 +48,16 @@ describe('ReactionNodeValidationResultDisplay', () => {
     expect(queryByText('2')).not.toBeInTheDocument();
     expect(queryByText('1')).not.toBeInTheDocument();
   });
+
+  it('matches messages under a parent-path prefix (substring path match)', () => {
+    // pathComponents=['inputs'] is a prefix of the messages' 'inputs.0.*' paths, so all of them count.
+    const { getByText } = renderWithMantine(
+      <ReactionNodeValidationResultDisplay
+        pathComponents={['inputs']}
+        validation={validation}
+      />,
+    );
+    expect(getByText('2')).toBeInTheDocument();
+    expect(getByText('1')).toBeInTheDocument();
+  });
 });

--- a/ui/src/features/reactions/ReactionInteractions/ReactionNodeValidationResult/ReactionNodeValidationResult.test.tsx
+++ b/ui/src/features/reactions/ReactionInteractions/ReactionNodeValidationResult/ReactionNodeValidationResult.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { ReactionNodeValidationResultDisplay } from './ReactionNodeValidationResult.tsx';
+import type { ReactionValidation } from 'store/entities/reactions/reactions.types.ts';
+
+const validation = {
+  errors: [
+    { path: ['inputs', '0'], originalPath: 'inputs.0.a', text: 'e1' },
+    { path: ['inputs', '0'], originalPath: 'inputs.0.b', text: 'e2' },
+  ],
+  warnings: [{ path: ['inputs', '0'], originalPath: 'inputs.0.c', text: 'w1' }],
+} as unknown as ReactionValidation;
+
+describe('ReactionNodeValidationResultDisplay', () => {
+  it('shows red/yellow badges with the error and warning counts matching the path', () => {
+    const { getByText } = renderWithMantine(
+      <ReactionNodeValidationResultDisplay
+        pathComponents={['inputs', '0']}
+        validation={validation}
+      />,
+    );
+    expect(getByText('2')).toBeInTheDocument(); // errors at this path
+    expect(getByText('1')).toBeInTheDocument(); // warnings at this path
+  });
+
+  it('renders nothing when no messages match the path', () => {
+    const { queryByText } = renderWithMantine(
+      <ReactionNodeValidationResultDisplay
+        pathComponents={['conditions']}
+        validation={validation}
+      />,
+    );
+    expect(queryByText('2')).not.toBeInTheDocument();
+    expect(queryByText('1')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`ReactionNodeValidationResultDisplay`** — shows red/yellow count badges for the errors and warnings whose path matches the node's `pathComponents`, and renders nothing when none match.

## Test

2 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file covering `ReactionNodeValidationResultDisplay`, verifying that error/warning badge counts are filtered correctly by path and that the component renders nothing when no messages match the given path components.

- Three tests cover: exact-path match showing 2 errors + 1 warning, a completely-disjoint path producing no output, and a parent-prefix path (`['inputs']`) that aggregates all child messages via the substring filter.
- The third test directly addresses the prefix-match behavior noted in a previous review, documenting that `pathComponents=['inputs']` matches messages at `['inputs', '0']` because the production filter uses `Array.toString().includes()`.

<h3>Confidence Score: 5/5</h3>

Test-only change with no production code modifications; all three new tests correctly reflect the existing filter logic.

The change is entirely additive test coverage. The fixture data, filter expectations, and the new prefix-path test all line up accurately with the substring-based Array.toString().includes() filter in the component. No production paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionInteractions/ReactionNodeValidationResult/ReactionNodeValidationResult.test.tsx | New test file adding three cases for ReactionNodeValidationResultDisplay: exact-path match, no-match (renders nothing), and prefix/parent-path substring match — all aligned with the production filter logic. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): cover parent-path prefix match..."](https://github.com/open-reaction-database/ord-app/commit/3f40c28abf42b49b1cfd8fa2f6b4829599c9371c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37933687)</sub>

<!-- /greptile_comment -->