### PR TITLE
fix(be): return 404 (not 403) for datasets/reactions a user can't access (#446)

### DIFF
--- a/ord_app/service_api/domain/auth.py
+++ b/ord_app/service_api/domain/auth.py
@@ -25,7 +25,7 @@ from ord_app.service_api.models import (
 )
 from ord_app.service_api.repositories.users import UserRepository
 from ord_app.service_api.services.auth0 import verify_access_token
-from ord_app.service_api.services.exceptions import ForbiddenError, UnauthenticatedError
+from ord_app.service_api.services.exceptions import EntityNotFoundError, ForbiddenError, UnauthenticatedError
 from ord_app.service_api.services.postgresql import get_db_session
 
 
@@ -60,16 +60,20 @@ def dataset_authorization(allowed_roles: tuple[UserRolesList, ...]):
         user: UserModel = Depends(authenticate),
         db_session: AsyncSession = Depends(get_db_session),
     ):
-        stmt = select(
-            exists().where(
-                DatasetGroupAssociationModel.dataset_id == dataset_id,
-                DatasetGroupAssociationModel.dataset_id == DatasetModel.id,
-                UserGroupsMembershipModel.group_id == DatasetGroupAssociationModel.group_id,
-                UserGroupsMembershipModel.user_id == user.id,
-                UserGroupsMembershipModel.role.in_(allowed_roles),
-            )
+        membership = (
+            DatasetGroupAssociationModel.dataset_id == dataset_id,
+            DatasetGroupAssociationModel.dataset_id == DatasetModel.id,
+            UserGroupsMembershipModel.group_id == DatasetGroupAssociationModel.group_id,
+            UserGroupsMembershipModel.user_id == user.id,
         )
-        if not await db_session.scalar(stmt):
+        # A user with no membership in any of the dataset's groups (or a dataset that doesn't exist)
+        # gets a 404 — we don't reveal whether the dataset exists. A member whose role is insufficient
+        # for the action gets a 403, which lets the UI re-gate to read-only on the next write. (#446)
+        if not await db_session.scalar(select(exists().where(*membership))):
+            raise EntityNotFoundError(detail="Dataset not found")
+        if not await db_session.scalar(
+            select(exists().where(*membership, UserGroupsMembershipModel.role.in_(allowed_roles)))
+        ):
             raise ForbiddenError(detail="Access forbidden", headers={"WWW-Authenticate": "Bearer"})
 
     return _authorize

--- a/ord_app/service_api/domain/auth.py
+++ b/ord_app/service_api/domain/auth.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from fastapi import Depends
-from sqlalchemy import exists, select
+from sqlalchemy import exists, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ord_app.service_api.models import (
@@ -66,14 +66,16 @@ def dataset_authorization(allowed_roles: tuple[UserRolesList, ...]):
             UserGroupsMembershipModel.group_id == DatasetGroupAssociationModel.group_id,
             UserGroupsMembershipModel.user_id == user.id,
         )
-        # A user with no membership in any of the dataset's groups (or a dataset that doesn't exist)
-        # gets a 404 — we don't reveal whether the dataset exists. A member whose role is insufficient
-        # for the action gets a 403, which lets the UI re-gate to read-only on the next write. (#446)
-        if not await db_session.scalar(select(exists().where(*membership))):
+        # Single query (no TOCTOU window): bool_or over the user's memberships for this dataset is
+        # None when there's no membership at all -> 404 (don't reveal whether the dataset exists),
+        # False when the user is a member but has no allowed role -> 403 (lets the UI re-gate to
+        # read-only on the next write), and True when an allowed role is present. (#446)
+        authorized = await db_session.scalar(
+            select(func.bool_or(UserGroupsMembershipModel.role.in_(allowed_roles))).where(*membership)
+        )
+        if authorized is None:
             raise EntityNotFoundError(detail="Dataset not found")
-        if not await db_session.scalar(
-            select(exists().where(*membership, UserGroupsMembershipModel.role.in_(allowed_roles)))
-        ):
+        if not authorized:
             raise ForbiddenError(detail="Access forbidden", headers={"WWW-Authenticate": "Bearer"})
 
     return _authorize

--- a/ord_app/tests/tests_datasets/test_get_datasets.py
+++ b/ord_app/tests/tests_datasets/test_get_datasets.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from faker import Faker
 from fastapi import status
 
-from ord_app.service_api.models import DatasetGroupAssociationModel, DatasetModel, ReactionModel
+from ord_app.service_api.models import DatasetGroupAssociationModel, DatasetModel, ReactionModel, UserModel
 from ord_app.tests.conftest import create_test_dataset
 
 faker = Faker()
@@ -78,6 +78,27 @@ async def test_get_dataset(api_client, mock_authenticated_user, test_db_session)
 async def test_get_dataset_by_long_id(api_client, mock_authenticated_user, test_db_session):
     response_data = api_client.get("/api/v1/datasets/1234567891011")
     assert response_data.status_code == status.HTTP_400_BAD_REQUEST
+
+
+async def test_get_nonexistent_dataset_returns_404(api_client, mock_authenticated_user, test_db_session):
+    # A dataset that doesn't exist is indistinguishable from one the user can't access: 404, not 403,
+    # so we never leak whether the dataset exists. (#446)
+    response = api_client.get("/api/v1/datasets/999999")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_get_dataset_without_membership_returns_404(api_client, mock_authenticated_user, test_db_session):
+    # A user with no membership in any of the dataset's groups gets 404 (not 403) — no existence leak. (#446)
+    dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
+    _, set_user_auth, _ = mock_authenticated_user
+    outsider = UserModel(email=faker.email(), external_id=str(faker.uuid4()), auth0_id=str(faker.uuid4()))
+    test_db_session.add(outsider)
+    await test_db_session.commit()
+    await test_db_session.refresh(outsider)
+    set_user_auth(outsider)
+
+    response = api_client.get(f"/api/v1/datasets/{dataset.id}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 async def test_download_dataset(api_client, mock_authenticated_user, test_db_session):

--- a/ord_app/tests/tests_datasets/test_share_dataset.py
+++ b/ord_app/tests/tests_datasets/test_share_dataset.py
@@ -95,8 +95,10 @@ async def test_share_and_unshare_dataset(api_client, mock_authenticated_user, te
     set_user_auth(secondary_user)
     secondary_group_datasets = api_client.get(f"/api/v1/groups/{secondary_group.id}/datasets").raise_for_status().json()
     assert secondary_group_datasets["total"] == 0
+    # Having been unshared, the secondary user has lost access: a 404 (not 403) so we don't reveal
+    # that the dataset still exists. (#446)
     secondary_user_response = api_client.get(f"/api/v1/datasets/{primary_dataset.id}")
-    assert status.HTTP_403_FORBIDDEN == secondary_user_response.status_code
+    assert status.HTTP_404_NOT_FOUND == secondary_user_response.status_code
 
 
 async def test_share_dataset_to_the_same_group(api_client, mock_authenticated_user, test_db_session):


### PR DESCRIPTION
## Summary

`dataset_authorization` conflated **"no access / doesn't exist"** with **"insufficient role"**, returning **403 for both** — which leaks the existence of datasets a user has no membership in (opening an unknown id, or one that was unshared, returned 403, revealing it exists).

**Fix:** split the check —
- **No membership** in any of the dataset's groups (or the dataset doesn't exist) → **404** (no existence leak).
- **Member but insufficient role** for the action → **403** (unchanged).

Keeping insufficient-role as **403 preserves the UI re-gate-on-write behavior from #770** (just merged). Reactions share `dataset_authorization`, so datasets and reactions are now consistent. Malformed/oversized ids already return **400** (existing handler + `test_get_dataset_by_long_id`).

## Reconciliation with #770 (important)
| Case | Before | After |
|---|---|---|
| GET unknown / unshared dataset (no membership) | 403 (leaks existence) | **404** |
| GET dataset as a member | 200 | 200 |
| Write (PATCH/DELETE) as a viewer (member, insufficient role) | 403 | **403** (re-gate preserved) |
| Malformed / oversized id | 400 | 400 |

## Test plan
- [x] `ruff`, `ruff-format`, `pytype` clean; **75 backend tests pass**
- [x] Added `test_get_nonexistent_dataset_returns_404` and `test_get_dataset_without_membership_returns_404`
- [x] Updated `test_share_and_unshare_dataset`: after unshare, the secondary user's read now correctly returns **404** (was the leaky 403)
- [x] **Runtime-verified** on the live stack: unknown/unshared dataset & reaction → 404; member read → 200; viewer write → 403

**Held for review** — this is an auth/existence-leak semantics change that interacts with the freshly-merged #770, so it warrants your eyes rather than auto-merge.

Closes #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an information-disclosure bug where `dataset_authorization` returned 403 for both "no membership / dataset doesn't exist" and "member with insufficient role", leaking the existence of datasets the caller has no access to. The fix collapses the previous two-query approach into a single `bool_or` aggregate that atomically distinguishes the three cases without a TOCTOU window.

- **`auth.py`**: `SELECT bool_or(role IN allowed_roles) … WHERE membership_conditions` returns `None` (no rows → 404), `False` (rows but wrong role → 403), or `True` (authorized). The `exists` import is retained for `group_authorization`.
- **Tests**: two new tests assert that a nonexistent dataset and an outsider-user both produce 404; the existing unshare test is updated from 403 to 404.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the atomic bool_or query closes both the existence-leak and the TOCTOU window in one well-tested change.

The auth logic is narrowly scoped: one aggregate query replaces two sequential queries, the three return values map cleanly to the three HTTP outcomes, and the tests cover all three branches. No pre-existing behaviour (member-reads, viewer-write 403, malformed-id 400) is disturbed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_app/service_api/domain/auth.py | Replaces two-query existence+role check with a single bool_or aggregate that atomically maps NULL→404, False→403, True→authorized, eliminating the TOCTOU window from the previous thread. |
| ord_app/tests/tests_datasets/test_get_datasets.py | Adds two new tests covering nonexistent dataset (999999 → 404) and no-membership outsider (404); imports UserModel accordingly. |
| ord_app/tests/tests_datasets/test_share_dataset.py | Updates unshare assertion from 403 to 404 with an explanatory comment; no logic changes. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ord_app/service_api/domain/auth.py`, line 38-53 ([link](https://github.com/open-reaction-database/ord-app/blob/3e90ea59b5214dcd6eabffcdd2b25b18f01b9436/ord_app/service_api/domain/auth.py#L38-L53)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`group_authorization` still conflates no-membership with insufficient-role**

   `group_authorization` raises a single `ForbiddenError` (403) whether the group doesn't exist, the user has no membership, or the user's role is insufficient — the same existence-leaking pattern this PR fixes for datasets. Group IDs may be less sensitive than dataset IDs, but if consistent behaviour is desired, the same two-query split would apply here. Out of scope for this PR, but worth tracking.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(be): collapse dataset\_authorization ..."](https://github.com/open-reaction-database/ord-app/commit/492c1e22fd967c51f2dcd757fdf16e437db81ca9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38812467)</sub>

<!-- /greptile_comment -->