### PR TITLE
fix(ui): show a 404 for an unknown template id instead of a blank page (#496)

### DIFF
--- a/ui/src/pages/TemplatePage/TemplatePage.test.tsx
+++ b/ui/src/pages/TemplatePage/TemplatePage.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+
+// Drives the three branches of the page (#496): the template lookup and the templates-loaded flag.
+const control = vi.hoisted(() => ({ template: undefined as unknown, loaded: false }));
+
+vi.mock('wouter', () => ({ useParams: () => ({ templateId: '999' }) }));
+vi.mock('react-redux', () => ({ useSelector: (selector: (state: unknown) => unknown) => selector(undefined) }));
+vi.mock('store/entities/reactions/reactions.selectors.ts', () => ({
+  selectReactionById: () => () => control.template,
+}));
+vi.mock('store/entities/templates/templates.selectors.ts', () => ({
+  selectAreTemplatesLoaded: () => control.loaded,
+}));
+
+// Stub the full-page 404 and the heavy template subtree so the test stays focused on the page's
+// branch decision rather than its children's internals.
+vi.mock('pages/NotFound/NotFoundPage.tsx', () => ({
+  NotFoundPage: ({ rejectValue }: Readonly<{ rejectValue?: { errorCode?: number } }>) => (
+    <div data-testid="not-found">{rejectValue?.errorCode}</div>
+  ),
+}));
+vi.mock('common/components/PageContainer/PageContainer.tsx', () => ({
+  PageContainer: ({ children }: Readonly<{ children: React.ReactNode }>) => (
+    <div data-testid="page-container">{children}</div>
+  ),
+}));
+vi.mock('features/templates/TemplateHeader/TemplateHeader.tsx', () => ({
+  TemplateHeader: () => <div data-testid="template-header" />,
+}));
+vi.mock('features/reactions/ReactionEntities/ReactionTabs/ReactionTabs.tsx', () => ({ ReactionTabs: () => null }));
+vi.mock('features/reactions/ReactionDetailsSidebar/ReactionDetailsSidebar.tsx', () => ({
+  ReactionDetailsSidebar: () => null,
+}));
+vi.mock('features/templates/VariablesSidebar/VariablesSidebar.tsx', () => ({ VariablesSidebar: () => null }));
+vi.mock('features/reactions/ReactionInteractions/ReactionValueLabel/TemplateReactionValueLabel.tsx', () => ({
+  TemplateReactionValueLabelWrapper: () => null,
+}));
+vi.mock('features/reactions/ReactionInteractions/ReactionViewDeleteButtons/ReactionSetVariablesButton.tsx', () => ({
+  ReactionSetVariablesButton: () => null,
+}));
+vi.mock('features/reactions/ReactionInteractions/ReactionValueLabel/DatasetReactionValueLable.tsx', () => ({
+  DatasetReactionValueLabel: () => null,
+}));
+
+import { TemplatePage } from './TemplatePage.tsx';
+
+beforeEach(() => {
+  control.template = undefined;
+  control.loaded = false;
+});
+
+describe('TemplatePage (#496 — 404 for a missing template)', () => {
+  it('shows a 404 once templates are loaded and the id is unknown', () => {
+    control.loaded = true;
+    control.template = undefined;
+    renderWithMantine(<TemplatePage />);
+    expect(screen.getByTestId('not-found')).toHaveTextContent('404');
+  });
+
+  it('does not flash a 404 while templates are still loading', () => {
+    control.loaded = false;
+    control.template = undefined;
+    renderWithMantine(<TemplatePage />);
+    expect(screen.queryByTestId('not-found')).toBeNull();
+    expect(screen.getByTestId('page-container')).toBeInTheDocument();
+  });
+
+  it('renders the template content when the template exists', () => {
+    control.loaded = true;
+    control.template = { id: 'template_999', name: 'My Template', data: { outcomes: [] } };
+    renderWithMantine(<TemplatePage />);
+    expect(screen.queryByTestId('not-found')).toBeNull();
+    expect(screen.getByTestId('template-header')).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/TemplatePage/TemplatePage.tsx
+++ b/ui/src/pages/TemplatePage/TemplatePage.tsx
@@ -22,6 +22,8 @@ import { ReactionDetailsSidebar } from 'features/reactions/ReactionDetailsSideba
 import { PageContainer } from 'common/components/PageContainer/PageContainer.tsx';
 import type { Breadcrumbs } from 'common/types/breadcrumbs.ts';
 import { selectReactionById } from 'store/entities/reactions/reactions.selectors.ts';
+import { selectAreTemplatesLoaded } from 'store/entities/templates/templates.selectors.ts';
+import { NotFoundPage } from 'pages/NotFound/NotFoundPage.tsx';
 import { ReactionTabs } from 'features/reactions/ReactionEntities/ReactionTabs/ReactionTabs.tsx';
 import { TemplateHeader } from 'features/templates/TemplateHeader/TemplateHeader.tsx';
 import { reactionContext } from 'features/reactions/reactions.context.ts';
@@ -35,6 +37,7 @@ export function TemplatePage() {
   const { templateId: rawTemplateId } = useParams<{ templateId: string }>();
   const templateId = `template_${rawTemplateId}`;
   const template = useSelector(selectReactionById(templateId));
+  const areTemplatesLoaded = useSelector(selectAreTemplatesLoaded);
 
   const breadcrumbs = useMemo((): Breadcrumbs => {
     return [
@@ -57,6 +60,12 @@ export function TemplatePage() {
     }),
     [templateId],
   );
+
+  // Once the template list has loaded, an unknown id is genuinely missing — show a 404 instead of
+  // a blank page. While templates are still loading we keep rendering so we don't flash a 404. (#496)
+  if (areTemplatesLoaded && !template) {
+    return <NotFoundPage rejectValue={{ errorCode: 404, errorMessage: 'Template not found' }} />;
+  }
 
   return (
     <PageContainer

--- a/ui/src/store/entities/templates/templates.reducer.test.ts
+++ b/ui/src/store/entities/templates/templates.reducer.test.ts
@@ -31,7 +31,15 @@ const initialState = () => templatesReducer(undefined, { type: '@@INIT' });
 
 describe('templatesReducer', () => {
   it('returns the initial state', () => {
-    expect(initialState()).toEqual({ templatesOrder: [], isTemplateCreating: false });
+    expect(initialState()).toEqual({ templatesOrder: [], isTemplateCreating: false, areTemplatesLoaded: false });
+  });
+
+  describe('areTemplatesLoaded', () => {
+    it('is false initially and flips to true once the full list is fetched (#496)', () => {
+      expect(initialState().areTemplatesLoaded).toBe(false);
+      const state = templatesReducer(initialState(), getAllTemplatesActions.success([makeTemplate('a')]));
+      expect(state.areTemplatesLoaded).toBe(true);
+    });
   });
 
   describe('templatesOrder', () => {

--- a/ui/src/store/entities/templates/templates.reducer.test.ts
+++ b/ui/src/store/entities/templates/templates.reducer.test.ts
@@ -40,6 +40,11 @@ describe('templatesReducer', () => {
       const state = templatesReducer(initialState(), getAllTemplatesActions.success([makeTemplate('a')]));
       expect(state.areTemplatesLoaded).toBe(true);
     });
+
+    it('also settles to true when the fetch fails, so the 404 path still reaches the user (#496)', () => {
+      const state = templatesReducer(initialState(), getAllTemplatesActions.failure(new Error('network')));
+      expect(state.areTemplatesLoaded).toBe(true);
+    });
   });
 
   describe('templatesOrder', () => {

--- a/ui/src/store/entities/templates/templates.reducer.ts
+++ b/ui/src/store/entities/templates/templates.reducer.ts
@@ -53,11 +53,12 @@ const isTemplateCreating = createReducer<boolean>(false, builder => {
   );
 });
 
-// Whether the full template list has been fetched. Lets the template page tell "still loading"
-// apart from "no such template" so it can show a 404 for a missing id rather than a blank page,
-// without flashing the 404 during the initial load. (#496)
+// Whether the template-list fetch has settled. Lets the template page tell "still loading" apart
+// from "no such template" so it can show a 404 for a missing id rather than a blank page, without
+// flashing the 404 during the initial load. Set on failure too, so a failed fetch still reaches the
+// 404 path instead of leaving a permanently blank page. (#496)
 const areTemplatesLoaded = createReducer<boolean>(false, builder => {
-  builder.addCase(getAllTemplatesActions.success, () => true);
+  builder.addMatcher(isAnyOf(getAllTemplatesActions.success, getAllTemplatesActions.failure), () => true);
 });
 
 export const templatesReducer = combineReducers({

--- a/ui/src/store/entities/templates/templates.reducer.ts
+++ b/ui/src/store/entities/templates/templates.reducer.ts
@@ -53,7 +53,15 @@ const isTemplateCreating = createReducer<boolean>(false, builder => {
   );
 });
 
+// Whether the full template list has been fetched. Lets the template page tell "still loading"
+// apart from "no such template" so it can show a 404 for a missing id rather than a blank page,
+// without flashing the 404 during the initial load. (#496)
+const areTemplatesLoaded = createReducer<boolean>(false, builder => {
+  builder.addCase(getAllTemplatesActions.success, () => true);
+});
+
 export const templatesReducer = combineReducers({
   templatesOrder,
   isTemplateCreating,
+  areTemplatesLoaded,
 });

--- a/ui/src/store/entities/templates/templates.selectors.test.ts
+++ b/ui/src/store/entities/templates/templates.selectors.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { describe, it, expect } from 'vitest';
-import { selectTemplates, selectTemplatesOrder } from './templates.selectors.ts';
+import { selectAreTemplatesLoaded, selectTemplates, selectTemplatesOrder } from './templates.selectors.ts';
 import type { ReactionTemplate } from 'store/entities/reactions/reactions.types.ts';
 import type { AppState } from '../../configureAppStore.ts';
 
@@ -31,6 +31,15 @@ const buildState = (templatesOrder: Array<string>, reactionsById: Record<string,
 describe('selectTemplatesOrder', () => {
   it('returns the stored order', () => {
     expect(selectTemplatesOrder(buildState(['a', 'b'], {}))).toEqual(['a', 'b']);
+  });
+});
+
+describe('selectAreTemplatesLoaded', () => {
+  it('reflects the templates-loaded flag (#496)', () => {
+    const state = (loaded: boolean) =>
+      ({ entities: { templates: { areTemplatesLoaded: loaded } } }) as unknown as AppState;
+    expect(selectAreTemplatesLoaded(state(false))).toBe(false);
+    expect(selectAreTemplatesLoaded(state(true))).toBe(true);
   });
 });
 

--- a/ui/src/store/entities/templates/templates.selectors.ts
+++ b/ui/src/store/entities/templates/templates.selectors.ts
@@ -22,6 +22,8 @@ const { buildSelector } = createSelectorFactory(state => state.entities.template
 
 export const selectTemplatesOrder = buildSelector(state => state.templatesOrder);
 
+export const selectAreTemplatesLoaded = buildSelector(state => state.areTemplatesLoaded);
+
 export const selectTemplates = createSelector([selectTemplatesOrder, selectReactions], (order, templates) => {
   return order.map(id => templates[id] as ReactionTemplate);
 });


### PR DESCRIPTION
## Summary

Visiting `/templates/<unknown-id>` rendered a **blank page** — `TemplatePage` guards its content on `{template && ...}` and silently renders nothing when the template isn't in the store. Because templates are fetched in bulk via `getAllTemplates`, a missing id is indistinguishable from "still loading" without an explicit signal.

**Fix:** add an `areTemplatesLoaded` flag to the templates slice (flips to `true` once the full list is fetched) + a `selectAreTemplatesLoaded` selector. `TemplatePage` now renders the shared `NotFoundPage` (404) when the list **has loaded** and the id is unknown, while staying quiet during the initial load so it doesn't **flash** a 404.

### Scope notes
- Long template ids already work — the page keys templates by string (`template_<id>`), so there's no numeric overflow and no "data type" change needed.
- The issue's secondary ask (datasets returning **404 instead of 403** for unknown ids) is backend work tracked under #446 and is **out of scope** here.

## Test plan
- [x] `tsc -b` clean; `prettier` / `eslint` clean; **689 tests pass**
- [x] New tests (8 across reducer/selector/page):
  - reducer: `areTemplatesLoaded` is `false` initially, `true` after `getAllTemplates` success
  - selector: `selectAreTemplatesLoaded` reflects the flag
  - page: renders 404 when loaded + unknown id; **no** 404 while still loading; renders content when the template exists
- [ ] Not booted on the stack for this one — the page-render test directly covers all three branches (404 / loading / present); a quick manual nav to `/templates/999999` would be a nice final eyeball before merge.

Closes #496 (template half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a blank-page bug where navigating to `/templates/<unknown-id>` silently rendered nothing because `TemplatePage` guarded its content on `{template && ...}` with no way to distinguish "still loading" from "genuinely missing."

- Adds an `areTemplatesLoaded` boolean to the templates Redux slice (settles to `true` on both `getAllTemplates` success and failure) and a matching `selectAreTemplatesLoaded` selector.
- `TemplatePage` now short-circuits to `NotFoundPage` (404) when the list has settled and the id is absent, while keeping the existing `PageContainer` render during the initial load to avoid flashing a 404 prematurely.
- All three branches (404 / loading / present) are covered by new unit tests alongside reducer and selector tests, including the failure-path case addressed during review.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, well-tested, and the failure-path edge case flagged in review has been addressed.

The fix is confined to three small files: a new sub-reducer with a single `addMatcher`, a one-line selector, and an early-return guard in the page component. The reducer correctly settles the flag on both success and failure, and the three-branch test matrix (404 / loading / present) gives good coverage of the added logic. No existing behaviour is altered for users who already have templates loaded.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/pages/TemplatePage/TemplatePage.tsx | Adds the `areTemplatesLoaded` guard before the main render: shows `NotFoundPage` (404) when the list has settled and the id is absent; keeps rendering `PageContainer` while still loading to avoid flashing a 404. |
| ui/src/store/entities/templates/templates.reducer.ts | Adds `areTemplatesLoaded` reducer (flips to `true` on both success and failure of `getAllTemplates`) and includes it in `combineReducers`; correctly handles network failure so the 404 path is reachable even when the initial fetch errors out. |
| ui/src/store/entities/templates/templates.selectors.ts | Adds `selectAreTemplatesLoaded` using the existing `buildSelector` factory — minimal and consistent with surrounding selectors. |
| ui/src/pages/TemplatePage/TemplatePage.test.tsx | New test file covering all three branches of the guard (404 when loaded + unknown, no flash while loading, content when template exists) using hoisted mocks for clean isolation. |
| ui/src/store/entities/templates/templates.reducer.test.ts | Adds tests for `areTemplatesLoaded` covering initial state, success case, and the failure case added after the previous review thread. |
| ui/src/store/entities/templates/templates.selectors.test.ts | Adds a focused test for `selectAreTemplatesLoaded` confirming it reflects both `false` and `true` states from the store shape. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): settle areTemplatesLoaded on fe..."](https://github.com/open-reaction-database/ord-app/commit/b63328d0b4a15cc3508c1c6303a36f7c69bd157d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38757774)</sub>

<!-- /greptile_comment -->