### PR TITLE
fix(ui): refresh the datasets list on return so deleted/lost-access datasets disappear (#584)

### DIFF
--- a/ui/src/pages/DatasetsList/DatasetsList.page.test.tsx
+++ b/ui/src/pages/DatasetsList/DatasetsList.page.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderWithMantine } from 'test/renderWithMantine.tsx';
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  getInitialDatasetsList: vi.fn((groupId: unknown) => ({ type: 'datasets/getInitial', payload: groupId })),
+  activeGroupId: 7 as number | null,
+}));
+vi.mock('store/useAppDispatch.ts', () => ({ useAppDispatch: () => mocks.dispatch }));
+vi.mock('react-redux', () => ({ useSelector: (sel: (s: unknown) => unknown) => sel(undefined) }));
+vi.mock('store/features/groups/groups.selectors.ts', () => ({ selectActiveGroupId: () => mocks.activeGroupId }));
+vi.mock('store/entities/datasets/datasets.thunks.ts', () => ({ getInitialDatasetsList: mocks.getInitialDatasetsList }));
+// Stub the heavy children — the test only covers the page's fetch-on-mount behaviour.
+vi.mock('common/components/PageContainer/PageContainer.tsx', () => ({
+  PageContainer: ({ children }: Readonly<{ children: React.ReactNode }>) => <div>{children}</div>,
+}));
+vi.mock('features/groups', () => ({ GroupsSidebar: () => null }));
+vi.mock('features/datasets', () => ({ DatasetTable: () => null }));
+vi.mock('./DatasetsListTopActions/DatasetsListTopActions.tsx', () => ({ DatasetsListTopActions: () => null }));
+vi.mock('features/templates/EntitiesMenu/EntitiesMenu.tsx', () => ({ EntitiesMenu: () => null }));
+
+import { DatasetsListPage } from './DatasetsList.page.tsx';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.activeGroupId = 7;
+});
+
+describe('DatasetsListPage', () => {
+  it('refetches the datasets list for the active group on mount (#584)', () => {
+    renderWithMantine(<DatasetsListPage />);
+    expect(mocks.getInitialDatasetsList).toHaveBeenCalledWith(7);
+    expect(mocks.dispatch).toHaveBeenCalledWith({ type: 'datasets/getInitial', payload: 7 });
+  });
+});

--- a/ui/src/pages/DatasetsList/DatasetsList.page.tsx
+++ b/ui/src/pages/DatasetsList/DatasetsList.page.tsx
@@ -19,8 +19,21 @@ import { DatasetTable } from 'features/datasets';
 import { PageContainer } from 'common/components/PageContainer/PageContainer.tsx';
 import { DatasetsListTopActions } from './DatasetsListTopActions/DatasetsListTopActions.tsx';
 import { EntitiesMenu } from 'features/templates/EntitiesMenu/EntitiesMenu.tsx';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useAppDispatch } from 'store/useAppDispatch.ts';
