### PR TITLE
fix(be): include the user's role in single-group endpoint responses (#569)

### DIFF
--- a/ord_app/service_api/domain/groups.py
+++ b/ord_app/service_api/domain/groups.py
@@ -33,16 +33,25 @@ class GroupUseCases:
 
     async def create(self, payload: GroupCreateSchema):
         group = await self.group_repository.create(self.current_user.id, payload.model_dump(exclude_unset=True))
-        return group
+        # The creator is added as the group's admin (see GroupRepository.create). (#569)
+        return {"id": group.id, "name": group.name, "role": "admin"}
 
     async def get(self, group_id: int):
-        return await self.group_repository.get(id=group_id)
+        group = await self.group_repository.get(id=group_id)
+        if group is None:
+            raise EntityNotFoundError(f"Group {group_id} not found")
+        role = await self.group_repository.get_user_role(self.current_user.id, group_id)
+        return {"id": group.id, "name": group.name, "role": role}
 
     async def user_groups(self):
         return await self.group_repository.get_user_groups(self.current_user.id)
 
     async def update(self, group_id: int, payload: GroupCreateSchema):
-        return await self.group_repository.update(payload.model_dump(), id=group_id)
+        group = await self.group_repository.update(payload.model_dump(), id=group_id)
+        if group is None:
+            raise EntityNotFoundError(f"Group {group_id} not found")
+        role = await self.group_repository.get_user_role(self.current_user.id, group_id)
+        return {"id": group.id, "name": group.name, "role": role}
 
     async def delete(self, group_id: int):
         await self.group_repository.delete(id=group_id)

--- a/ord_app/service_api/repositories/groups.py
+++ b/ord_app/service_api/repositories/groups.py
@@ -19,7 +19,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from ord_app.service_api.models import GroupModel, UserGroupsMembershipModel
+from ord_app.service_api.models import GroupModel, UserGroupsMembershipModel, UserRolesList
 from ord_app.service_api.repositories.base import BaseRepository
 
 
@@ -48,6 +48,13 @@ class GroupRepository(BaseRepository[GroupModel]):
         rows = (await self.db.execute(stmt)).all()
         groups = [dict(id=group.id, name=group.name, role=user_group.role) for group, user_group in rows]
         return groups
+
+    async def get_user_role(self, user_id: int, group_id: int) -> UserRolesList | None:
+        stmt = select(UserGroupsMembershipModel.role).where(
+            UserGroupsMembershipModel.user_id == user_id,
+            UserGroupsMembershipModel.group_id == group_id,
+        )
+        return await self.db.scalar(stmt)
 
 
 class GroupMembersRepository:

--- a/ord_app/service_api/resources/v1/group.py
+++ b/ord_app/service_api/resources/v1/group.py
@@ -26,7 +26,6 @@ from ord_app.service_api.schemas.groups import (
     GroupAddMemberSchema,
     GroupCreateSchema,
     GroupMemberResponseSchema,
-    GroupResponseSchema,
     GroupUpdateMemberSchema,
     GroupUserResponseSchema,
 )
@@ -34,7 +33,7 @@ from ord_app.service_api.schemas.groups import (
 router = APIRouter(tags=["group"], prefix="/groups")
 
 
-@router.post("", response_model=GroupResponseSchema, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=GroupUserResponseSchema, status_code=status.HTTP_201_CREATED)
 async def create_group(payload: GroupCreateSchema, use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]):
     return await use_case.create(payload)
 
