### PR TITLE
fix(ui): show a validation-in-progress loader instead of the invalid filter while reactions validate (#622)

### DIFF
--- a/ui/src/features/reactions/ReactionList/ReactionList.test.tsx
+++ b/ui/src/features/reactions/ReactionList/ReactionList.test.tsx
@@ -14,12 +14,37 @@
  * limitations under the License.
  */
 import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
 import { renderWithProviders } from 'test/renderWithProviders.tsx';
 import { ReactionList } from './ReactionList.tsx';
+import type { AppState } from 'store/configureAppStore.ts';
+
+// Seed the active dataset's reaction counts; `none` is the count of reactions still being validated.
+const stateWithPendingCount = (none: number) =>
+  ({
+    entities: {
+      reactions: { activeDatasetId: 1 },
+      datasets: {
+        datasetsById: { 1: { id: 1, groups: [], reactions_count: { total: 4, invalid: 1, valid: 3 - none, none } } },
+      },
+    },
+  }) as unknown as Partial<AppState>;
 
 describe('ReactionList', () => {
   it('mounts without crashing', () => {
     const { container } = renderWithProviders(<ReactionList />);
     expect(container).toBeInTheDocument();
+  });
+
+  it('shows a validation-in-progress loader instead of the toggle while reactions are pending (#622)', () => {
+    renderWithProviders(<ReactionList />, { preloadedState: stateWithPendingCount(2) });
+    expect(screen.getByText('Reaction validation in progress')).toBeInTheDocument();
+    expect(screen.queryByText('Show Invalid Only')).toBeNull();
+  });
+
+  it('shows the Show Invalid Only toggle once validation has completed (#622)', () => {
+    renderWithProviders(<ReactionList />, { preloadedState: stateWithPendingCount(0) });
+    expect(screen.getByText('Show Invalid Only')).toBeInTheDocument();
+    expect(screen.queryByText('Reaction validation in progress')).toBeNull();
   });
 });

--- a/ui/src/features/reactions/ReactionList/ReactionList.tsx
+++ b/ui/src/features/reactions/ReactionList/ReactionList.tsx
@@ -15,16 +15,18 @@
  */
 import { useCallback, useMemo } from 'react';
 import { Pagination } from 'common/components/interactions/Pagination/Pagination.tsx';
-import { Flex, Paper, Title, Loader, Switch } from '@mantine/core';
+import { Flex, Paper, Title, Loader, Switch, Text } from '@mantine/core';
 import { EmptyIcon } from 'common/icons';
 import classes from './reactionsList.module.scss';
 import { useSelector } from 'react-redux';
 import {
+  selectActiveDatasetId,
   selectReactionsLoading,
   selectReactionsOrder,
   selectReactionsPagination,
   selectShowInvalidOnly,
 } from 'store/entities/reactions/reactions.selectors.ts';
+import { selectDatasetById } from 'store/entities/datasets/datasets.selectors.ts';
 import { getReactionsPage } from 'store/entities/reactions/reactions.thunks.ts';
 import { useAppDispatch } from 'store/useAppDispatch.ts';
 import { CreateReactionMenu } from './CreateReactionMenu/CreateReactionMenu.tsx';
@@ -40,6 +42,11 @@ export function ReactionList() {
   const isLoading = useSelector(selectReactionsLoading);
   const canDatasetBeEdited = useSelector(selectCanDatasetBeEdited);
   const showInvalidOnly = useSelector(selectShowInvalidOnly);
+  const activeDatasetId = useSelector(selectActiveDatasetId);
+  const dataset = useSelector(selectDatasetById(activeDatasetId));
+  // Reactions with a null validation status (still being validated server-side) are counted under
+  // `none`; while any are pending we can't trust the valid/invalid split. (#622)
+  const isValidationInProgress = (dataset?.reactions_count?.none ?? 0) > 0;
 
   const hasReactions = reactionsIds.length > 0;
 
@@ -84,13 +91,23 @@ export function ReactionList() {
             <div className={classes.counterContainer}>
               {isLoading ? <Loader size="sm" /> : <Counter amount={pagination.total} />}
             </div>
-            <Switch
-              className={classes.switcher}
-              size="sm"
-              label="Show Invalid Only"
-              checked={showInvalidOnly}
-              onChange={event => handleToggleInvalid(event.currentTarget.checked)}
-            />
+            {isValidationInProgress ? (
+              <Flex
+                align="center"
+                gap="xs"
+              >
+                <Loader size="sm" />
+                <Text size="sm">Reaction validation in progress</Text>
+              </Flex>
+            ) : (
+              <Switch
+                className={classes.switcher}
+                size="sm"
+                label="Show Invalid Only"
+                checked={showInvalidOnly}
+                onChange={event => handleToggleInvalid(event.currentTarget.checked)}
+              />
+            )}
           </Flex>
           {canDatasetBeEdited && <CreateReactionMenu />}
         </Flex>


### PR DESCRIPTION
## Summary

When a dataset's reactions are still being validated server-side they have a **null** validation status (counted under `reactions_count.none`). They were rendered as *invalid*, and toggling **"Show Invalid Only"** then showed nothing — confusing, since validation was simply still running.

**Fix:** while any reaction is pending validation (the active dataset's `reactions_count.none > 0`), replace the "Show Invalid Only" toggle in the Dataset Reactions header with a **loader + "Reaction validation in progress"** message. This also prevents toggling until validation completes (the agreed fix in the issue).

## Test plan
- [x] `tsc -b`, `vitest` (711 pass, incl. 2 new ReactionList cases: loader when `none>0`, toggle when `none=0`), `eslint`, `prettier` clean
- [x] **Runtime-verified** on the live no-auth stack: set a reaction's validation status to `null` (`reactions_count.none=1`) → the header shows the spinner + "Reaction validation in progress" in place of the toggle; restored the data after.

Closes #622.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a confusing UX issue where reactions still undergoing server-side validation (tracked as `reactions_count.none > 0`) were displayed as invalid, and toggling "Show Invalid Only" then showed an empty list. While any reactions are pending validation, the Switch is now replaced with a spinner and "Reaction validation in progress" text.

- **`ReactionList.tsx`**: Reads the active dataset's `reactions_count.none` via two new selectors (`selectActiveDatasetId`, `selectDatasetById`) and conditionally renders a `Loader` + `Text` in place of the `Switch` when `none > 0`.
- **`ReactionList.test.tsx`**: Two new targeted tests verify the loader appears when `none > 0` and the toggle reappears when `none = 0`, using a minimal preloaded Redux state.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is UI-only and purely additive; it cannot break existing reaction loading or editing flows.

The logic is a single boolean derived from an already-populated Redux field, guarded with optional chaining and a nullish-coalescing fallback so it degrades gracefully when no dataset is loaded. Both new states are covered by unit tests.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionList/ReactionList.tsx | Adds `isValidationInProgress` derived from `reactions_count.none` and conditionally renders a Loader+Text instead of the "Show Invalid Only" Switch while validation is pending. |
| ui/src/features/reactions/ReactionList/ReactionList.test.tsx | Adds two focused unit tests covering the loader-visible (`none > 0`) and toggle-visible (`none = 0`) states using a preloaded Redux store slice. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show a validation-in-progress l..."](https://github.com/open-reaction-database/ord-app/commit/160ff657f3280891b50c2ea9b014b8ba9130c58b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38811165)</sub>

<!-- /greptile_comment -->