### PR TITLE
test(ui): cover DatasetReactionValueLabel label/children (#662)

### DIFF
--- a/ui/src/features/reactions/ReactionInteractions/ReactionValueLabel/DatasetReactionValueLable.test.tsx
+++ b/ui/src/features/reactions/ReactionInteractions/ReactionValueLabel/DatasetReactionValueLable.test.tsx
@@ -36,9 +36,10 @@ describe('DatasetReactionValueLabel', () => {
     expect(getByText('extra')).toBeInTheDocument();
   });
 
-  it('renders nothing when no label is configured', () => {
-    const { queryByText } = render({});
-    expect(queryByText('pH')).not.toBeInTheDocument();
-    expect(queryByText('extra')).not.toBeInTheDocument();
+  it('renders nothing — not even children — when no label is configured', () => {
+    // children ARE passed here, so their absence proves the no-label guard returns null before
+    // any children would render (rather than being vacuously true).
+    const { queryByText } = render({ children: <span>orphan</span> });
+    expect(queryByText('orphan')).not.toBeInTheDocument();
   });
 });

--- a/ui/src/features/reactions/ReactionInteractions/ReactionValueLabel/DatasetReactionValueLable.test.tsx
+++ b/ui/src/features/reactions/ReactionInteractions/ReactionValueLabel/DatasetReactionValueLable.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { DatasetReactionValueLabel } from './DatasetReactionValueLable.tsx';
+import { VariableType } from 'store/entities/templates/templates.types.ts';
+import type { ReactionValueLabelProps } from './reactionValueLabel.types.ts';
+
+const render = (wrapperConfig: ReactionValueLabelProps['wrapperConfig']) =>
+  renderInReactionView(
+    <DatasetReactionValueLabel
+      name="ph"
+      type={VariableType.Number}
+      wrapperConfig={wrapperConfig}
+    />,
+    { pathComponents: ['conditions'] },
+  );
+
+describe('DatasetReactionValueLabel', () => {
+  it('renders the label and any children when a label is configured', () => {
+    const { getByText } = render({ label: 'pH', children: <span>extra</span> });
+    expect(getByText('pH')).toBeInTheDocument();
+    expect(getByText('extra')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no label is configured', () => {
+    const { queryByText } = render({});
+    expect(queryByText('pH')).not.toBeInTheDocument();
+    expect(queryByText('extra')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Extends the #662 test backfill (test-only, no production code):

- **`DatasetReactionValueLabel`** — renders the configured label and any children, and renders nothing when no label is set.

## Test

2 new tests pass; `tsc -b` + lint clean. No-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two Vitest tests for the `DatasetReactionValueLabel` component as part of the ongoing #662 test backfill. No production code is changed.

- The first test verifies that a configured `label` and `children` are both rendered.
- The second test addresses the previously raised vacuous-assertion concern: it passes `children` (but no `label`) and confirms those children are absent, proving the early-return guard fires before any children render.

<h3>Confidence Score: 5/5</h3>

Test-only change with no production code modifications; both tests correctly exercise the component contract.

The change is entirely additive test coverage. The second test was specifically reworked to be non-vacuous by supplying children without a label, confirming the early-return path suppresses them. No existing behavior is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionInteractions/ReactionValueLabel/DatasetReactionValueLable.test.tsx | New test file covering two cases for DatasetReactionValueLabel: renders label + children when a label is configured, and returns null (suppressing even passed children) when no label is set. The second test properly addresses the earlier vacuous-assertion concern by passing children without a label. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): make the no-label render-nothi..."](https://github.com/open-reaction-database/ord-app/commit/22c9cb882fabf7bb063d16222f96c33f34c511f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37942065)</sub>

<!-- /greptile_comment -->