+import { getInitialDatasetsList } from 'store/entities/datasets/datasets.thunks.ts';
+import { selectActiveGroupId } from 'store/features/groups/groups.selectors.ts';
 
 export function DatasetsListPage() {
+  const dispatch = useAppDispatch();
+  const activeGroupId = useSelector(selectActiveGroupId);
+  // Refetch whenever the list view is shown (and on group switch) so a dataset removed by another
+  // user — or after losing access — disappears on return instead of lingering stale. (#584)
+  useEffect(() => {
+    dispatch(getInitialDatasetsList(activeGroupId));
+  }, [activeGroupId, dispatch]);
+
   return (
     <PageContainer breadcrumbs={[{ title: 'Datasets', path: '~/' }]}>
       <Flex

--- a/ui/src/routes/DatasetsList/DatasetsList.route.tsx
+++ b/ui/src/routes/DatasetsList/DatasetsList.route.tsx
@@ -16,19 +16,10 @@
 import { Route, Switch } from 'wouter';
 import { DatasetRoute } from './Dataset/Dataset.route.tsx';
 import { DatasetsListPage } from 'pages/DatasetsList/DatasetsList.page.tsx';
-import { useEffect } from 'react';
-import { getInitialDatasetsList } from 'store/entities/datasets/datasets.thunks.ts';
-import { useAppDispatch } from 'store/useAppDispatch.ts';
-import { useSelector } from 'react-redux';
-import { selectActiveGroupId } from 'store/features/groups/groups.selectors.ts';
 
 export function DatasetsListRoute() {
-  const dispatch = useAppDispatch();
-  const activeGroupId = useSelector(selectActiveGroupId);
-  useEffect(() => {
-    dispatch(getInitialDatasetsList(activeGroupId));
-  }, [activeGroupId, dispatch]);
-
+  // The datasets list is fetched by DatasetsListPage on mount (and on group switch), so navigating
+  // back to the list always gets a fresh list rather than a stale cached one. (#584)
   return (
     <Switch>
       <Route


### PR DESCRIPTION
## Summary

The datasets list was fetched by the **parent route** (`DatasetsListRoute`), which stays mounted while you navigate between the list (`/`) and a dataset (`:datasetId`) — so it only refetched on a **group switch**. Returning to the list after a dataset was **deleted by another user** (or after losing access) left the stale dataset in the list.

**Fix:** move the fetch into `DatasetsListPage` so it runs whenever the **list view mounts** (and on group switch). Navigating back always gets a fresh list. Removed the now-redundant parent-route fetch → single fetch, no double-load. This also pairs with #446 (the deleted dataset now 404s when clicked) and the issue's note that it "works the same in case of removing a user from the group."

## Test plan
- [x] `tsc -b`, `vitest` (712 pass, incl. a new page test asserting the fetch-on-mount), `eslint`, `prettier` clean
- [x] **Runtime-verified** on the live stack: list showing a dataset → deleted out-of-band (HTTP 200) → navigate back via breadcrumb → the dataset is **gone** (`before: shown, after: gone`).

Closes #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves the datasets-list fetch from `DatasetsListRoute` (which stays mounted during dataset navigation) into `DatasetsListPage` (which unmounts/remounts on every navigation back to `/`), so stale entries disappear immediately on return. Removes the now-duplicate dispatch in the parent route, eliminating a double-fetch risk.

- `DatasetsList.page.tsx`: adds `useEffect` dispatching `getInitialDatasetsList(activeGroupId)` on mount and on group switch.
- `DatasetsList.route.tsx`: strips the old `useEffect` + Redux wiring that was the root cause of the stale-list bug.
- `DatasetsList.page.test.tsx`: new Vitest unit test asserting the fetch fires on mount with the correct group ID.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward relocation of a single useEffect, verified runtime and by a new unit test.

The fetch logic is identical to what was removed from the parent route; only its home changed. The dependency array is correct, the thunk already handles a null groupId gracefully, and the PR description confirms runtime verification. The new test covers the primary scenario. The only gap is a missing null-groupId test case in the new test file, which does not affect correctness.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/pages/DatasetsList/DatasetsList.page.tsx | Adds a useEffect that dispatches getInitialDatasetsList on mount and on group change, moving the fetch from the persistent parent route into the page component so it re-runs on every navigation back to the list. |
| ui/src/routes/DatasetsList/DatasetsList.route.tsx | Removes the now-redundant fetch logic (dispatch/useEffect/selectors) that previously lived in the parent route; leaves only the Switch/Route structure with an explanatory comment. |
| ui/src/pages/DatasetsList/DatasetsList.page.test.tsx | New unit test asserting that DatasetsListPage dispatches getInitialDatasetsList with the active group ID on mount; only covers the happy path (activeGroupId = 7), missing a null/unauthenticated-group case. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): refresh the datasets list on re..."](https://github.com/open-reaction-database/ord-app/commit/b8f99e77f9fa61d0c034e2e870f955ce2671264e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38813268)</sub>

<!-- /greptile_comment -->