### PR TITLE
fix(ui): keep the Remove button red on hover instead of orange (#314)

### DIFF
--- a/ui/src/common/components/inputs/FileControl/FileControl.tsx
+++ b/ui/src/common/components/inputs/FileControl/FileControl.tsx
@@ -20,6 +20,7 @@ import { Buffer } from 'buffer';
 import { ActionIcon, FileInput, Flex, Input } from '@mantine/core';
 import { inputWrapperClasses } from '../../display/InputWrapper';
 import { RemoveIcon } from 'common/icons';
+import { buttonClasses } from 'common/styling';
 import type { FileControlValue } from './fileControl.types.ts';
 import { showNotification } from 'common/utils/showNotification.tsx';
 import { NotificationVariant } from 'common/types/notification.ts';
@@ -81,6 +82,7 @@ export function FileControl({ name, value, disabled, onChange, label }: Readonly
           </a>
           <ActionIcon
             aria-label="Remove file"
+            className={buttonClasses.redHover}
             onClick={handleRemoveFile}
             variant="transparent"
             color="red"

--- a/ui/src/common/styling/buttons.module.scss
+++ b/ui/src/common/styling/buttons.module.scss
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* The global transparent-button rule in index.scss forces an orange hover (--color-text-hover),
+   which overrides the red of a destructive button (e.g. "Remove") and makes it turn orange on
+   hover. Apply this to such buttons to keep them red on hover. The class is intentionally doubled
+   so it outranks the `button[data-variant='transparent']` element+attribute selector. (#314) */
+.redHover.redHover {
+  --button-hover-color: var(--mantine-color-red-8);
+  --ai-hover-color: var(--mantine-color-red-8);
+
+  &:hover {
+    color: var(--mantine-color-red-8);
+  }
+}

--- a/ui/src/common/styling/index.ts
+++ b/ui/src/common/styling/index.ts
@@ -15,3 +15,4 @@
  */
 export * from './theme';
 export { default as typographyClasses } from './typography.module.scss';
+export { default as buttonClasses } from './buttons.module.scss';

--- a/ui/src/features/datasets/DatasetHeader/DatasetHeader.tsx
+++ b/ui/src/features/datasets/DatasetHeader/DatasetHeader.tsx
@@ -39,7 +39,7 @@ import {
   selectCanDatasetBeEdited,
 } from 'store/features/canDatasetBeEdited/canDatasetBeEdited.selectors.ts';
 import { domain } from 'common/configuration.constants.ts';
-import { typographyClasses } from 'common/styling';
+import { buttonClasses, typographyClasses } from 'common/styling';
 import { ShareDataset } from '../ShareDataset/ShareDataset.tsx';
 
 interface DatasetHeaderProps {
@@ -151,6 +151,7 @@ export function DatasetHeader({ dataset }: Readonly<DatasetHeaderProps>) {
             onCancel={closeRemoveConfirm}
             target={
               <Button
+                className={buttonClasses.redHover}
                 classNames={{ section: classes.removeIcon }}
                 variant="transparent"
                 color="red"

--- a/ui/src/features/datasets/ShareDataset/ShareDatasetSidebar.tsx
+++ b/ui/src/features/datasets/ShareDataset/ShareDatasetSidebar.tsx
@@ -28,7 +28,7 @@ import classes from './shareDataset.module.scss';
 import { RemoveIcon } from 'common/icons';
 import { Counter } from 'common/components/display/Counter/Counter.tsx';
 import { KeyValueDisplay } from 'common/components/display/KeyValueDisplay/KeyValueDisplay.tsx';
-import { typographyClasses } from 'common/styling';
+import { buttonClasses, typographyClasses } from 'common/styling';
 import { clearDatasetGroupsListAction } from 'store/entities/datasets/datasets.actions.ts';
 import { ConfirmPopover } from 'common/components/interactions/ConfirmPopover/ConfirmPopover.tsx';
 import { useDisclosure } from '@mantine/hooks';
@@ -71,6 +71,7 @@ function GroupListItem({ group, onUnshareWithGroup }: Readonly<GroupsListItemPro
         onConfirm={() => onUnshareWithGroup(group.id)}
         target={
           <ActionIcon
+            className={buttonClasses.redHover}
             color="red"
             variant="transparent"
             size="sm"

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityDelete/ReactionEntityDelete.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityDelete/ReactionEntityDelete.tsx
@@ -17,6 +17,8 @@ import type { ReactionPathComponents } from 'common/types/reaction/reactionPathC
 import { ActionIcon } from '@mantine/core';
 import { RemoveIcon } from 'common/icons';
 import classes from './reactionEntityDelete.module.scss';
+import { buttonClasses } from 'common/styling';
+import clsx from 'clsx';
 import { useDisclosure } from '@mantine/hooks';
 import { ConfirmPopover } from 'common/components/interactions/ConfirmPopover/ConfirmPopover.tsx';
 import { useCallback, useRef } from 'react';
@@ -66,7 +68,7 @@ export function ReactionEntityDelete({
       target={
         <ActionIcon
           onClick={openConfirmation}
-          className={classes.icon}
+          className={clsx(classes.icon, buttonClasses.redHover)}
           variant="transparent"
           color="red"
           ref={ref}

--- a/ui/src/features/reactions/RemoveReaction/RemoveReaction.tsx
+++ b/ui/src/features/reactions/RemoveReaction/RemoveReaction.tsx
@@ -19,6 +19,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { useAppDispatch } from 'store/useAppDispatch.ts';
 import { Button } from '@mantine/core';
 import { RemoveIcon } from 'common/icons';
+import { buttonClasses } from 'common/styling';
 import { ConfirmPopover } from 'common/components/interactions/ConfirmPopover/ConfirmPopover.tsx';
 import { removeTemplate } from 'store/entities/templates/templates.thunks.ts';
 import type { ReactionId } from 'store/entities/reactions/reactions.types.ts';
@@ -54,6 +55,7 @@ export function RemoveReaction({ reactionId }: Readonly<RemoveReactionProps>) {
           variant="transparent"
           onClick={openConfirmation}
           color="red"
+          className={buttonClasses.redHover}
           leftSection={<RemoveIcon />}
         >
           Remove


### PR DESCRIPTION
## Summary

The destructive **"Remove"** buttons (reaction/template via `RemoveReaction`, dataset via `DatasetHeader`) turned **orange on hover** instead of staying red.

**Root cause:** a global rule in `index.scss` forces *every* transparent button to hover to the orange `--color-text-hover`, which overrides the button's red `color`. (Confirmed via live DOM inspection: hover color `rgb(255,141,0)` = orange.)

**Fix:** add a shared `buttonClasses.redHover` that pins the hover (and `--button-hover-color` / `--ai-hover-color`) to a darker red, and apply it to the Remove buttons. The class is intentionally *doubled* (`.redHover.redHover`) so it outranks the `button[data-variant='transparent']` element+attribute selector. Neutral transparent buttons intentionally keep their orange hover.

**Verified on the live no-auth stack** (Playwright): Remove button hover color **orange `rgb(255,141,0)` → dark red `rgb(224,49,49)`** (Mantine red-8); rest color unchanged.

## Scope
Addresses the **button-hover** part of #314. The **modal-window** styling part is explicitly marked *TBD (@yketov)* in the issue, so it's left for that design decision — **not closing #314**.

## Test plan
- [x] `tsc -b`, `vitest` (690 pass), `stylelint`, `eslint`, `prettier` all clean
- [x] Runtime-verified the hover color change on the live stack

CSS-only cosmetic change (hover color); no behavior/logic touched.

Refs #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes destructive "Remove" buttons turning orange on hover instead of staying red, caused by a global `index.scss` rule that forces all transparent buttons to hover to `--color-text-hover` (orange), overriding the red `color` set on each button.

- Adds `ui/src/common/styling/buttons.module.scss` with a `.redHover.redHover` rule (doubled to reach specificity `(0,2,0)`, beating the global `button[data-variant='transparent']` selector at `(0,1,1)`) that pins hover color to Mantine `red-8`.
- Applies `buttonClasses.redHover` to all five affected destructive buttons: `RemoveReaction`, `DatasetHeader`, `ShareDatasetSidebar`, `ReactionEntityDelete`, and `FileControl`; neutral transparent buttons intentionally keep their orange hover.

<h3>Confidence Score: 5/5</h3>

CSS-only cosmetic change with no logic or behavior modifications; safe to merge.

All five destructive buttons now receive the fix (including the three previously flagged in review), the specificity doubling trick is correctly applied and well-commented, and the change touches no application logic.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/styling/buttons.module.scss | New shared SCSS module: exports `.redHover.redHover` with a doubled-class specificity trick to override the global orange transparent-button hover with Mantine red-8; well-commented and intentional. |
| ui/src/common/styling/index.ts | Adds `buttonClasses` barrel export alongside the existing `typographyClasses` export; no issues. |
| ui/src/features/reactions/RemoveReaction/RemoveReaction.tsx | Applies `buttonClasses.redHover` to the Remove reaction Button; straightforward one-line addition. |
| ui/src/features/datasets/DatasetHeader/DatasetHeader.tsx | Applies `buttonClasses.redHover` to the dataset Remove Button; correctly imports `buttonClasses` alongside the existing `typographyClasses`. |
| ui/src/features/reactions/ReactionEntities/ReactionEntityDelete/ReactionEntityDelete.tsx | Merges `buttonClasses.redHover` with the existing `classes.icon` using `clsx`; import of `clsx` is correctly added. |
| ui/src/features/datasets/ShareDataset/ShareDatasetSidebar.tsx | Applies `buttonClasses.redHover` to the unshare-from-group ActionIcon; no issues. |
| ui/src/common/components/inputs/FileControl/FileControl.tsx | Applies `buttonClasses.redHover` to the "Remove file" ActionIcon; no issues. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): apply red hover to the remainin..."](https://github.com/open-reaction-database/ord-app/commit/c34c57849cba97ea13e092e7bd311a373102ebc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38765068)</sub>

<!-- /greptile_comment -->