### PR TITLE
fix(ui): show the dataset size in a grey pill in the Size column (#466)

### DIFF
--- a/ui/src/features/datasets/DatasetTable/datasetTable.columns.tsx
+++ b/ui/src/features/datasets/DatasetTable/datasetTable.columns.tsx
@@ -57,7 +57,9 @@ export const columns: Array<MRT_ColumnDef<Dataset>> = [
       return (
         <Tooltip label={tooltipText}>
           <div className={classes.sizeCell}>
-            <span className={classes.sizeBadge}>{row.original.reactions_count?.total}</span>
+            {row.original.reactions_count?.total != null && (
+              <span className={classes.sizeBadge}>{row.original.reactions_count.total}</span>
+            )}
             {hasInvalidReactions && (
               <div className={classes.invalidIcon}>
                 <span className={classes.countDivider}>/</span>

--- a/ui/src/features/datasets/DatasetTable/datasetTable.columns.tsx
+++ b/ui/src/features/datasets/DatasetTable/datasetTable.columns.tsx
@@ -57,7 +57,7 @@ export const columns: Array<MRT_ColumnDef<Dataset>> = [
       return (
         <Tooltip label={tooltipText}>
           <div className={classes.sizeCell}>
-            {row.original.reactions_count?.total}
+            <span className={classes.sizeBadge}>{row.original.reactions_count?.total}</span>
             {hasInvalidReactions && (
               <div className={classes.invalidIcon}>
                 <span className={classes.countDivider}>/</span>

--- a/ui/src/features/datasets/DatasetTable/datasetTable.module.scss
+++ b/ui/src/features/datasets/DatasetTable/datasetTable.module.scss
@@ -61,7 +61,7 @@
    called out in red beside it. (#466) */
 .sizeBadge {
   padding: 2px 8px;
-  border-radius: var(--mantine-spacing-xl);
+  border-radius: var(--mantine-radius-xl);
   background-color: var(--color-background-gray);
   color: var(--color-text-primary);
 }

--- a/ui/src/features/datasets/DatasetTable/datasetTable.module.scss
+++ b/ui/src/features/datasets/DatasetTable/datasetTable.module.scss
@@ -54,6 +54,16 @@
 
 .sizeCell {
   display: flex;
+  align-items: center;
+}
+
+/* The dataset size sits in a grey pill so it reads as a distinct chip, with the invalid count
+   called out in red beside it. (#466) */
+.sizeBadge {
+  padding: 2px 8px;
+  border-radius: var(--mantine-spacing-xl);
+  background-color: var(--color-background-gray);
+  color: var(--color-text-primary);
 }
 
 .countDivider {


### PR DESCRIPTION
## Summary

Completes #466. The Size column already showed the invalid count in red with the AC#3 tooltip (`Dataset contains N reactions, X are invalid`), but the **dataset size itself had no background** (AC#1/#2 call for a grey background).

Wrap the size in a grey pill (mirroring the `Counter` chip — `--color-background-gray`, rounded) so it reads as a distinct chip, with the invalid count called out in red beside it.

- AC#1 ✅ size shown with grey background
- AC#2 ✅ size grey + invalid count red
- AC#3 ✅ tooltip (already present)

## Test plan
- [x] `tsc -b`, `vitest` (datasetTable tests pass), `stylelint`, `prettier` clean
- [x] **Runtime-verified** on the live no-auth stack: the Size column now renders the total in a grey pill (`0`, `4`) with `/ ⓧ4` invalid count in red, and the tooltip on hover.

CSS + one-line JSX; additive visual change.

Closes #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a grey pill to the Size column in the dataset table, wrapping the total reaction count in a styled `<span>` with a background matching the existing `Counter` chip pattern. Both previously-raised issues (incorrect spacing token for border-radius, empty pill when `reactions_count` is absent) have been resolved in the latest commit.

- The `reactions_count?.total != null` guard correctly suppresses the badge for datasets without count data, matching pre-PR behaviour.
- `.sizeBadge` uses `--mantine-radius-xl` (a radius token) and `--color-background-gray`/`--color-text-primary` (established tokens used across 20+ files), so no new design-system dependencies are introduced.
- `align-items: center` added to `.sizeCell` improves vertical alignment of the badge and the existing invalid-count indicator.

<h3>Confidence Score: 5/5</h3>

Additive visual change with no logic regressions; the null guard and correct radius token are both in place.

The change is purely presentational — a new CSS class and a one-line JSX conditional — with no data fetching, state management, or API surface touched. The null guard prevents the previously-noted empty pill, and the CSS tokens used are well-established across the codebase. No issues remain from the earlier review thread.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/datasets/DatasetTable/datasetTable.columns.tsx | Wraps `reactions_count.total` in a `sizeBadge` span with a `!= null` guard, preventing an empty pill for datasets without count data. |
| ui/src/features/datasets/DatasetTable/datasetTable.module.scss | Adds `align-items: center` to `.sizeCell` and introduces `.sizeBadge` with correct Mantine radius token (`--mantine-radius-xl`), grey background, and primary text color. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): use radius token for size pill ..."](https://github.com/open-reaction-database/ord-app/commit/87fcb43f6b237cd6d9d61980fed4572fdfb48ad5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38809266)</sub>

<!-- /greptile_comment -->