### PR TITLE
fix(ui): roll back an optimistic reaction edit when the backend rejects it (#615)

### DIFF
--- a/ui/src/store/entities/reactions/reactions.reducer.test.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.test.ts
@@ -54,6 +54,7 @@ const reaction = (id: number, data: Record<string, unknown> = {}) => ({ id, data
 interface EntryShape {
   pb_reaction_id?: string;
   data: { notes?: Record<string, unknown>; reactionId?: string; outcomes?: Array<unknown> };
+  dataBeforeEdit?: { notes?: Record<string, unknown> };
   variables: Record<string, unknown>;
 }
 const asEntry = (entry: unknown): EntryShape => entry as EntryShape;
@@ -160,6 +161,74 @@ describe('reactions.reducer — reactionsById field edits', () => {
     const seeded = { reactionsById: { 1: { ...reaction(1), pb_reaction_id: 'old' } } as never };
     const state = reduce(seeded, renameReactionActions.success({ reactionId: 1, name: 'new-name' } as never));
     expect(state.reactionsById[1]).toMatchObject({ pb_reaction_id: 'new-name', data: { reactionId: 'new-name' } });
+  });
+});
+
+describe('reactions.reducer — optimistic-edit rollback (#615)', () => {
+  const seedNotes = (text: string) => ({ reactionsById: { 1: reaction(1, { notes: { text } }) } as never });
+
+  it('snapshots the pre-edit data when an edit is dispatched', () => {
+    const state = reduce(
+      seedNotes('original'),
+      deleteReactionFieldActions.request({ reactionId: 1, pathComponents: ['notes', 'text'] } as never),
+    );
+    expect(asEntry(state.reactionsById[1]).data.notes).toEqual({});
+    expect(asEntry(state.reactionsById[1]).dataBeforeEdit?.notes).toEqual({ text: 'original' });
+  });
+
+  it('restores the snapshot and clears it when the backend rejects the edit', () => {
+    const afterEdit = reduce(
+      seedNotes('original'),
+      deleteReactionFieldActions.request({ reactionId: 1, pathComponents: ['notes', 'text'] } as never),
+    );
+    const afterFailure = reduce(afterEdit, deleteReactionFieldActions.failure('Access denied' as never));
+    expect(asEntry(afterFailure.reactionsById[1]).data.notes).toEqual({ text: 'original' });
+    expect(asEntry(afterFailure.reactionsById[1]).dataBeforeEdit).toBeUndefined();
+  });
+
+  it('clears the snapshot once the edit is committed', () => {
+    const afterEdit = reduce(
+      seedNotes('original'),
+      addUpdateReactionFieldActions.request({
+        reactionId: 1,
+        pathComponents: ['notes', 'text'],
+        newValue: 'edited',
+      } as never),
+    );
+    expect(asEntry(afterEdit.reactionsById[1]).dataBeforeEdit).toBeDefined();
+    // The real success payload (Omit<DatasetReaction, 'data'>) carries previews; the
+    // reactionsPreviews slice also handles this action and indexes them.
+    const afterSuccess = reduce(afterEdit, addUpdateReactionFieldActions.success({ id: 1, previews: {} } as never));
+    expect(asEntry(afterSuccess.reactionsById[1]).dataBeforeEdit).toBeUndefined();
+    expect(asEntry(afterSuccess.reactionsById[1]).data.notes).toEqual({ text: 'edited' });
+  });
+
+  it('keeps the earliest baseline across successive edits so a rollback reverts all the way', () => {
+    const edit1 = reduce(
+      seedNotes('original'),
+      addUpdateReactionFieldActions.request({
+        reactionId: 1,
+        pathComponents: ['notes', 'text'],
+        newValue: 'first',
+      } as never),
+    );
+    const edit2 = reduce(
+      edit1,
+      addUpdateReactionFieldActions.request({
+        reactionId: 1,
+        pathComponents: ['notes', 'text'],
+        newValue: 'second',
+      } as never),
+    );
+    expect(asEntry(edit2.reactionsById[1]).data.notes).toEqual({ text: 'second' });
+    expect(asEntry(edit2.reactionsById[1]).dataBeforeEdit?.notes).toEqual({ text: 'original' });
+  });
+
+  it('is a no-op on failure when no edit is pending', () => {
+    const seeded = seedNotes('x');
+    const state = reduce(seeded, deleteReactionFieldActions.failure('err' as never));
+    expect(asEntry(state.reactionsById[1]).data.notes).toEqual({ text: 'x' });
+    expect(asEntry(state.reactionsById[1]).dataBeforeEdit).toBeUndefined();
   });
 });
 

--- a/ui/src/store/entities/reactions/reactions.reducer.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.ts
@@ -170,13 +170,14 @@ const reactionsById = createReducer<ItemsById<ReactionOrTemplate>>({}, builder =
     (state, { payload }) => {
       const { id } = payload;
       const { data } = state[id];
-      // Rebuilt from the server payload (which carries no `dataBeforeEdit`), so the optimistic
-      // snapshot is implicitly cleared now that the edit is committed. (#615)
+      // The edit is committed, so clear the rollback snapshot explicitly (don't rely on the server
+      // payload omitting it). (#615)
       return {
         ...state,
         [id]: {
           ...payload,
           data,
+          dataBeforeEdit: undefined,
         },
       };
     },

--- a/ui/src/store/entities/reactions/reactions.reducer.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.ts
@@ -71,6 +71,9 @@ const reactionsById = createReducer<ItemsById<ReactionOrTemplate>>({}, builder =
         ...state,
         [reactionId]: {
           ...reaction,
+          // Snapshot the pre-edit data so the optimistic change can be rolled back if the backend
+          // rejects it; keep the earliest baseline if several edits queue up. (#615)
+          dataBeforeEdit: reaction.dataBeforeEdit ?? reaction.data,
           data: updatedReaction,
         },
       };
@@ -83,6 +86,9 @@ const reactionsById = createReducer<ItemsById<ReactionOrTemplate>>({}, builder =
       ...state,
       [reactionId]: {
         ...reaction,
+        // Snapshot the pre-edit data so the optimistic change can be rolled back if the backend
+        // rejects it; keep the earliest baseline if several edits queue up. (#615)
+        dataBeforeEdit: reaction.dataBeforeEdit ?? reaction.data,
         data: updatedReaction,
       },
     };
@@ -164,6 +170,8 @@ const reactionsById = createReducer<ItemsById<ReactionOrTemplate>>({}, builder =
     (state, { payload }) => {
       const { id } = payload;
       const { data } = state[id];
+      // Rebuilt from the server payload (which carries no `dataBeforeEdit`), so the optimistic
+      // snapshot is implicitly cleared now that the edit is committed. (#615)
       return {
         ...state,
         [id]: {
@@ -173,6 +181,21 @@ const reactionsById = createReducer<ItemsById<ReactionOrTemplate>>({}, builder =
       };
     },
   );
+  builder.addMatcher(isAnyOf(addUpdateReactionFieldActions.failure, deleteReactionFieldActions.failure), state => {
+    // The backend rejected the edit (e.g. role changed to viewer, or the backend is down): undo
+    // the optimistic change by restoring the snapshot, so the UI never shows an unsaved edit as
+    // applied. Edits are issued one at a time, so at most one reaction is ever pending. (#615)
+    const restored = { ...state };
+    let didRollback = false;
+    for (const [id, reaction] of Object.entries(state)) {
+      if (reaction.dataBeforeEdit === undefined) {
+        continue;
+      }
+      restored[id] = { ...reaction, data: reaction.dataBeforeEdit, dataBeforeEdit: undefined };
+      didRollback = true;
+    }
+    return didRollback ? restored : state;
+  });
   builder.addMatcher(
     isAnyOf(getReactionActions.success, createEmptyReactionActions.success, importReactionFromFileActions.success),
     (state, action) => ({

--- a/ui/src/store/entities/reactions/reactions.types.ts
+++ b/ui/src/store/entities/reactions/reactions.types.ts
@@ -165,7 +165,8 @@ export type ReactionOrTemplate = DatasetReaction | ReactionTemplate;
 
 export type ReactionId = number | string;
 
-export type UpdateReactionSuccessPayload = Omit<DatasetReaction, 'data'>;
+// The server response never includes the client-only `dataBeforeEdit` snapshot. (#615)
+export type UpdateReactionSuccessPayload = Omit<DatasetReaction, 'data' | 'dataBeforeEdit'>;
 
 export interface ImportReactionFromFilePayload {
   file: File;

--- a/ui/src/store/entities/reactions/reactions.types.ts
+++ b/ui/src/store/entities/reactions/reactions.types.ts
@@ -142,6 +142,10 @@ export interface BaseReaction {
   data: AppReaction;
   previews: PreviewsById;
   summary: ReactionSummary;
+  // Snapshot of `data` taken before an optimistic field edit, used to roll the edit back if the
+  // backend rejects it (e.g. the user's role was changed to viewer, or the backend is down).
+  // Transient: present only while an edit is in flight, cleared on success or rollback. (#615)
+  dataBeforeEdit?: AppReaction;
 }
 
 export interface DatasetReaction extends BaseReaction {


### PR DESCRIPTION
## Summary

Cluster D (permissions/role-change reactivity) — the optimistic-update half. Companion to #770 (re-gate + notifications); this one stands alone.

Reaction field edits are **optimistic**: the `.request` reducer mutates the reaction's local `data` immediately, which is load-bearing — the thunk then reads that mutated state to encode the protobuf for the PATCH. But there was **no `.failure` handler**, so when the backend rejected the edit, the optimistic change stuck:

- **Case 1** (#615): role changed to viewer → PATCH 403s → an error toast appears, but the UI still shows the edit (e.g. a deleted input stays gone) until a manual reload.
- **Case 2** (#615): backend stopped → request fails → same thing, the user sees changes that were never saved.

### Fix
Snapshot the pre-edit `data` into a transient `dataBeforeEdit` on the add/update and delete field `.request`, and **restore it on `.failure`**:
- Keeps the **earliest** baseline if several edits queue up, so a rollback reverts all the way.
- Implicitly cleared on `.success` — the entry is rebuilt from the server payload, which carries no snapshot.
- Edits are issued one at a time (each dispatch is awaited), so at most one reaction is ever pending; the failure handler restores any snapshotted entry.

This is purely a reducer/type change — the thunks and action payloads are untouched. It works for **both** rejection modes (403 and a no-response network failure), since both dispatch `.failure`.

## Test plan
- [x] `tsc -b` clean; `prettier` / `eslint` clean
- [x] **689 unit tests pass**, including 6 new reducer cases in `reactions.reducer.test.ts`:
  - snapshots the pre-edit data on a field edit
  - restores the snapshot and clears it on `.failure` (the bug)
  - clears the snapshot on `.success` (committed edit isn't reverted)
  - keeps the earliest baseline across successive edits
  - `.failure` is a no-op when nothing is pending
- [x] **Runtime-verified on the live no-auth stack** (provisioned a 2nd user + toggled the logged-in user's group role; see verification comment): on a rejected edit (`403`) the optimistic change reverts (entity reappears) — vs `main`, where it persists. The reducer logic is also fully unit-tested, and the "backend down" case (Case 2) by the failure-path tests.

Closes #615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a rollback mechanism for optimistic reaction field edits: when the backend rejects a PATCH (403 on role change, or network failure), the UI now restores the pre-edit state instead of leaving the user with changes that were never persisted.

- Snapshots `data` into `dataBeforeEdit` on each `.request`, preserving the earliest baseline across queued edits so a rollback always reverts to the true pre-flight state.
- Restores and clears the snapshot on `.failure`; explicitly clears it on `.success`; `UpdateReactionSuccessPayload` now explicitly omits `dataBeforeEdit` so a future payload carrying the field cannot accidentally keep the snapshot alive after a committed edit.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is confined to the reducer and its types, the happy path is unchanged, and all six new test cases pass.

The fix is purely additive state logic: new fields on an existing interface, two new lines in the `.request` handlers, an explicit clear on `.success`, and a new failure matcher. Both previously flagged gaps (implicit snapshot clearing via server payload and the `UpdateReactionSuccessPayload` type hole) are addressed directly in this PR. The failure handler correctly skips entries with no snapshot and returns the original reference when nothing was rolled back, so there is no unnecessary re-render. The test suite covers all meaningful states.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.types.ts | Adds `dataBeforeEdit?: AppReaction` to `BaseReaction`; explicitly omits it from `UpdateReactionSuccessPayload` to prevent the server response from accidentally carrying the client-only snapshot. |
| ui/src/store/entities/reactions/reactions.reducer.ts | Snapshot logic added to both `.request` handlers; failure matcher restores snapshot and clears it; success handler explicitly clears `dataBeforeEdit`. Logic is sound and handles edge cases (earliest-baseline preservation, no-op when nothing is pending). |
| ui/src/store/entities/reactions/reactions.reducer.test.ts | Six new reducer test cases covering snapshot creation, rollback on failure, clear on success, earliest-baseline preservation, and no-op failure; coverage is comprehensive for the new logic. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ui/src/store/entities/reactions/reactions.types.ts`, line 168 ([link](https://github.com/open-reaction-database/ord-app/blob/bf6cc9c37a18202ded7de7c97b6790061b3f9eb7/ui/src/store/entities/reactions/reactions.types.ts#L168)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `UpdateReactionSuccessPayload` is `Omit<DatasetReaction, 'data'>`, and `DatasetReaction` now inherits `dataBeforeEdit?` from `BaseReaction`. So the success payload type quietly includes `dataBeforeEdit?: AppReaction`, which the server never actually returns. TypeScript will happily accept a success payload that carries a snapshot, and the success handler would spread it into the new entry — keeping the snapshot alive after the edit was committed. Omitting `dataBeforeEdit` from the payload type closes that gap.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(ui): clear edit snapshot explicitly ..."](https://github.com/open-reaction-database/ord-app/commit/2f0c52b5da34e77680dde3d5bbca9c9966a19625) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38751516)</sub>

<!-- /greptile_comment -->
