### PR TITLE
fix(ui): scope "Show Invalid Only" per dataset, reset on dataset load (#591)

### DIFF
--- a/ui/src/store/entities/reactions/reactions.reducer.test.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.test.ts
@@ -206,4 +206,9 @@ describe('reactions.reducer — showInvalidOnly', () => {
     expect(reduce(undefined, setShowInvalidOnly(true)).showInvalidOnly).toBe(true);
     expect(reduce({ showInvalidOnly: true }, setShowInvalidOnly(false)).showInvalidOnly).toBe(false);
   });
+
+  it('resets to the default when a dataset loads, so the filter is per-dataset (#591)', () => {
+    const state = reduce({ showInvalidOnly: true }, getReactionsListActions.request(7));
+    expect(state.showInvalidOnly).toBe(false);
+  });
 });

--- a/ui/src/store/entities/reactions/reactions.reducer.ts
+++ b/ui/src/store/entities/reactions/reactions.reducer.ts
@@ -251,6 +251,11 @@ const areReactionsLoading = createReducer<boolean>(false, builder => {
 
 const showInvalidOnly = createReducer<boolean>(false, builder => {
   builder.addCase(setShowInvalidOnly, (_, action) => action.payload);
+  // Reset to the default (show all) whenever a dataset's reactions load — on open, refresh, or
+  // switching datasets — so the filter is scoped per dataset rather than persisting globally,
+  // mirroring the Tabs/List view toggle. The in-list toggle refetches via getReactionsPage, so it
+  // doesn't trip this reset. (#591)
+  builder.addCase(getReactionsListActions.request, () => false);
 });
 
 export const reactionsReducer = combineReducers({


### PR DESCRIPTION
## Summary

Implements the agreed behavior for #591 (recorded in the triage plan #656): the **"Show Invalid Only"** filter should be **per-dataset** and reset to its default when switching datasets or refreshing, mirroring the Tabs/List view toggle.

**Before:** the flag was a single global boolean, so toggling it on one dataset persisted to every other dataset; it only cleared on a full page refresh.

**After:** reset `showInvalidOnly` to the default (show all) on `getReactionsListActions.request`, which the Dataset page dispatches from its `[dispatch, id]` effect — so it fires on open, refresh, and every dataset switch. The in-list toggle refetches via `getReactionsPage` (a different action), so flipping the switch within a dataset doesn't trip the reset.

## Test plan
- [x] `tsc -b` clean; `prettier` / `eslint` clean
- [x] Unit test added: the reducer resets `showInvalidOnly` to `false` on a list request (with a seeded `true`).
- [x] Code-traced the trigger: `getReactionsList` is dispatched from exactly one place (the Dataset page mount/id-change effect), so there are no unwanted resets and the switch always resets.

Held for review: small behavioral change to an existing flow's semantics (filter scope), so flagged rather than auto-merged.

Closes #591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes the "Show Invalid Only" filter to the currently loaded dataset by resetting `showInvalidOnly` to `false` whenever `getReactionsListActions.request` fires — the action dispatched on dataset open, refresh, or switch. The in-list pagination toggle (`getReactionsPage`) is intentionally left out of the reset, so toggling the filter within a dataset does not clear itself.

- **`reactions.reducer.ts`**: One `builder.addCase` line added to the `showInvalidOnly` sub-reducer; no other logic changed.
- **`reactions.reducer.test.ts`**: One focused unit test added that seeds `showInvalidOnly: true`, dispatches a list-request action, and asserts the flag is back to `false`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single reducer case addition with a matching unit test, no existing behavior is removed.

The fix is surgical: one `addCase` in the `showInvalidOnly` sub-reducer and one test. The action chosen for the reset (`getReactionsListActions.request`) is already used by four other sub-reducers for exactly the same 'new dataset loaded' semantics, so the pattern is consistent with the rest of the file. The `getReactionsPage` path is correctly excluded, preserving the in-dataset toggle behavior. No edge cases appear to be overlooked.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/entities/reactions/reactions.reducer.ts | Adds a single `addCase` handler to reset `showInvalidOnly` to `false` on `getReactionsListActions.request`, scoping the filter per dataset. |
| ui/src/store/entities/reactions/reactions.reducer.test.ts | Adds a targeted unit test that seeds `showInvalidOnly: true` and asserts it resets to `false` on a list request action. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): scope &quot;Show Invalid Only&quot; per d..."](https://github.com/open-reaction-database/ord-app/commit/b02fe2d835948608905dfa928f23037f78934d8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38756086)</sub>

<!-- /greptile_comment -->