### PR TITLE
test(ui): cover getSidebarInfo path resolution (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/sidebarInfo/getSidebarInfo.test.ts
+++ b/ui/src/features/reactions/ReactionEntities/sidebarInfo/getSidebarInfo.test.ts
@@ -23,15 +23,17 @@ describe('getSidebarInfo', () => {
     expect(getSidebarInfo(['identifiers']).label).toBe('Identifier');
   });
 
-  it('recursively narrows a nested path to the matching entry', () => {
-    // products live under outcomes; the two-segment path must resolve to the Products entry.
-    const info = getSidebarInfo(['products', 'outcomes']);
-    expect(info.label).toBe('Products');
+  it('recurses to later segments when the first segment is ambiguous', () => {
+    // "identifiers" alone matches several entries (component/molblock/product identifiers), so the
+    // match must narrow on the following segments to reach the component-identifiers entry.
+    const info = getSidebarInfo(['identifiers', 'products', 'outcomes']);
+    expect(info.label).toBe('Identifiers');
     expect(typeof info.sidebarTitle).toBe('function');
   });
 
-  it('skips numeric indices when matching the path', () => {
-    // A concrete reaction path interleaves numeric ids, which must be ignored during matching.
-    expect(getSidebarInfo(['products', 0, 'outcomes', 1]).label).toBe('Products');
+  it('skips numeric indices interleaved in a concrete reaction path', () => {
+    // Same ambiguous-first-segment path, but with numeric ids between entities — they must be
+    // skipped at each recursion step to still resolve to the component-identifiers entry.
+    expect(getSidebarInfo(['identifiers', 0, 'products', 1, 'outcomes']).label).toBe('Identifiers');
   });
 });

--- a/ui/src/features/reactions/ReactionEntities/sidebarInfo/getSidebarInfo.test.ts
+++ b/ui/src/features/reactions/ReactionEntities/sidebarInfo/getSidebarInfo.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { getSidebarInfo } from './getSidebarInfo.tsx';
+
+describe('getSidebarInfo', () => {
+  it('resolves a top-level entity path to its sidebar info', () => {
+    expect(getSidebarInfo(['inputs']).label).toBe('Input');
+    expect(getSidebarInfo(['outcomes']).label).toBe('Outcomes');
+    expect(getSidebarInfo(['identifiers']).label).toBe('Identifier');
+  });
+
+  it('recursively narrows a nested path to the matching entry', () => {
+    // products live under outcomes; the two-segment path must resolve to the Products entry.
+    const info = getSidebarInfo(['products', 'outcomes']);
+    expect(info.label).toBe('Products');
+    expect(typeof info.sidebarTitle).toBe('function');
+  });
+
+  it('skips numeric indices when matching the path', () => {
+    // A concrete reaction path interleaves numeric ids, which must be ignored during matching.
+    expect(getSidebarInfo(['products', 0, 'outcomes', 1]).label).toBe('Products');
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`getSidebarInfo`** (pure function) — resolves top-level entity paths (`inputs`/`outcomes`/`identifiers`) to their sidebar entries, recursively narrows a nested path (`products` under `outcomes` → "Products"), and skips numeric indices in a concrete reaction path.

## Test

3 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new test file for the `getSidebarInfo` pure function, covering three paths: top-level entity resolution, recursive narrowing when the first path segment is ambiguous, and skipping of numeric indices interleaved in a concrete reaction path.

- **Top-level test** — `['inputs']`, `['outcomes']`, `['identifiers']` each resolve in one pass and return the expected `label`, confirmed against `sidebarInfo.models.ts`.
- **Recursion test** — `['identifiers', 'products', 'outcomes']` correctly yields 5 candidates on the first pass (all entries whose `pathComponents[0]` is `'identifiers'`), then narrows to the single `componentIdentifiersSidebarInfo` entry on the second pass; the test description is accurate.
- **Numeric-skip test** — `['identifiers', 0, 'products', 1, 'outcomes']` correctly exercises `getEntityPathComponent`'s number-skipping branch during the second recursion step (the leading `0` in `[0, 'products', 1, 'outcomes']` is skipped before extracting `'products'`), and the description is accurate.

<h3>Confidence Score: 5/5</h3>

Test-only change with no production code modifications; safe to merge.

All three new tests accurately exercise the paths their descriptions claim. The ['identifiers', 'products', 'outcomes'] path produces 5 candidates on the first pass and genuinely recurses to disambiguate. The ['identifiers', 0, 'products', 1, 'outcomes'] path correctly triggers the number-skipping branch inside getEntityPathComponent during the second recursion step. No production logic is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/sidebarInfo/getSidebarInfo.test.ts | Adds 3 Vitest tests for getSidebarInfo covering top-level resolution, genuine recursive narrowing via an ambiguous first segment (identifiers), and numeric-index skipping during recursion. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): exercise real recursion + nume..."](https://github.com/open-reaction-database/ord-app/commit/0d1f65030dbd62ef5945a4b0fc40299f0406850c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37938560)</sub>

<!-- /greptile_comment -->