### PR TITLE
fix(ui): truncate long group names in the create-dataset group dropdown (#355)

### DIFF
--- a/ui/src/features/groups/GroupSelector/GroupSelector.tsx
+++ b/ui/src/features/groups/GroupSelector/GroupSelector.tsx
@@ -33,7 +33,7 @@ export function GroupSelector({ ...rest }: Readonly<GroupSelectorProps>) {
       placeholder="Select a group"
       searchable
       {...rest}
-      classNames={{ option: classes.option, ...rest.classNames }}
+      classNames={{ option: classes.option, options: classes.options, ...rest.classNames }}
     />
   );
 }

--- a/ui/src/features/groups/GroupSelector/groupSelector.module.scss
+++ b/ui/src/features/groups/GroupSelector/groupSelector.module.scss
@@ -14,8 +14,24 @@
  * limitations under the License.
  */
 
-/* Truncate long group names to the dropdown width instead of wrapping. */
+/* Truncate long group names to the dropdown width instead of overflowing it. Mantine lays the
+   options out in a flex column that grows to the widest option, and renders each option as a flex
+   row with the label in a child <span>; the row is otherwise clipped (without an ellipsis) by the
+   dropdown. Cap the options column and each row to the dropdown width and let the label shrink and
+   ellipsize. (#355) */
+.options,
+.options * {
+  max-width: 100%;
+  min-width: 0;
+}
+
 .option {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.option span {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
## Summary

Completes #355 (consistent truncation of long Group names). Verified each surface on the live no-auth stack with a long-named group ("Computational Chemistry and High-Throughput Experimentation Working Group Alpha"):

| Surface | Status |
|---|---|
| Group sidebar (part 1) | already truncates ✅ |
| Datasets-table **Group** column (part 2) | already truncates ✅ |
| **Create-dataset modal group dropdown** (part 3) | **fixed here** |

**The bug:** the group `<Select>` in the create-dataset (from-scratch / from-file) modals lays its options out inside a Mantine **ScrollArea** that horizontally-scrolled a long option and clipped it at the dropdown edge **without an ellipsis**. The existing `.option` truncation never fired because the option row grew to its content width (554px) inside the scrolling viewport rather than being capped to the ~400px dropdown.

**The fix (CSS only):** cap every element inside the options dropdown to the dropdown width (and let flex items shrink via `min-width: 0`), so the row stays within the dropdown and the label `<span>` ellipsizes.

**Before → After** (live screenshots):
- Before: `Computational Chemistry and High-Throughput Experimentatio` (clipped mid-word, no ellipsis, option box 554px overflowing the dropdown)
- After: `Computational Chemistry and High-Throughput Experimen…` (ellipsized, option box 396px within the dropdown)

## Test plan
- [x] `tsc -b`, `vitest` (684 pass, GroupSelector test green), `stylelint`, `eslint`, `prettier` all clean
- [x] **Runtime-verified** on the live no-auth stack via Playwright — measured the option width drop 554px → 396px and confirmed the ellipsis renders (DOM-inspected + screenshotted before/after)
- CSS-only layout change; no behavior/logic touched (happy-dom can't assert computed truncation, hence the live verification)

Closes #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes long group names overflowing the create-dataset modal's group dropdown without an ellipsis by adding a CSS class to Mantine's `options` container slot and tightening the truncation rules on individual option rows and their label `<span>` children.

- **`GroupSelector.tsx`**: Wires `classes.options` to the Mantine `Select` `options` classNames slot (one-line change), keeping the existing `option` and `...rest.classNames` spread order intact.
- **`groupSelector.module.scss`**: Adds `.options, .options *` with `max-width: 100%; min-width: 0` to cap the flex column and allow flex items to shrink; splits the former `.option` truncation rules into `.option` (overflow: hidden) and `.option span` (ellipsis + nowrap), matching the actual Mantine DOM structure where the label lives in a child `<span>`.

<h3>Confidence Score: 5/5</h3>

CSS-only change scoped to the GroupSelector dropdown; no logic, data, or API surface is touched.

The change is minimal — one new classNames key in TSX and a few additional CSS rules in the module file. The `.options *` universal selector is broad within the options container but cannot escape the CSS module's generated scope, and the properties set (`max-width: 100%`, `min-width: 0`) are safe layout constraints that won't affect icon dimensions in practice. No behaviour, state, or API contracts are modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/groups/GroupSelector/groupSelector.module.scss | Adds `.options`/`.options *` rules with `max-width: 100%` and `min-width: 0` to constrain the options container and all its descendants, then splits truncation properties between `.option` (overflow: hidden) and `.option span` (ellipsis). The universal `*` selector is broad but appropriately scoped to the module's `.options` context. |
| ui/src/features/groups/GroupSelector/GroupSelector.tsx | One-line change: adds `options: classes.options` to the Mantine `Select` classNames prop, wiring the new CSS class to the options list container. The spread order (`...rest.classNames` last) keeps the existing override behaviour consistent with the pre-existing `option` key. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): truncate long group names in th..."](https://github.com/open-reaction-database/ord-app/commit/2c6cdeb4680235e88b48d3f8087c7323446700a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38762087)</sub>

<!-- /greptile_comment -->