### PR TITLE
test(ui): cover DatasetsListTopActions entry points + disclosure (#662)

### DIFF
--- a/ui/src/pages/DatasetsList/DatasetsListTopActions/DatasetsListTopActions.test.tsx
+++ b/ui/src/pages/DatasetsList/DatasetsListTopActions/DatasetsListTopActions.test.tsx
@@ -42,4 +42,11 @@ describe('DatasetsListTopActions', () => {
     fireEvent.click(getByText('New Dataset'));
     expect(queryByTestId('create-new-dataset')).toBeInTheDocument();
   });
+
+  it('opens the create-from-file modal when "From File" is clicked', () => {
+    const { getByText, queryByTestId } = renderWithProviders(<DatasetsListTopActions />);
+    expect(queryByTestId('create-from-file')).not.toBeInTheDocument();
+    fireEvent.click(getByText('From File'));
+    expect(queryByTestId('create-from-file')).toBeInTheDocument();
+  });
 });

--- a/ui/src/pages/DatasetsList/DatasetsListTopActions/DatasetsListTopActions.test.tsx
+++ b/ui/src/pages/DatasetsList/DatasetsListTopActions/DatasetsListTopActions.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProviders } from 'test/renderWithProviders.tsx';
+import { DatasetsListTopActions } from './DatasetsListTopActions.tsx';
+
+// The create flows / wizard have their own store + form deps; stub them so this test focuses on the
+// top-action buttons and the disclosure that mounts the create-from-scratch modal.
+vi.mock('features/datasets/CreateNewDataset/CreateNewDataset.tsx', () => ({
+  CreateNewDataset: () => <div data-testid="create-new-dataset" />,
+}));
+vi.mock('features/datasets/CreateDatasetFromFile/CreateDatasetFromFile.tsx', () => ({
+  CreateDatasetFromFile: () => <div data-testid="create-from-file" />,
+}));
+vi.mock('features/enumeration/EnumerationWizard.tsx', () => ({ EnumerationWizard: () => <div /> }));
+
+describe('DatasetsListTopActions', () => {
+  it('renders the three dataset-creation entry points', () => {
+    const { getByText } = renderWithProviders(<DatasetsListTopActions />);
+    expect(getByText('New Dataset')).toBeInTheDocument();
+    expect(getByText('From File')).toBeInTheDocument();
+    expect(getByText('Enumerate')).toBeInTheDocument();
+  });
+
+  it('opens the create-from-scratch modal when "New Dataset" is clicked', () => {
+    const { getByText, queryByTestId } = renderWithProviders(<DatasetsListTopActions />);
+    expect(queryByTestId('create-new-dataset')).not.toBeInTheDocument();
+    fireEvent.click(getByText('New Dataset'));
+    expect(queryByTestId('create-new-dataset')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`DatasetsListTopActions`** — renders the three dataset-creation entry points (New Dataset / From File / Enumerate) and mounts the create-from-scratch modal when "New Dataset" is clicked (the create flows + enumeration wizard are stubbed).

## Test

2 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Vitest test file for `DatasetsListTopActions`, covering the three dataset-creation entry points and both conditional-render (disclosure) branches. No production code is changed.

- Three tests verify that \"New Dataset\", \"From File\", and \"Enumerate\" buttons render, and that clicking \"New Dataset\" / \"From File\" mounts the respective stubbed modal components via their `useDisclosure`-gated branches.
- `CreateNewDataset`, `CreateDatasetFromFile`, and `EnumerationWizard` are all mocked with lightweight stubs so the test stays focused on the action buttons rather than the complex inner flows.
- Note: the PR description mentions \"2 new tests\" but the file contains 3 tests — the third test for the \"From File\" disclosure was added (addressing a prior review comment) and the description was not updated.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no production code changes; safe to merge.

The change is entirely new test coverage — no production logic is modified. The mocks are correctly scoped, both disclosure branches are now exercised, and the assertions check the before/after DOM state for each modal.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/pages/DatasetsList/DatasetsListTopActions/DatasetsListTopActions.test.tsx | Adds 3 Vitest tests covering the three entry-point buttons and both conditional disclosure branches (createNewOpened / createFromFileOpened); mocks correctly isolate CreateNewDataset, CreateDatasetFromFile, and EnumerationWizard. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): also cover the From File discl..."](https://github.com/open-reaction-database/ord-app/commit/fe875816f384a9de41c1826d5f18543f5b0567bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37933514)</sub>

<!-- /greptile_comment -->