### PR TITLE
test(ui): cover ShareDataset button gating + sidebar disclosure (#662)

### DIFF
--- a/ui/src/features/datasets/ShareDataset/ShareDataset.test.tsx
+++ b/ui/src/features/datasets/ShareDataset/ShareDataset.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+import { ShareDataset } from './ShareDataset.tsx';
+import type { Dataset } from 'store/entities/datasets/datasets.types.ts';
+
+vi.mock('./ShareDatasetSidebar.tsx', () => ({ ShareDatasetSidebar: () => <div data-testid="share-sidebar" /> }));
+
+const dataset = (is_sharable: boolean) => ({ id: 1, is_sharable }) as unknown as Dataset;
+
+describe('ShareDataset', () => {
+  it('shows the Share button for a sharable dataset and opens the sidebar on click', () => {
+    const { getByText, queryByTestId } = renderWithMantine(<ShareDataset dataset={dataset(true)} />);
+    expect(queryByTestId('share-sidebar')).not.toBeInTheDocument();
+    fireEvent.click(getByText('Share'));
+    expect(queryByTestId('share-sidebar')).toBeInTheDocument();
+  });
+
+  it('hides the Share button when the dataset is not sharable', () => {
+    const { queryByText } = renderWithMantine(<ShareDataset dataset={dataset(false)} />);
+    expect(queryByText('Share')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`ShareDataset`** — shows the Share button only for a sharable dataset and opens the `ShareDatasetSidebar` (stubbed) on click; hides the button when the dataset is not sharable.

## Test

2 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new test file for the `ShareDataset` component, covering two behaviors: the Share button appearing only for sharable datasets and opening the `ShareDatasetSidebar` on click, and the button being absent when the dataset is not sharable.

- `ShareDatasetSidebar` is correctly stubbed via `vi.mock`, and `renderWithMantine` (no Redux store needed) is the right helper since the production component only relies on `useDisclosure` — no Redux.
- The `dataset` factory cast (`as unknown as Dataset`) is intentionally minimal and safe given the component only accesses `id` and `is_sharable`.

<h3>Confidence Score: 5/5</h3>

Test-only addition with no production code changes; safe to merge.

The single new file tests exactly the two code branches in ShareDataset.tsx (is_sharable true/false) using the correct render helper and a well-scoped mock. No production logic is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/datasets/ShareDataset/ShareDataset.test.tsx | New test file covering share-button visibility gating and sidebar disclosure; tests are correct and use the right render helper |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): cover ShareDataset button gati..."](https://github.com/open-reaction-database/ord-app/commit/0d79843959e7e8f5d16bae3c5eb46e8d9bb10fe9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37936691)</sub>

<!-- /greptile_comment -->