### PR TITLE
fix(ui): surface 403s & silent request failures — re-gate + notify (#617, #614, #616)

### DIFF
--- a/ui/src/common/hooks/useAuth.test.ts
+++ b/ui/src/common/hooks/useAuth.test.ts
@@ -42,15 +42,19 @@ vi.mock('react-redux', () => ({
 const mocks = vi.hoisted(() => ({
   dispatch: vi.fn(),
   setAccessTokenGetter: vi.fn(),
+  setPermissionDeniedHandler: vi.fn(),
   createUser: vi.fn((arg: unknown) => ({ type: 'users/createUser', payload: arg })),
+  getGroupList: vi.fn(() => ({ type: 'groups/getGroupList' })),
 }));
 vi.mock('store/useAppDispatch', () => ({ useAppDispatch: () => mocks.dispatch }));
 vi.mock('store/axiosInstance.ts', () => ({
   default: {},
   setAccessTokenGetter: mocks.setAccessTokenGetter,
+  setPermissionDeniedHandler: mocks.setPermissionDeniedHandler,
   getAccessToken: undefined,
 }));
 vi.mock('store/entities/users/users.thunks', () => ({ createUser: mocks.createUser }));
+vi.mock('store/entities/groups/groups.thunks', () => ({ getGroupList: mocks.getGroupList }));
 
 import { useAuth } from './useAuth.ts';
 
@@ -159,5 +163,41 @@ describe('useAuth — Auth0 flow', () => {
     expect(loginWithRedirect).toHaveBeenCalledWith(
       expect.objectContaining({ appState: expect.objectContaining({ returnTo: expect.any(String) }) }),
     );
+  });
+});
+
+describe('useAuth — permission re-gate on 403 (#617)', () => {
+  it('registers a handler that refreshes group roles', async () => {
+    renderHook(() => useAuth());
+    expect(mocks.setPermissionDeniedHandler).toHaveBeenCalledTimes(1);
+    const handler = mocks.setPermissionDeniedHandler.mock.calls[0][0] as () => void;
+
+    await act(async () => {
+      handler();
+    });
+
+    expect(mocks.getGroupList).toHaveBeenCalledTimes(1);
+    expect(mocks.dispatch).toHaveBeenCalledWith({ type: 'groups/getGroupList' });
+  });
+
+  it('ignores re-entrant refreshes while one is still in flight', async () => {
+    renderHook(() => useAuth());
+    const handler = mocks.setPermissionDeniedHandler.mock.calls[0][0] as () => void;
+
+    // Hold the first refresh open so the in-flight guard is active for the re-entrant call.
+    let settleRefresh: () => void = () => {};
+    mocks.dispatch.mockReturnValueOnce(new Promise<void>(resolve => (settleRefresh = resolve)));
+
+    handler();
+    handler(); // re-entrant; must be ignored while the first refresh is pending
+    expect(mocks.getGroupList).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      settleRefresh();
+      await Promise.resolve();
+    });
+
+    handler(); // the guard has cleared, so a fresh 403 refreshes again
+    expect(mocks.getGroupList).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/common/hooks/useAuth.ts
+++ b/ui/src/common/hooks/useAuth.ts
@@ -15,10 +15,11 @@
  */
 import { useAuth0 } from '@auth0/auth0-react';
 import { useEffect } from 'react';
-import { setAccessTokenGetter } from 'store/axiosInstance.ts';
+import { setAccessTokenGetter, setPermissionDeniedHandler } from 'store/axiosInstance.ts';
 import { useAppDispatch } from 'store/useAppDispatch';
 import { useSelector } from 'react-redux';
 import { createUser } from 'store/entities/users/users.thunks';
+import { getGroupList } from 'store/entities/groups/groups.thunks';
 import { selectSelf } from 'store/entities/users/users.selectors';
 import { e2eDevToken, noAuth } from 'common/noAuth.constants.ts';
 import type { GetAccessToken } from 'common/types/auth.ts';
@@ -56,6 +57,23 @@ export function useAuth() {
       setAccessTokenGetter(getAccessTokenSilently);
     }
   }, [isAuthenticated, getAccessTokenSilently]);
+
+  useEffect(() => {
+    // When the backend rejects an action with 403 (role downgraded to viewer, removed from a
+    // group), refresh the current user's group memberships/roles so permission-gated affordances
+    // re-gate without a manual page reload. (#617) The in-flight guard prevents re-entrancy if the
+    // refresh request is itself rejected.
+    let isRefreshing = false;
+    setPermissionDeniedHandler(() => {
+      if (isRefreshing) {
+        return;
+      }
+      isRefreshing = true;
+      void Promise.resolve(dispatch(getGroupList())).finally(() => {
+        isRefreshing = false;
+      });
+    });
+  }, [dispatch]);
 
   useEffect(() => {
     // Provision the mock user once with the static dev token (requires the backend e2e mode, #664).

--- a/ui/src/store/axiosInstance.test.ts
+++ b/ui/src/store/axiosInstance.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleResponseError, setPermissionDeniedHandler } from './axiosInstance.ts';
+
+function axiosError(status: number) {
+  // Minimal shape that axios.isAxiosError() recognizes (checks `isAxiosError === true`).
+  return { isAxiosError: true, response: { status } } as unknown;
+}
+
+describe('handleResponseError', () => {
+  let handler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    handler = vi.fn();
+    setPermissionDeniedHandler(handler);
+  });
+
+  it('invokes the permission-denied handler on a 403 and re-rejects the same error (#617)', async () => {
+    const error = axiosError(403);
+    await expect(handleResponseError(error)).rejects.toBe(error);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([401, 404, 409, 500])('re-rejects without re-gating on a %i', async status => {
+    const error = axiosError(status);
+    await expect(handleResponseError(error)).rejects.toBe(error);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not re-gate for a non-axios error (e.g. a network failure with no response)', async () => {
+    const error = new Error('network down');
+    await expect(handleResponseError(error)).rejects.toBe(error);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/store/axiosInstance.ts
+++ b/ui/src/store/axiosInstance.ts
@@ -22,6 +22,15 @@ export function setAccessTokenGetter(getAccessTokenParam: GetAccessToken) {
   getAccessToken = getAccessTokenParam;
 }
 
+// Called when the backend rejects a request with 403 Forbidden — the UI's cue that the user's
+// permissions may have changed (role downgraded to viewer, removed from a group) so it should
+// refresh and re-gate. Wired up by the app once the store is available; a no-op until then. (#617)
+let onPermissionDenied: (() => void) | undefined;
+
+export function setPermissionDeniedHandler(handler: () => void) {
+  onPermissionDenied = handler;
+}
+
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_ENDPOINT,
 });
@@ -31,11 +40,16 @@ axiosInstance.interceptors.request.use(async config => {
   return config;
 });
 
-axiosInstance.interceptors.response.use(
-  response => response,
-  async error => {
-    return Promise.reject(error);
-  },
-);
+// Exported for unit testing; registered as the response error interceptor below. A 403 means the
+// user is authenticated but no longer authorized for the action, so trigger a permission refresh.
+// (401 is an authentication failure handled by the Auth0 token-refresh/redirect path, not here.)
+export async function handleResponseError(error: unknown): Promise<never> {
+  if (axios.isAxiosError(error) && error.response?.status === 403) {
+    onPermissionDenied?.();
+  }
+  return Promise.reject(error);
+}
+
+axiosInstance.interceptors.response.use(response => response, handleResponseError);
 
 export default axiosInstance;

--- a/ui/src/store/entities/enumeration/enumeration.thunks.test.ts
+++ b/ui/src/store/entities/enumeration/enumeration.thunks.test.ts
@@ -18,9 +18,16 @@ import { type UnknownAction } from '@reduxjs/toolkit';
 import axiosInstance from 'store/axiosInstance.ts';
 import { makeRecordingStore } from 'test/recordingStore.ts';
 import { finishEnumeration } from './enumeration.thunks.ts';
-import { enumerateBatchActions, finishEnumerationAction, startEnumerationActions } from './enumeration.actions.ts';
+import {
+  enumerateBatchActions,
+  finishEnumerationAction,
+  interruptEnumerationAction,
+  startEnumerationActions,
+} from './enumeration.actions.ts';
 import type { StartEnumeration } from './enumeration.types.ts';
 import { getGroupsInitialDatasetListActions } from '../datasets/datasets.actions.ts';
+import { showNotification } from 'common/utils/showNotification.tsx';
+import { NotificationVariant } from 'common/types/notification.ts';
 
 vi.mock('store/axiosInstance.ts', () => ({
   default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -61,5 +68,22 @@ describe('finishEnumeration (new dataset)', () => {
     expect(types()).toContain(finishEnumerationAction.type);
     // The new dataset is created server-side but isn't in the list store yet; refetch the list. (#611)
     expect(types()).toContain(getGroupsInitialDatasetListActions.request.type);
+  });
+});
+
+describe('finishEnumeration (backend rejects the request)', () => {
+  it('notifies the user and stops the enumeration instead of failing silently (#614)', async () => {
+    const { store, types } = makeRecordingStore();
+    seedNewDatasetProgress(store);
+    axiosMock.post.mockRejectedValueOnce({ isAxiosError: true, response: { status: 403 } });
+
+    await store.dispatch(finishEnumeration() as unknown as UnknownAction);
+
+    // The user gets feedback rather than a console-only error...
+    expect(showNotification).toHaveBeenCalledWith({ variant: NotificationVariant.ERROR, message: 'Access denied' });
+    // ...and the enumeration is stopped (progress reset), with no success result dispatched.
+    expect(types()).toContain(interruptEnumerationAction.type);
+    expect(types()).not.toContain(finishEnumerationAction.type);
+    expect(types()).not.toContain(getGroupsInitialDatasetListActions.request.type);
   });
 });

--- a/ui/src/store/entities/enumeration/enumeration.thunks.ts
+++ b/ui/src/store/entities/enumeration/enumeration.thunks.ts
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { enumerateBatchActions, finishEnumerationAction, startEnumerationActions } from './enumeration.actions.ts';
+import {
+  enumerateBatchActions,
+  finishEnumerationAction,
+  interruptEnumerationAction,
+  startEnumerationActions,
+} from './enumeration.actions.ts';
+import { notifyApiError } from '../../utils';
 import type { ThunkCustomWrapper } from 'common/types/store/thunk.ts';
 import type { ActionPayload } from 'common/types';
 import { selectEnumerationProgress } from './enumeration.selectors.ts';
@@ -107,20 +113,28 @@ export const finishEnumeration: ThunkCustomWrapper<void> = () => async (dispatch
   // Groups") to match what the Datasets page shows, rather than the new dataset's own group. (#611)
   const activeGroupId = selectActiveGroupId(getState());
 
-  if (isNewDataset) {
-    const createdDataset = await axiosInstance.post<Dataset>(
-      `/groups/${dataset.groupId}/datasets/enumerate`,
-      datasetEnumeration,
-    );
-    dispatch(finishEnumerationAction(createdDataset.data.id));
-    // Refresh the datasets list so the newly created dataset appears without a manual
-    // page reload, including when the user dismisses the result modal with "Close". (#611)
-    dispatch(getInitialDatasetsList(activeGroupId));
-  } else {
-    const datasetId = dataset;
-    await axiosInstance.post<Dataset>(`/datasets/${datasetId}/enumerate/extend`, datasetEnumeration);
-    dispatch(finishEnumerationAction(datasetId));
-    dispatch(getDataset(datasetId));
-    dispatch(getReactionsPage({ page: 1 }));
+  try {
+    if (isNewDataset) {
+      const createdDataset = await axiosInstance.post<Dataset>(
+        `/groups/${dataset.groupId}/datasets/enumerate`,
+        datasetEnumeration,
+      );
+      dispatch(finishEnumerationAction(createdDataset.data.id));
+      // Refresh the datasets list so the newly created dataset appears without a manual
+      // page reload, including when the user dismisses the result modal with "Close". (#611)
+      dispatch(getInitialDatasetsList(activeGroupId));
+    } else {
+      const datasetId = dataset;
+      await axiosInstance.post<Dataset>(`/datasets/${datasetId}/enumerate/extend`, datasetEnumeration);
+      dispatch(finishEnumerationAction(datasetId));
+      dispatch(getDataset(datasetId));
+      dispatch(getReactionsPage({ page: 1 }));
+    }
+  } catch (error) {
+    // The backend rejects the enumeration when the user no longer has edit access (role changed
+    // to viewer, removed from the group). Surface it and stop the enumeration instead of failing
+    // silently in the console. (#614)
+    notifyApiError(error);
+    dispatch(interruptEnumerationAction());
   }
 };

--- a/ui/src/store/utils/downloadFile.thunks.test.ts
+++ b/ui/src/store/utils/downloadFile.thunks.test.ts
@@ -16,8 +16,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import axiosInstance from '../axiosInstance.ts';
 import { downloadFile, downloadFileFromUrl, downloadAsJson } from './downloadFile.thunks.ts';
+import { notifyApiError } from './notifyApiError.ts';
 
 vi.mock('../axiosInstance.ts', () => ({ default: { get: vi.fn() } }));
+vi.mock('./notifyApiError.ts', () => ({ notifyApiError: vi.fn() }));
 const axiosMock = axiosInstance as unknown as Record<'get', ReturnType<typeof vi.fn>>;
 
 let clickSpy: ReturnType<typeof vi.fn>;
@@ -71,12 +73,11 @@ describe('downloadFileFromUrl', () => {
     expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('swallows errors (logs, no throw, no download) when the request fails', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    axiosMock.get.mockRejectedValueOnce(new Error('network'));
+  it('notifies the user (no throw, no download) when the request fails (#616)', async () => {
+    axiosMock.get.mockRejectedValueOnce({ isAxiosError: true, response: { status: 404 } });
     await expect(downloadFileFromUrl('/bad')(vi.fn(), vi.fn(), undefined)).resolves.toBeUndefined();
     expect(clickSpy).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalled();
+    expect(notifyApiError).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/ui/src/store/utils/downloadFile.thunks.ts
+++ b/ui/src/store/utils/downloadFile.thunks.ts
@@ -16,6 +16,7 @@
 import type { Action, ThunkAction } from '@reduxjs/toolkit';
 import type { AppState } from '../configureAppStore.ts';
 import axiosInstance from '../axiosInstance.ts';
+import { notifyApiError } from './notifyApiError.ts';
 
 export const downloadFile = (blob: Blob, fileName: string) => {
   const link = document.createElement('a');
@@ -44,7 +45,9 @@ export const downloadFileFromUrl =
       const fileName = header.replace(/^.*filename="(.*)"/, '$1');
       downloadFile(blob, fileName);
     } catch (error) {
-      console.error(error);
+      // A removed dataset/reaction (404) or lost group access (403) rejects the download; tell the
+      // user instead of only logging to the console. (#616)
+      notifyApiError(error);
     }
   };
 

--- a/ui/src/store/utils/index.ts
+++ b/ui/src/store/utils/index.ts
@@ -16,3 +16,4 @@
 export * from './actions.ts';
 export * from './thunks.ts';
 export * from './createSelectorFactory.ts';
+export * from './notifyApiError.ts';

--- a/ui/src/store/utils/notifyApiError.test.ts
+++ b/ui/src/store/utils/notifyApiError.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { showNotification } from 'common/utils/showNotification.tsx';
+import { NotificationVariant } from 'common/types/notification.ts';
+import { notifyApiError } from './notifyApiError.ts';
+
+vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() }));
+const showMock = vi.mocked(showNotification);
+
+function axiosError(status: number, data?: unknown) {
+  return { isAxiosError: true, response: { status, data } } as unknown;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('notifyApiError', () => {
+  it('shows an error toast with the mapped message for a 403 (#614/#616)', () => {
+    notifyApiError(axiosError(403));
+    expect(showMock).toHaveBeenCalledWith({ variant: NotificationVariant.ERROR, message: 'Access denied' });
+  });
+
+  it('maps 404 to "Entity not found"', () => {
+    notifyApiError(axiosError(404));
+    expect(showMock).toHaveBeenCalledWith({ variant: NotificationVariant.ERROR, message: 'Entity not found' });
+  });
+
+  it('prefers the backend-provided message when present', () => {
+    notifyApiError(axiosError(403, { message: 'You cannot edit this dataset' }));
+    expect(showMock).toHaveBeenCalledWith({
+      variant: NotificationVariant.ERROR,
+      message: 'You cannot edit this dataset',
+    });
+  });
+
+  it('falls back to the generic message for a non-axios error', () => {
+    notifyApiError(new Error('boom'));
+    expect(showMock).toHaveBeenCalledWith({ variant: NotificationVariant.ERROR, message: 'Unknown error' });
+  });
+});

--- a/ui/src/store/utils/notifyApiError.ts
+++ b/ui/src/store/utils/notifyApiError.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { showNotification } from 'common/utils/showNotification.tsx';
+import { NotificationVariant } from 'common/types/notification.ts';
+import { getErrorDetails } from './handleApiError.ts';
+
+/**
+ * Show an error toast for a failed request, mapping the HTTP status to a human-readable message.
+ *
+ * Use this in flows that catch their own request errors (and would otherwise swallow them) so the
+ * user gets feedback instead of a silent console log — e.g. a removed dataset (404) or lost group
+ * access (403) during download/enumeration. (#614, #616)
+ */
+export function notifyApiError(error: unknown) {
+  showNotification({
+    variant: NotificationVariant.ERROR,
+    message: getErrorDetails(error).errorMessage,
+  });
+}


### PR DESCRIPTION
## Summary

Cluster D (permissions/role-change reactivity), implementing the maintainer decision recorded in the triage plan (#656, 2026-06-16): **graceful 401/403 handling — catch the BE rejection on the next action, notify, then refresh/re-gate. No polling/push** (the BE already enforces; this is purely the UI response).

Three related bugs where the backend rejected an action because the user's permissions changed out from under them (role downgraded to viewer, removed from a group) or an entity was removed — and the UI gave no feedback:

| Issue | Symptom | Fix |
|---|---|---|
| **#617** | Admin buttons stay visible after the user's role is changed to viewer (no re-gate) | Centralized axios **response interceptor**: on a 403 it invokes a settable handler; `useAuth` wires it to refetch the user's group roles (`getGroupList`) so the permission selectors recompute — no manual reload. |
| **#614** | Enumeration stops silently on a mid-flight 403 | Wrap `finishEnumeration`'s POST in a catch that **notifies** and **interrupts** the enumeration (resets progress). |
| **#616** | Downloading a removed (404) or now-forbidden (403) dataset/reaction only logs to the console | **Notify** the user instead of swallowing. |

A shared `notifyApiError` helper (maps HTTP status → message) DRYs the two notification sites.

### Design notes
- **403 only, not 401.** A 403 means *authenticated but not authorized* — the right cue to refresh permissions. A 401 is an authentication failure, already handled by the Auth0 token-refresh / redirect path; re-fetching `/groups` wouldn't help and could loop. The refetch is also **re-entrancy-guarded** as defense-in-depth.
- The interceptor's **success path is unchanged** (`response => response`).
- **#615** (a rejected edit is shown optimistically and never rolled back) is a separate, higher-risk **reducer** change — it'll come as its own follow-up PR so it gets focused review.

## Test plan
- [x] `tsc -b` clean; `prettier` / `eslint` clean
- [x] **697 unit tests pass** (25 new/updated across the touched units):
  - `axiosInstance.test.ts` — `handleResponseError` fires the handler on 403 only (not 401/404/409/500/non-axios) and always re-rejects.
  - `notifyApiError.test.ts` — status→message mapping + BE-message preference + fallback.
  - `useAuth.test.ts` — registers the handler, dispatches `getGroupList`, and ignores re-entrant refreshes while one is in flight.
  - `enumeration.thunks.test.ts` — a rejected enumerate notifies and interrupts (no success result / list refetch).
  - `downloadFile.thunks.test.ts` — a failed download notifies (no throw, no download).
- [x] Interceptor regression (normal requests still flow) is runtime-covered by CI `test_e2e`, which boots the full no-auth stack and drives the app through this interceptor.
- [x] **Runtime-verified on the live no-auth stack** (provisioned a 2nd user + toggled the logged-in user's group role; see verification comment): on a write `403` the interceptor re-fetches `getGroupList` and the UI re-gates to read-only — 5 admin controls → 0, plus an "Access forbidden" toast, with no page refresh.

Closes #617, #614, #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces previously-silent backend rejections (403/404) to the user across three flows: admin-button re-gating after a role downgrade, enumeration interruption on forbidden POST, and download failure notification. It introduces a centralized axios response interceptor and a shared `notifyApiError` helper, with 25 new/updated unit tests.

- **Interceptor + re-gate (#617):** `axiosInstance.ts` exports a settable `onPermissionDenied` hook; `useAuth.ts` wires it to dispatch `getGroupList()` with a closure-scoped re-entrancy guard, so permission-gated affordances recompute without a page reload.
- **Enumeration catch (#614):** `finishEnumeration`'s POST is now wrapped in try/catch; failures call `notifyApiError` and dispatch `interruptEnumerationAction()` instead of propagating silently.
- **Download notification (#616):** `downloadFileFromUrl`'s catch replaces `console.error` with `notifyApiError`, giving users a toast on 403/404 download failures.

<h3>Confidence Score: 5/5</h3>

Safe to merge. All three flows are well-contained: the interceptor only fires for 403 and always re-rejects, the re-entrancy guard is correctly scoped, and the catch blocks notify without swallowing the original error path.

The changes are narrowly scoped — an axios interceptor hook, a small re-gate effect in useAuth, a new notification utility, and two catch-block additions. Each is independently testable and well-tested. The interceptor's success path is untouched, the isRefreshing guard correctly handles self-referential 403s during the group refresh, and notifyApiError always resolves to a user-facing string. No data mutations, no store-reducer changes, and no auth-boundary alterations.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/axiosInstance.ts | Adds module-level `onPermissionDenied` handler and exports `handleResponseError` for unit testing; interceptor now fires the 403 hook and re-rejects cleanly. |
| ui/src/common/hooks/useAuth.ts | Registers `setPermissionDeniedHandler` with an in-flight guard that dispatches `getGroupList()` on 403, preventing re-entrancy if the refresh itself is rejected. |
| ui/src/store/utils/notifyApiError.ts | New thin wrapper over `getErrorDetails` + `showNotification`; maps HTTP status codes to human-readable messages and prefers backend-provided messages. |
| ui/src/store/entities/enumeration/enumeration.thunks.ts | Wraps enumeration POST in try/catch; on failure calls `notifyApiError` and dispatches `interruptEnumerationAction` instead of letting the error silently disappear. |
| ui/src/store/utils/downloadFile.thunks.ts | Replaces silent `console.error` with `notifyApiError` so 403/404 download failures surface a user-visible toast. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): surface 403s and silent request..."](https://github.com/open-reaction-database/ord-app/commit/39e54b51136e3d3021ee62b3f0bcd80f0f358a96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38750917)</sub>

<!-- /greptile_comment -->