@@ -47,7 +46,7 @@ async def list_current_user_groups(use_case: Annotated[GroupUseCases, Depends(ge
 
 @router.get(
     "/{group_id}",
-    response_model=GroupResponseSchema,
+    response_model=GroupUserResponseSchema,
     dependencies=[Depends(group_authorization(("admin", "editor", "viewer")))],
 )
 async def get_group(group_id: int, use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]):
@@ -57,7 +56,7 @@ async def get_group(group_id: int, use_case: Annotated[GroupUseCases, Depends(ge
 @router.patch(
     "/{group_id}",
     status_code=status.HTTP_201_CREATED,
-    response_model=GroupResponseSchema,
+    response_model=GroupUserResponseSchema,
     dependencies=[Depends(group_authorization(("admin",)))],
 )
 async def update_group(

--- a/ord_app/tests/test_groups/test_create_groups.py
+++ b/ord_app/tests/test_groups/test_create_groups.py
@@ -23,6 +23,8 @@ async def test_create_group(api_client, mock_authenticated_user):
     payload = {"name": faker.company()}
     response_data = api_client.post("/api/v1/groups", json=payload).raise_for_status().json()
     assert payload["name"] == response_data["name"]
+    # The creator is the group's admin; the response includes their role. (#569)
+    assert response_data["role"] == "admin"
 
 
 async def test_create_group_with_character_limitations(api_client, mock_authenticated_user):

--- a/ord_app/tests/test_groups/test_get_groups.py
+++ b/ord_app/tests/test_groups/test_get_groups.py
@@ -19,6 +19,7 @@ async def test_get_group_members(api_client, mock_authenticated_user):
     response_data = api_client.get(f"/api/v1/groups/{group.id}/members").raise_for_status().json()[0]
 
     assert response_data["user"]["id"] == user.id
+    assert response_data["role"] == "admin"
 
 
 async def test_get_group_returns_role(api_client, mock_authenticated_user):
@@ -27,5 +28,4 @@ async def test_get_group_returns_role(api_client, mock_authenticated_user):
     response_data = api_client.get(f"/api/v1/groups/{group.id}").raise_for_status().json()
     assert response_data["id"] == group.id
     assert response_data["name"] == group.name
-    assert response_data["role"] == "admin"
     assert response_data["role"] == "admin"

--- a/ord_app/tests/test_groups/test_get_groups.py
+++ b/ord_app/tests/test_groups/test_get_groups.py
@@ -19,4 +19,13 @@ async def test_get_group_members(api_client, mock_authenticated_user):
     response_data = api_client.get(f"/api/v1/groups/{group.id}/members").raise_for_status().json()[0]
 
     assert response_data["user"]["id"] == user.id
+
+
+async def test_get_group_returns_role(api_client, mock_authenticated_user):
+    # GET /groups/{id} returns the current user's role for the group. (#569)
+    *_, group = mock_authenticated_user
+    response_data = api_client.get(f"/api/v1/groups/{group.id}").raise_for_status().json()
+    assert response_data["id"] == group.id
+    assert response_data["name"] == group.name
+    assert response_data["role"] == "admin"
     assert response_data["role"] == "admin"

--- a/ord_app/tests/test_groups/test_update_group.py
+++ b/ord_app/tests/test_groups/test_update_group.py
@@ -21,3 +21,4 @@ async def test_update_group(api_client, mock_authenticated_user):
     payload = {"name": faker.company()}
     response_data = api_client.patch(f"/api/v1/groups/{group.id}", json=payload).raise_for_status().json()
     assert payload["name"] == response_data["name"]
+    assert response_data["role"] == "admin"  # (#569)


### PR DESCRIPTION
## Summary

`POST /groups`, `GET /groups/{id}`, and `PATCH /groups/{id}` returned `GroupResponseSchema` (id, name) with **no role**, unlike the list endpoint (`GET /groups`) which already returns it. #569 asks for role on these endpoints.

Switch the three to `GroupUserResponseSchema` and populate the role in the use case:
- **create** → the creator is the group's admin (`GroupRepository.create` adds them as admin), so `role="admin"`.
- **get / update** → look up the current user's membership role via a new `GroupRepository.get_user_role(user_id, group_id)` helper (with a not-found guard).

Additive only — existing fields are unchanged; the response just gains `role`.

## Test plan
- [x] `ruff`, `ruff-format`, `pytype` clean; **76 backend tests pass**
- [x] `test_create_group` / `test_update_group` now assert `role == "admin"`; added `test_get_group_returns_role` for `GET /groups/{id}`.

Closes #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `role` to the responses of `POST /groups`, `GET /groups/{id}`, and `PATCH /groups/{id}`, which previously returned only `id` and `name`. The `create` path hardcodes `"admin"` (matching the repository invariant that the creator is always added as admin), while `get` and `update` fetch the role via a new `GroupRepository.get_user_role` helper.

- Switches the three endpoint `response_model` declarations from `GroupResponseSchema` to `GroupUserResponseSchema` and wires up role population in `GroupUseCases`.
- Adds a `get_user_role(user_id, group_id)` query on `UserGroupsMembershipModel` in the repository layer.
- Covers the new behaviour with updated/new tests in all three test files.

<h3>Confidence Score: 5/5</h3>

The change is purely additive — existing fields are untouched and the new role field is correctly populated on all three endpoints.

All three endpoints now correctly return the user's role. The create path hardcodes "admin", which matches the enforced repository invariant. The get/update paths use a targeted single-column query with correct filtering. Tests cover all three endpoints. The only open question (race-condition null role) was flagged and discussed in a prior review thread.

ord_app/service_api/domain/groups.py — the get and update use cases each issue a second query to the membership table after group_authorization already queried it.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_app/service_api/domain/groups.py | Core domain logic updated to return role in create/get/update; create hardcodes "admin", get/update query get_user_role. The race-condition null-role issue was raised in a prior review thread. |
| ord_app/service_api/repositories/groups.py | Adds get_user_role helper that queries UserGroupsMembershipModel by (user_id, group_id) and returns the role or None; straightforward and correct. |
| ord_app/service_api/resources/v1/group.py | Switches three endpoint response_model declarations from GroupResponseSchema to GroupUserResponseSchema; clean, no logic changes. |
| ord_app/tests/test_groups/test_create_groups.py | Adds role=="admin" assertion to test_create_group; straightforward and correct. |
| ord_app/tests/test_groups/test_get_groups.py | Adds test_get_group_returns_role for GET /groups/{id}; the previously-flagged duplicate assertion was fixed and test_get_group_members retains its own role assertion. |
| ord_app/tests/test_groups/test_update_group.py | Adds role=="admin" assertion to test_update_group; straightforward and correct. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(be): fix duplicate role assertion, ..."](https://github.com/open-reaction-database/ord-app/commit/e6b3aa9574bc4938cf6999319c21967988b6ffe7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38815976)</sub>

<!-- /greptile_comment -->