### PR TITLE
fix(ui): contain wide reactions so they scroll instead of clipping off-screen (#408)

### DIFF
--- a/ui/src/common/components/PageContainer/PageContainer.module.scss
+++ b/ui/src/common/components/PageContainer/PageContainer.module.scss
@@ -34,6 +34,11 @@
 .content {
   flex: 0 1 1440px;
   max-width: 1440px;
+
+  /* Allow the content column to shrink below its intrinsic width so over-wide content (e.g. a
+     reaction with many inputs) scrolls within its own container instead of widening the whole page
+     and pushing its left edge off-screen. (#408) */
+  min-width: 0;
 }
 
 .footer {

--- a/ui/src/common/components/ReactionCard/reactionCard.module.scss
+++ b/ui/src/common/components/ReactionCard/reactionCard.module.scss
@@ -17,6 +17,10 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+
+  /* Let the card shrink below its content's intrinsic width so the preview can scroll horizontally
+     within it rather than overflowing the page. (#408) */
+  min-width: 0;
 }
 
 .topContainer {

--- a/ui/src/common/components/ReactionPreview/reactionPreview.module.scss
+++ b/ui/src/common/components/ReactionPreview/reactionPreview.module.scss
@@ -28,6 +28,10 @@ $line-clamp: 4;
   align-items: center;
   padding-bottom: var(--mantine-spacing-md);
   min-height: $wrapper-height;
+
+  /* Shrink below the inputs' intrinsic width so overflow-x:auto actually scrolls them within the
+     card, instead of the row growing and pushing the page (and the reaction's start) off-screen. (#408) */
+  min-width: 0;
 }
 
 .inputCard {

--- a/ui/src/pages/Dataset/dataset.page.module.scss
+++ b/ui/src/pages/Dataset/dataset.page.module.scss
@@ -17,4 +17,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+
+  /* Allow this column to shrink below its content's intrinsic width so a wide reaction's preview
+     scrolls horizontally within its card instead of forcing the whole page wider. (#408) */
+  min-width: 0;
 }


### PR DESCRIPTION
## Summary

A reaction with many inputs rendered **wider than the viewport**, and its **left edge (the start of the reaction) was pushed off-screen with no way to scroll to it** — exactly the issue reported in #408.

**Root cause** (diagnosed via live DOM inspection): the preview row already has `overflow-x: auto`, but it never engaged because every flex ancestor had the default `min-width: auto` and refused to shrink below the inputs' intrinsic width (~1440px). So the whole **page** widened instead, and `PageContainer`'s `justify-content: center` then centered the over-wide content, pushing its left edge off-screen.

**Fix:** add `min-width: 0` down the flex chain so the content shrinks to the viewport and the preview's own `overflow-x: auto` provides a horizontal scrollbar **within the card**:
- `PageContainer .content` (global)
- the dataset page column
- the reaction card `.container`
- the reaction preview row `.wrapper`

## Verification (live no-auth stack, Playwright + DOM measurement)
| Metric | Before | After |
|---|---|---|
| Page horizontal overflow | 80px | **0** |
| Preview row | 1388px wide, not scrollable, left edge at **-54px** (off-screen) | shrinks to card width, **scrollWidth 1413 > clientWidth** (scrolls), left edge **+46px** (on-screen) |

Screenshot-verified the dataset page now shows the reaction from its start, and confirmed **no regression** on the datasets-list and reaction-detail pages (the global `PageContainer` change).

## Test plan
- [x] `tsc -b`, `vitest` (690 pass), `stylelint`, `prettier` clean
- [x] Runtime-verified before/after + regression-checked other pages
- CSS-only; happy-dom can't assert computed layout, hence the live verification

**Held for review:** touches the shared `PageContainer` content sizing (affects every page), so flagging rather than auto-merging despite being CSS-only.

Closes #408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a longstanding layout bug where reactions with many inputs pushed the page wider than the viewport, centering the over-wide content and leaving its left edge inaccessible off-screen. The root cause was the default `min-width: auto` on flex items preventing the existing `overflow-x: auto` on `.wrapper` from ever activating.

- Adds `min-width: 0` at four points in the flex chain — `PageContainer .content`, the dataset page column, `ReactionCard .container`, and `ReactionPreview .wrapper` — so each ancestor can shrink and the scroll is properly contained within the preview row.
- The global `PageContainer` change is intentionally shared, since allowing content to shrink rather than widening the page is the correct behavior for all pages; the existing `min-width: 1280px` on `.main` ensures usable page width is preserved.

<h3>Confidence Score: 5/5</h3>

CSS-only, well-targeted fix with no logic changes; safe to merge.

All four changes are the established `min-width: 0` flex-shrink pattern, each accompanied by a clear comment explaining its role in the chain. The `.wrapper` already carried `overflow: auto hidden`, so the fix is purely unlocking behavior that was already intended but blocked by the flex default. The global `PageContainer .content` change is the most impactful, but it only affects pages where content would previously have widened the page beyond the viewport — a regression in that scenario would require content genuinely wider than the `min-width: 1280px` page floor, which is the exact case the fix is designed to handle correctly. No new layout properties are introduced; the diff is additive and tightly scoped.

No files require special attention. The `PageContainer.module.scss` change affects every page, but the behavioral change is benign for all cases where content is narrower than the viewport.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/PageContainer/PageContainer.module.scss | Adds `min-width: 0` to `.content` so the global page content column can shrink below its intrinsic width and prevent wide reactions from pushing the whole page wider than the viewport. |
| ui/src/common/components/ReactionCard/reactionCard.module.scss | Adds `min-width: 0` to `.container` so the reaction card flex item can shrink, propagating the shrinkability down to the preview row. |
| ui/src/common/components/ReactionPreview/reactionPreview.module.scss | Adds `min-width: 0` to `.wrapper`, which already had `overflow: auto hidden`; without this, the flex default `min-width: auto` prevented shrinking and made the `overflow-x: auto` ineffective. |
| ui/src/pages/Dataset/dataset.page.module.scss | Adds `min-width: 0` to the dataset page's flex column container, completing the intermediate shrink-chain link between the global `PageContainer .content` and the individual `ReactionCard .container`. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): contain wide reactions so they ..."](https://github.com/open-reaction-database/ord-app/commit/e9154c0717127c11a867fb10c440a6d6a45beab4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38764318)</sub>

<!-- /greptile_comment -->