### PR TITLE
fix(be): cap cumulative reaction file attachments at 10 MB (#543)

### DIFF
--- a/ord_app/service_api/domain/reactions.py
+++ b/ord_app/service_api/domain/reactions.py
@@ -40,8 +40,10 @@ from ord_app.service_api.services.exceptions import (
     UnprocessableEntityError,
 )
 from ord_app.service_api.services.pb_utils import (
+    MAX_REACTION_ATTACHMENTS_SIZE,
     async_validate_pb_reaction,
     load_message,
+    total_attachment_size,
     write_message,
 )
 from ord_app.service_api.services.postgresql import get_db_session
@@ -173,6 +175,11 @@ class ReactionsUseCase:
 
     async def update(self, dataset_id: int, reaction_id: int, payload: ReactionUpdateSchema):
         pb_reaction = cast(Reaction, await run_in_threadpool(load_message, payload.binpb, Reaction, "binpb"))
+        if total_attachment_size(pb_reaction) > MAX_REACTION_ATTACHMENTS_SIZE:
+            raise UnprocessableEntityError(
+                f"Total file attachment size for a reaction must not exceed "
+                f"{MAX_REACTION_ATTACHMENTS_SIZE // (1024 * 1024)} MB"
+            )
         pb_reaction_id = (pb_reaction.reaction_id or "").strip()
         if len(pb_reaction_id) > MAX_CRITICAL_FIELD_LENGTH:
             raise UnprocessableEntityError(

--- a/ord_app/service_api/domain/reactions.py
+++ b/ord_app/service_api/domain/reactions.py
@@ -84,7 +84,17 @@ class ReactionsUseCase:
         self.reaction_repo = ReactionsRepository(db)
         self.dataset_repo = DatasetsRepository(db)
 
+    @staticmethod
+    def _enforce_attachment_limit(pb_reaction: Reaction):
+        """Reject reactions whose cumulative file attachments exceed the size cap."""
+        if total_attachment_size(pb_reaction) > MAX_REACTION_ATTACHMENTS_SIZE:
+            raise UnprocessableEntityError(
+                f"Total file attachment size for a reaction must not exceed "
+                f"{MAX_REACTION_ATTACHMENTS_SIZE // (1024 * 1024)} MB"
+            )
+
     async def _create_reaction(self, dataset_id: int, pb_reaction: Reaction):
+        self._enforce_attachment_limit(pb_reaction)
         # validate reaction id
         if len(pb_reaction.reaction_id) > MAX_CRITICAL_FIELD_LENGTH:
             raise UnprocessableEntityError(
@@ -175,11 +185,7 @@ class ReactionsUseCase:
 
     async def update(self, dataset_id: int, reaction_id: int, payload: ReactionUpdateSchema):
         pb_reaction = cast(Reaction, await run_in_threadpool(load_message, payload.binpb, Reaction, "binpb"))
-        if total_attachment_size(pb_reaction) > MAX_REACTION_ATTACHMENTS_SIZE:
-            raise UnprocessableEntityError(
-                f"Total file attachment size for a reaction must not exceed "
-                f"{MAX_REACTION_ATTACHMENTS_SIZE // (1024 * 1024)} MB"
-            )
+        self._enforce_attachment_limit(pb_reaction)
         pb_reaction_id = (pb_reaction.reaction_id or "").strip()
         if len(pb_reaction_id) > MAX_CRITICAL_FIELD_LENGTH:
             raise UnprocessableEntityError(

--- a/ord_app/service_api/services/pb_utils.py
+++ b/ord_app/service_api/services/pb_utils.py
@@ -18,6 +18,7 @@ from typing import TypeVar
 
 from fastapi import HTTPException, UploadFile, status
 from google.protobuf import json_format, text_format
+from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.message import Message
 from ord_schema.proto.dataset_pb2 import Dataset
 from ord_schema.proto.reaction_pb2 import Reaction
@@ -27,6 +28,40 @@ from starlette.concurrency import run_in_threadpool
 # Constrained to the proto messages this module serializes; load_message returns
 # the same concrete type passed via message_type rather than the bare union.
 MessageT = TypeVar("MessageT", Dataset, Reaction)
+
+# Maximum cumulative size of uploaded file attachments (Data.bytes_value) in a single reaction. (#543)
+MAX_REACTION_ATTACHMENTS_SIZE = 10 * 1024 * 1024
+
+
+def total_attachment_size(message: Message) -> int:
+    """Sum the byte length of every Data.bytes_value attachment anywhere in a proto message.
+
+    Walks the message tree (including repeated and map fields) so attachments nested in observations,
+    analyses, compound features, etc. are all counted. Only set fields are visited, so empty
+    bytes_value fields contribute nothing.
+
+    Args:
+        message: The protobuf message to inspect (typically a Reaction).
+
+    Returns:
+        The total number of bytes across all populated ``bytes_value`` fields.
+    """
+    total = 0
+    for field, value in message.ListFields():
+        if field.name == "bytes_value" and field.type == FieldDescriptor.TYPE_BYTES:
+            total += len(value)
+        elif field.type == FieldDescriptor.TYPE_MESSAGE:
+            if field.label != FieldDescriptor.LABEL_REPEATED:
+                total += total_attachment_size(value)
+            elif field.message_type.GetOptions().map_entry:
+                if field.message_type.fields_by_name["value"].type == FieldDescriptor.TYPE_MESSAGE:
+                    for item in value.values():
+                        total += total_attachment_size(item)
+            else:
+                for item in value:
+                    total += total_attachment_size(item)
+    return total
+
 
 MAP_FILE_EXT_TO_PB_KIND = {
     ".json": "json",

--- a/ord_app/service_api/services/pb_utils.py
+++ b/ord_app/service_api/services/pb_utils.py
@@ -54,9 +54,14 @@ def total_attachment_size(message: Message) -> int:
             if field.label != FieldDescriptor.LABEL_REPEATED:
                 total += total_attachment_size(value)
             elif field.message_type.GetOptions().map_entry:
-                if field.message_type.fields_by_name["value"].type == FieldDescriptor.TYPE_MESSAGE:
+                value_type = field.message_type.fields_by_name["value"].type
+                if value_type == FieldDescriptor.TYPE_MESSAGE:
                     for item in value.values():
                         total += total_attachment_size(item)
+                elif value_type == FieldDescriptor.TYPE_BYTES:
+                    # Defensive: no map<string, bytes> exists in the Reaction schema today, but count
+                    # it toward the cap if one is ever added so attachments there can't slip past.
+                    total += sum(len(item) for item in value.values())
             else:
                 for item in value:
                     total += total_attachment_size(item)

--- a/ord_app/tests/tests_reactions/test_create_reactions.py
+++ b/ord_app/tests/tests_reactions/test_create_reactions.py
@@ -114,3 +114,31 @@ async def test_create_reaction_with_character_limitations(api_client, mock_authe
 
     response = api_client.post(f"/api/v1/datasets/{dataset.id}/reactions", json=payload)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+async def test_create_reaction_rejects_oversized_attachments(api_client, mock_authenticated_user, test_db_session):
+    # The cumulative attachment cap is enforced on the POST create path too. (#543)
+    dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
+    pb_reaction = Reaction(reaction_id="test")
+    pb_reaction.observations.add().image.bytes_value = b"x" * (10 * 1024 * 1024 + 1)
+
+    payload = {"binpb": b64encode(pb_reaction.SerializeToString()).decode()}
+    response = api_client.post(f"/api/v1/datasets/{dataset.id}/reactions", json=payload)
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "10 MB" in response.json()["detail"]
+
+
+async def test_upload_reaction_rejects_oversized_attachments(api_client, mock_authenticated_user, test_db_session):
+    # The cumulative attachment cap is enforced on the upload path too. (#543)
+    dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
+    pb_reaction = Reaction(reaction_id="test")
+    pb_reaction.observations.add().image.bytes_value = b"x" * (10 * 1024 * 1024 + 1)
+
+    response = api_client.post(
+        f"/api/v1/datasets/{dataset.id}/reactions/upload",
+        files={"file": ("reaction.pb", pb_reaction.SerializeToString())},
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "10 MB" in response.json()["detail"]

--- a/ord_app/tests/tests_reactions/test_update_reactions.py
+++ b/ord_app/tests/tests_reactions/test_update_reactions.py
@@ -47,6 +47,30 @@ async def test_update_nonexistent_reaction(api_client, mock_authenticated_user, 
     assert status.HTTP_404_NOT_FOUND == response_data.status_code
 
 
+async def test_update_reaction_rejects_oversized_attachments(api_client, mock_authenticated_user, test_db_session):
+    # Cumulative file attachments over 10 MB are rejected at save time. (#543)
+    dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
+    reaction = await create_test_reaction(test_db_session, mock_authenticated_user, dataset)
+
+    pb_reaction = Reaction(reaction_id=faker.uuid4())
+    pb_reaction.observations.add().image.bytes_value = b"x" * (10 * 1024 * 1024 + 1)
+    payload = {"binpb": b64encode(pb_reaction.SerializeToString()).decode()}
+    response = api_client.patch(f"/api/v1/datasets/{dataset.id}/reactions/{reaction.id}", json=payload)
+
+    assert status.HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
+    assert "10 MB" in response.json()["detail"]
+
+
+async def test_update_reaction_allows_attachments_under_limit(api_client, mock_authenticated_user, test_db_session):
+    dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
+    reaction = await create_test_reaction(test_db_session, mock_authenticated_user, dataset)
+
+    pb_reaction = Reaction(reaction_id=faker.uuid4())
+    pb_reaction.observations.add().image.bytes_value = b"x" * (1024 * 1024)  # 1 MB, well under the 10 MB cap
+    payload = {"binpb": b64encode(pb_reaction.SerializeToString()).decode()}
+    api_client.patch(f"/api/v1/datasets/{dataset.id}/reactions/{reaction.id}", json=payload).raise_for_status()
+
+
 async def test_update_reaction_with_duplicate_reaction_id(api_client, mock_authenticated_user, test_db_session):
     dataset = await create_test_dataset(test_db_session, mock_authenticated_user)
     reaction = await create_test_reaction(test_db_session, mock_authenticated_user, dataset)


### PR DESCRIPTION
## Summary

Per-file data attachments were already capped at **1 MB** on the frontend (`FileControl`), but nothing stopped many sub-1 MB files from summing past **10 MB** for a single reaction.

Per your call (BE owner): enforce the cumulative cap at **save time** — the authoritative chokepoint. On reaction `PATCH`, sum every `Data.bytes_value` attachment in the decoded reaction (recursively, across observations / analyses / compound features and other nested + map fields) and reject with **422** if the total exceeds 10 MB.

- New `total_attachment_size(message)` + `MAX_REACTION_ATTACHMENTS_SIZE` in `pb_utils.py`.
- Check added in `ReactionsUseCase.update`, alongside the existing reaction-id-length guard.
- The FE surfaces the 422 `detail` ("Total file attachment size for a reaction must not exceed 10 MB") via the existing error-notification path.

## Test plan
- [x] `ruff`, `ruff-format`, `pytype` clean; **77 backend tests pass**
- [x] New tests: oversized attachments → **422** (`"10 MB"` in detail); 1 MB attachment → saves normally. Helper unit-verified to sum singular/repeated/map attachments and ignore non-file `Data` (`string_value`).

**Held for your review** (BE write-path behavioral change). Closes #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces a 10 MB cumulative cap on `Data.bytes_value` file attachments per reaction at all backend write paths. The previous review's concern about the create and upload paths being unguarded has been resolved by moving `_enforce_attachment_limit` into the shared `_create_reaction` helper.

- `pb_utils.py` introduces `total_attachment_size`, a recursive proto walker that correctly handles singular, repeated-message, map-message, and (defensively) map-bytes fields; only `bytes_value` fields are counted, so `string_value` and other `Data` variants are ignored.
- `reactions.py` wires the check into `_create_reaction` (covering POST create, upload, and create-from-scratch) and `update` (covering PATCH), returning a 422 with a human-readable message on overflow.
- Tests validate rejection (10 MB + 1 byte → 422 with `"10 MB"` in the detail) and acceptance (1 MB → 2xx) on all three write paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the cap is enforced uniformly across all write paths with no gaps, and the proto walker logic is correct for the current ORD schema.

All three write paths (create, upload, update) now call `_enforce_attachment_limit` before persisting. The `total_attachment_size` walker handles singular, repeated, and map proto fields correctly, and the `Data.bytes_value` oneof field is always singular so the `len(value)` call always measures bytes, not element count. Tests cover rejection and acceptance on every changed path.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_app/service_api/services/pb_utils.py | Adds `MAX_REACTION_ATTACHMENTS_SIZE` constant and `total_attachment_size` recursive walker; handles singular, repeated, map-message, and defensive map-bytes fields correctly. |
| ord_app/service_api/domain/reactions.py | Adds `_enforce_attachment_limit` static method and calls it at the top of `_create_reaction`, covering all three write paths (create, upload, create_from_scratch) and also in `update`; no enforcement gaps remain. |
| ord_app/tests/tests_reactions/test_update_reactions.py | New tests cover oversized rejection (422 + "10 MB" detail) and under-limit acceptance on the PATCH path; `raise_for_status()` pattern is appropriate for the happy-path assertion. |
| ord_app/tests/tests_reactions/test_create_reactions.py | New tests cover oversized rejection on both the POST create and upload paths; consistent with the update-path test pattern. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `ord_app/service_api/domain/reactions.py`, line 109-122 ([link](https://github.com/open-reaction-database/ord-app/blob/e6ee4618cc97508445773cd5ff1ba970490a33cb/ord_app/service_api/domain/reactions.py#L109-L122)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Attachment size check missing from `create` and `upload` paths**

   The 10 MB cumulative attachment cap is enforced only in `update`, but both `create` (line 109) and `upload` (line 139) write a reaction without checking `total_attachment_size`. A user can bypass the limit entirely by uploading or creating a new reaction with oversized attachments — the check at save time only guards PATCH, not POST paths.

2. `ord_app/service_api/domain/reactions.py`, line 87-107 ([link](https://github.com/open-reaction-database/ord-app/blob/036fd108c1705fe96fc02da7a1eb2176355b8cb8/ord_app/service_api/domain/reactions.py#L87-L107)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Attachment size cap not enforced on create or upload paths**

   `_create_reaction` — the shared sink for both `create` (line 109) and `upload` (line 139) — saves the reaction without calling `total_attachment_size`. A user can POST a brand-new reaction or upload a file containing a `Data.bytes_value` larger than 10 MB and it will be persisted, bypassing the cap entirely. Adding the same guard at the top of `_create_reaction` (before the reaction-id length check) would enforce the limit for all three write paths with a single change.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(be): enforce the attachment cap on a..."](https://github.com/open-reaction-database/ord-app/commit/c8f4ac6bde89fd158ab6ea2f1a476483224a41a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38815088)</sub>

<!-- /greptile_comment -->