### PR TITLE
chore(be): adopt ty as the type-check gate, replacing pytype (#681)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,8 +55,8 @@ jobs:
       - name: ruff format
         run: uv run ruff format --check ord_app/
 
-      - name: pytype
-        run: uv run pytype -j auto
+      - name: ty
+        run: uv run ty check ord_app
 
   check_javascript:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,17 @@ repos:
       - id: ruff-format
         files: ^ord_app/
 
+  # Type checking. ty (Astral) checks ord_app/ via uv, matching the CI step. It is a
+  # local hook because ty resolves through the project's uv environment.
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty check (ord_app)
+        entry: uv run ty check ord_app
+        language: system
+        files: ^ord_app/.*\.py$
+        pass_filenames: false
+
   # UI lint + format. Delegated to the tools already installed under ui/ via
   # their npm scripts (run `npm ci` in ui/ first).
   - repo: local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Web application for the [Open Reaction Database](https://open-reaction-database.
 - Postgres required, configured via `PG_DSN` / `PG_ALEMBIC_DSN` / `PG_TEST_DSN`. Migrate: `uv run alembic upgrade head`.
 - Run dev server: `cd ord_app/service_api && ORD_APP_TESTING=TRUE uv run fastapi dev main.py` → http://localhost:8000 (`/docs`).
 - Tests: `uv run pytest` (pytest-asyncio). Parallel runs are supported — `uv run pytest -n auto` — because the conftest gives each xdist worker its own isolated test database (DSN suffixed with `PYTEST_XDIST_WORKER`). Note: at the current suite size, per-worker DB setup makes `-n auto` roughly break-even with serial; the win grows as the suite does.
-- Lint/type: `ruff` + `ruff format`, `pytype` (migration to `ty` in progress — see #681).
+- Lint/type: `ruff` + `ruff format`, `ty` (Astral's type checker; `uv run ty check ord_app`).
 
 ## Frontend (`ui/`)
 
@@ -32,7 +32,7 @@ Run hooks via [pre-commit](https://pre-commit.com): `uv run pre-commit install` 
 ## CI gates (a PR is not mergeable until these are green)
 
 - **Tests**: `test_python` (ubuntu + macos), `test_ui`, `test_e2e` (boots the full no-auth stack).
-- **Checks**: `check_python` (ruff / ruff-format / pytype), `check_javascript` (clang-format), `lint_and_build_ui` (`lint:check` + `npm run build`), `check_license_headers`.
+- **Checks**: `check_python` (ruff / ruff-format / ty), `check_javascript` (clang-format), `lint_and_build_ui` (`lint:check` + `npm run build`), `check_license_headers`.
 - **SonarCloud quality gate** and **Greptile review** also gate merges — never merge over a red Sonar check; address Greptile findings (and read its PR-body summary for sub-threshold notes) before merging.
 
 ## Conventions

--- a/ord_app/service_api/domain/datasets.py
+++ b/ord_app/service_api/domain/datasets.py
@@ -37,7 +37,12 @@ from ord_app.service_api.schemas.datasets import (
     DatasetShareCreateSchema,
     DownloadFileFormats,
 )
-from ord_app.service_api.services.exceptions import ForbiddenError, ProtobufDecodeError, UnprocessableEntityError
+from ord_app.service_api.services.exceptions import (
+    EntityNotFoundError,
+    ForbiddenError,
+    ProtobufDecodeError,
+    UnprocessableEntityError,
+)
 from ord_app.service_api.services.pb_utils import load_message, write_message
 from ord_app.service_api.services.postgresql import get_db_session
 
@@ -68,7 +73,8 @@ class DatasetUseCases:
 
     async def extend_enumerate(self, dataset_id: int, payload: DatasetEnumerateExtendSchema):
         dataset = await self.dataset_repository.get(dataset_id)
-        assert dataset is not None  # existence enforced upstream by dataset_authorization
+        if dataset is None:
+            raise EntityNotFoundError(f"Dataset {dataset_id} not found")
         await self.add_reactions(dataset, [Reaction.FromString(i) for i in payload.reactions])
         return dataset
 
@@ -163,7 +169,8 @@ class DatasetUseCases:
     async def update(self, dataset_id: int, payload: DatasetCreateSchema) -> DatasetModel:
         await self.dataset_repository.update(dataset_id, payload.model_dump(exclude_unset=True))
         dataset = await self.dataset_repository.get(dataset_id)
-        assert dataset is not None  # existence enforced upstream by dataset_authorization
+        if dataset is None:
+            raise EntityNotFoundError(f"Dataset {dataset_id} not found")
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 

--- a/ord_app/service_api/domain/datasets.py
+++ b/ord_app/service_api/domain/datasets.py
@@ -52,6 +52,7 @@ class DatasetUseCases:
     async def create(self, group_id: int, payload: DatasetCreateSchema) -> DatasetModel:
         dataset = await self.dataset_repository.create(group_id, self.current_user.id, payload.model_dump())
         dataset = await self.dataset_repository.get(dataset.id)
+        assert dataset is not None  # just created above
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
@@ -61,11 +62,13 @@ class DatasetUseCases:
         await self.add_reactions(dataset, [Reaction.FromString(i) for i in payload.reactions])
 
         dataset = await self.dataset_repository.get(dataset.id)
+        assert dataset is not None  # just created above
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
     async def extend_enumerate(self, dataset_id: int, payload: DatasetEnumerateExtendSchema):
         dataset = await self.dataset_repository.get(dataset_id)
+        assert dataset is not None  # existence enforced upstream by dataset_authorization
         await self.add_reactions(dataset, [Reaction.FromString(i) for i in payload.reactions])
         return dataset
 
@@ -108,6 +111,7 @@ class DatasetUseCases:
         )
         await self.add_reactions(dataset, dataset_pb.reactions)
         dataset = await self.dataset_repository.get(dataset.id)
+        assert dataset is not None  # just created above
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
@@ -159,6 +163,7 @@ class DatasetUseCases:
     async def update(self, dataset_id: int, payload: DatasetCreateSchema) -> DatasetModel:
         await self.dataset_repository.update(dataset_id, payload.model_dump(exclude_unset=True))
         dataset = await self.dataset_repository.get(dataset_id)
+        assert dataset is not None  # existence enforced upstream by dataset_authorization
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 

--- a/ord_app/service_api/domain/reactions.py
+++ b/ord_app/service_api/domain/reactions.py
@@ -200,6 +200,8 @@ class ReactionsUseCase:
         }
 
         reaction = await self.reaction_repo.update(updating_data, id=reaction_id, dataset_id=dataset_id)
+        if reaction is None:
+            raise EntityNotFoundError(f"Reaction with id={reaction_id} not found")
         await self.dataset_repo.update_modified_at(dataset_id)
         reaction.validation = {"errors": errors, "warnings": warning}
         return reaction

--- a/ord_app/service_api/domain/templates.py
+++ b/ord_app/service_api/domain/templates.py
@@ -32,8 +32,8 @@ class TemplatesUseCase:
         self.template_repo = TemplateRepository(db)
 
     async def create(self, payload: TemplateCreateModel) -> TemplateModel:
-        payload = payload.model_dump() | {"owner_id": self.current_user.id}
-        return await self.template_repo.create(payload)
+        data = payload.model_dump() | {"owner_id": self.current_user.id}
+        return await self.template_repo.create(data)
 
     async def all(self) -> Sequence[TemplateModel]:
         return await self.template_repo.filter(owner_id=self.current_user.id)
@@ -44,8 +44,8 @@ class TemplatesUseCase:
         raise EntityNotFoundError("Template not found")
 
     async def update(self, template_id: int, payload: TemplateUpdateModel):
-        payload = payload.model_dump(exclude_none=True)
-        if template := await self.template_repo.update(payload, id=template_id, owner_id=self.current_user.id):
+        data = payload.model_dump(exclude_none=True)
+        if template := await self.template_repo.update(data, id=template_id, owner_id=self.current_user.id):
             return template
         raise EntityNotFoundError("Template not found")
 

--- a/ord_app/service_api/domain/users.py
+++ b/ord_app/service_api/domain/users.py
@@ -47,7 +47,7 @@ class UserUseCase:
         return await self.user_repo.get(auth0_id=auth0_id)
 
     async def update(self, user_id: int, payload: UserUpdateSchema):
-        if self.current_user.id != user_id:
+        if self.current_user is None or self.current_user.id != user_id:
             raise ForbiddenError("Action prohibited")
         if user := await self.user_repo.update(payload.model_dump(exclude_unset=True), id=user_id):
             return user
@@ -110,6 +110,8 @@ async def jit_provisioning(db_session: AsyncSession, payload: Auth0CreateSchema)
 
     # getting information about the user from the found 'userinfo' link in decoded_token["aud"]
     user_info_api = next(filter(lambda i: "userinfo" in i, decoded_token["aud"]), None)
+    if user_info_api is None:
+        raise ForbiddenError("userinfo endpoint not found in token audience")
     async with httpx.AsyncClient() as client:
         response = await client.get(user_info_api, headers={"Authorization": f"Bearer {payload.access_token}"})
         user_info = response.raise_for_status().json()

--- a/ord_app/service_api/main.py
+++ b/ord_app/service_api/main.py
@@ -31,7 +31,7 @@ from ord_app.service_api.resources.v1 import auth, datasets, group, reactions, t
 from ord_app.service_api.services.postgresql import db_session_maker
 from ord_app.service_api.settings import RuntimeSettings
 
-RDLogger.DisableLog("rdApp.*")
+RDLogger.DisableLog("rdApp.*")  # ty: ignore[unresolved-attribute]  # rdkit ships no type stubs
 logger.remove()
 match RuntimeSettings.app_env:
     case AppEnvs.production:
@@ -66,7 +66,7 @@ async def catch_errors(request: Request, call_next):
     try:
         return await call_next(request)
     except (DataError, DBAPIError) as err:
-        context_err = err.orig.__context__ or err.orig
+        context_err = (err.orig.__context__ or err.orig) if err.orig is not None else err
         if isinstance(context_err, asyncpg.UniqueViolationError):
             return JSONResponse(
                 status_code=status.HTTP_409_CONFLICT,

--- a/ord_app/service_api/models.py
+++ b/ord_app/service_api/models.py
@@ -148,6 +148,12 @@ class DatasetGroupAssociationModel(BaseModel):
 
 
 class ReactionModel(BaseModel):
+    # Validation errors/warnings are computed per request and attached for serialization;
+    # they are not persisted. __allow_unmapped__ tells SQLAlchemy to treat this plain
+    # annotation as an ordinary attribute rather than a mapped column.
+    __allow_unmapped__ = True
+    validation: dict[str, list[str]] | None = None
+
     id: Mapped[int] = mapped_column(primary_key=True)
     pb_reaction_id: Mapped[str]
     binpb: Mapped[bytes] = mapped_column(LargeBinary, nullable=True)

--- a/ord_app/service_api/repositories/base.py
+++ b/ord_app/service_api/repositories/base.py
@@ -91,4 +91,4 @@ class BaseRepository(AbstractRepository[T]):
         result = await self.db.execute(stmt)
         await self.db.commit()
         logger.debug(f"<{self.model.__name__.title()}({kwargs})> was deleted")
-        return result.rowcount
+        return result.rowcount  # ty: ignore[unresolved-attribute]  # execute() returns a CursorResult here

--- a/ord_app/service_api/repositories/datasets.py
+++ b/ord_app/service_api/repositories/datasets.py
@@ -64,7 +64,7 @@ class DatasetsRepository:
 
         return dataset
 
-    async def get(self, dataset_id: int) -> DatasetModel:
+    async def get(self, dataset_id: int) -> DatasetModel | None:
         stmt = (
             select(DatasetModel)
             .where(DatasetModel.id == dataset_id)
@@ -94,7 +94,9 @@ class DatasetsRepository:
             )
             .group_by(DatasetModel.id)
         )
-        dataset, rct_total, rct_invalid, rct_valid, rct_none = (await self.db.execute(stmt)).first()
+        row = (await self.db.execute(stmt)).first()
+        assert row is not None  # dataset existence is enforced upstream by dataset_authorization
+        dataset, rct_total, rct_invalid, rct_valid, rct_none = row
         dataset.reactions_count = {
             "total": rct_total,
             "invalid": rct_invalid,
@@ -124,7 +126,7 @@ class DatasetsRepository:
         assocs = (await self.db.scalars(stmt)).all()
         return [setattr(assoc.group, "is_primary", assoc.is_primary) or assoc.group for assoc in assocs]
 
-    async def get_with_reactions(self, dataset_id: int) -> DatasetModel:
+    async def get_with_reactions(self, dataset_id: int) -> DatasetModel | None:
         stmt = select(DatasetModel).where(DatasetModel.id == dataset_id).options(selectinload(DatasetModel.reactions))
         return await self.db.scalar(stmt)
 

--- a/ord_app/service_api/repositories/groups.py
+++ b/ord_app/service_api/repositories/groups.py
@@ -26,7 +26,11 @@ from ord_app.service_api.repositories.base import BaseRepository
 class GroupRepository(BaseRepository[GroupModel]):
     model = GroupModel
 
-    async def create(self, owner_id: int, payload: dict, autocommit: bool = True) -> GroupModel:
+    # Group creation needs an owner and seeds an admin membership, so this override
+    # deliberately takes a wider signature than the base create(payload).
+    async def create(  # ty: ignore[invalid-method-override]
+        self, owner_id: int, payload: dict, autocommit: bool = True
+    ) -> GroupModel:
         group = GroupModel(
             owner_id=owner_id, groups_member=[UserGroupsMembershipModel(user_id=owner_id, role="admin")], **payload
         )
@@ -55,7 +59,7 @@ class GroupMembersRepository:
         self.db = db
         self.autocommit = autocommit
 
-    async def get(self, user_id: int, group_id: int) -> UserGroupsMembershipModel:
+    async def get(self, user_id: int, group_id: int) -> UserGroupsMembershipModel | None:
         stmt = (
             select(UserGroupsMembershipModel)
             .where(

--- a/ord_app/service_api/repositories/reactions.py
+++ b/ord_app/service_api/repositories/reactions.py
@@ -14,7 +14,7 @@
 from itertools import batched
 
 from loguru import logger
-from sqlalchemy import insert, or_, select, update
+from sqlalchemy import insert, or_, select, true, update
 
 from ord_app.service_api.models import ReactionModel
 from ord_app.service_api.repositories.base import BaseRepository
@@ -38,8 +38,8 @@ class ReactionsRepository(BaseRepository[ReactionModel]):
             stmt = (
                 select(ReactionModel)
                 .where(
-                    ReactionModel.id > last_id if last_id is not None else True,
-                    ReactionModel.dataset_id == dataset_id if dataset_id is not None else True,
+                    ReactionModel.id > last_id if last_id is not None else true(),
+                    ReactionModel.dataset_id == dataset_id if dataset_id is not None else true(),
                     ReactionModel.is_valid.is_(None),
                 )
                 .order_by(ReactionModel.id)
@@ -51,7 +51,11 @@ class ReactionsRepository(BaseRepository[ReactionModel]):
             yield reactions
             last_id = reactions[-1].id
 
-    async def create(self, dataset_id: int, user_id: int, payload: dict, autocommit: bool = True):
+    # Reaction creation needs ownership and dataset context, so this override deliberately
+    # takes a wider signature than the base create(payload).
+    async def create(  # ty: ignore[invalid-method-override]
+        self, dataset_id: int, user_id: int, payload: dict, autocommit: bool = True
+    ):
         reaction = ReactionModel(owner_id=user_id, dataset_id=dataset_id, **payload)
 
         if autocommit:

--- a/ord_app/service_api/repositories/users.py
+++ b/ord_app/service_api/repositories/users.py
@@ -20,7 +20,7 @@ from ord_app.service_api.repositories.base import BaseRepository
 class UserRepository(BaseRepository[UserModel]):
     model = UserModel
 
-    async def search_user_by_identity(self, identity: int | str) -> UserModel:
+    async def search_user_by_identity(self, identity: int | str) -> UserModel | None:
         stmt = (
             select(UserModel)
             .where(

--- a/ord_app/service_api/services/pb_utils.py
+++ b/ord_app/service_api/services/pb_utils.py
@@ -55,7 +55,7 @@ async def validate_uploaded_pb_file(file: UploadFile):
         )
 
     file_data = await file.read()
-    if file.filename.endswith(".gz"):
+    if file.filename and file.filename.endswith(".gz"):
         file_data = gzip.decompress(file_data)
 
     return file_data, kind

--- a/ord_app/tests/test_repositories/test_user_repository.py
+++ b/ord_app/tests/test_repositories/test_user_repository.py
@@ -18,6 +18,7 @@ async def test_get(test_db_session, test_user):
     ur = UserRepository(test_db_session)
     user = await ur.get(id=test_user.id)
 
+    assert user is not None
     assert user.id == test_user.id
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
     "sqlalchemy-utils>=0.41.2,<0.42",
     "coverage>=7.6.12,<8",
     "pytest-cov>=6.0.0,<7",
-    "pytype>=2024.10.11",
+    "ty>=0.0.28",
     "pytest-asyncio>=0.25.3,<0.26",
     "pytest-xdist>=3.6,<4",
     "ruff>=0.9.9,<0.10",
@@ -93,9 +93,6 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
 
-[tool.pytype]
-inputs = ["ord_app"]
-exclude = ["**/*_test.py", "**/test_*.py", "build/", "dist/"]
-keep_going = true
-disable = ["module-attr", "pyi-error"]
-jobs = 0
+# ty (Astral's type checker) is invoked as `ty check ord_app` by CI and the pre-commit
+# hook, so no input globs are configured here; ord_app ships no generated sources, so no
+# excludes are needed. ty type-checks the test suite too, which is intentional.

--- a/uv.lock
+++ b/uv.lock
@@ -60,15 +60,6 @@ wheels = [
 ]
 
 [[package]]
-name = "attrs"
-version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -419,27 +410,6 @@ wheels = [
 ]
 
 [[package]]
-name = "immutabledict"
-version = "4.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/e6/718471048fea0366c3e3d1df3acfd914ca66d571cdffcf6d37bbcd725708/immutabledict-4.3.1.tar.gz", hash = "sha256:f844a669106cfdc73f47b1a9da003782fb17dc955a54c80972e0d93d1c63c514", size = 7806, upload-time = "2026-02-15T10:32:34.668Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl", hash = "sha256:c9facdc0ff30fdb8e35bd16532026cac472a549e182c94fa201b51b25e4bf7bf", size = 5000, upload-time = "2026-02-15T10:32:33.672Z" },
-]
-
-[[package]]
-name = "importlab"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "networkx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/22/ab9494dccf1e237276f98364d53673bc0ab97ebe5cb671e960f18710457d/importlab-0.8.1.tar.gz", hash = "sha256:b3893853b1f6eb027da509c3b40e6787e95dd66b4b66f1b3613aad77556e1465", size = 28856, upload-time = "2023-10-06T22:43:40.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/1e/cc7360b4259f283b1a2de153335ce15ac9e710d66145aa471cffefe4b394/importlab-0.8.1-py2.py3-none-any.whl", hash = "sha256:124cfa00e8a34fefe8aac1a5e94f56c781b178c9eb61a1d3f60f7e03b77338d3", size = 21671, upload-time = "2023-10-06T22:43:38.997Z" },
-]
-
-[[package]]
 name = "inflection"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -458,43 +428,12 @@ wheels = [
 ]
 
 [[package]]
-name = "jinja2"
-version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
-]
-
-[[package]]
-name = "libcst"
-version = "1.8.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/cd/337df968b38d94c5aabd3e1b10630f047a2b345f6e1d4456bd9fe7417537/libcst-1.8.6.tar.gz", hash = "sha256:f729c37c9317126da9475bdd06a7208eb52fcbd180a6341648b45a56b4ba708b", size = 891354, upload-time = "2025-11-03T22:33:30.621Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/3c/93365c17da3d42b055a8edb0e1e99f1c60c776471db6c9b7f1ddf6a44b28/libcst-1.8.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0c13d5bd3d8414a129e9dccaf0e5785108a4441e9b266e1e5e9d1f82d1b943c9", size = 2206166, upload-time = "2025-11-03T22:32:16.012Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/cb/7530940e6ac50c6dd6022349721074e19309eb6aa296e942ede2213c1a19/libcst-1.8.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f1472eeafd67cdb22544e59cf3bfc25d23dc94058a68cf41f6654ff4fcb92e09", size = 2083726, upload-time = "2025-11-03T22:32:17.312Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/cf/7e5eaa8c8f2c54913160671575351d129170db757bb5e4b7faffed022271/libcst-1.8.6-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:089c58e75cb142ec33738a1a4ea7760a28b40c078ab2fd26b270dac7d2633a4d", size = 2235755, upload-time = "2025-11-03T22:32:18.859Z" },
-    { url = "https://files.pythonhosted.org/packages/55/54/570ec2b0e9a3de0af9922e3bb1b69a5429beefbc753a7ea770a27ad308bd/libcst-1.8.6-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c9d7aeafb1b07d25a964b148c0dda9451efb47bbbf67756e16eeae65004b0eb5", size = 2301473, upload-time = "2025-11-03T22:32:20.499Z" },
-    { url = "https://files.pythonhosted.org/packages/11/4c/163457d1717cd12181c421a4cca493454bcabd143fc7e53313bc6a4ad82a/libcst-1.8.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:207481197afd328aa91d02670c15b48d0256e676ce1ad4bafb6dc2b593cc58f1", size = 2298899, upload-time = "2025-11-03T22:32:21.765Z" },
-    { url = "https://files.pythonhosted.org/packages/35/1d/317ddef3669883619ef3d3395ea583305f353ef4ad87d7a5ac1c39be38e3/libcst-1.8.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:375965f34cc6f09f5f809244d3ff9bd4f6cb6699f571121cebce53622e7e0b86", size = 2408239, upload-time = "2025-11-03T22:32:23.275Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a1/f47d8cccf74e212dd6044b9d6dbc223636508da99acff1d54786653196bc/libcst-1.8.6-cp312-cp312-win_amd64.whl", hash = "sha256:da95b38693b989eaa8d32e452e8261cfa77fe5babfef1d8d2ac25af8c4aa7e6d", size = 2119660, upload-time = "2025-11-03T22:32:24.822Z" },
-    { url = "https://files.pythonhosted.org/packages/19/d0/dd313bf6a7942cdf951828f07ecc1a7695263f385065edc75ef3016a3cb5/libcst-1.8.6-cp312-cp312-win_arm64.whl", hash = "sha256:bff00e1c766658adbd09a175267f8b2f7616e5ee70ce45db3d7c4ce6d9f6bec7", size = 1999824, upload-time = "2025-11-03T22:32:26.131Z" },
 ]
 
 [[package]]
@@ -539,57 +478,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
     { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
     { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
-]
-
-[[package]]
-name = "msgspec"
-version = "0.21.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
-    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
-]
-
-[[package]]
-name = "ninja"
-version = "1.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/73/79a0b22fc731989c708068427579e840a6cf4e937fe7ae5c5d0b7356ac22/ninja-1.13.0.tar.gz", hash = "sha256:4a40ce995ded54d9dc24f8ea37ff3bf62ad192b547f6c7126e7e25045e76f978", size = 242558, upload-time = "2025-08-11T15:10:19.421Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/74/d02409ed2aa865e051b7edda22ad416a39d81a84980f544f8de717cab133/ninja-1.13.0-py3-none-macosx_10_9_universal2.whl", hash = "sha256:fa2a8bfc62e31b08f83127d1613d10821775a0eb334197154c4d6067b7068ff1", size = 310125, upload-time = "2025-08-11T15:09:50.971Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/de/6e1cd6b84b412ac1ef327b76f0641aeb5dcc01e9d3f9eee0286d0c34fd93/ninja-1.13.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3d00c692fb717fd511abeb44b8c5d00340c36938c12d6538ba989fe764e79630", size = 177467, upload-time = "2025-08-11T15:09:52.767Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/83/49320fb6e58ae3c079381e333575fdbcf1cca3506ee160a2dcce775046fa/ninja-1.13.0-py3-none-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:be7f478ff9f96a128b599a964fc60a6a87b9fa332ee1bd44fa243ac88d50291c", size = 187834, upload-time = "2025-08-11T15:09:54.115Z" },
-    { url = "https://files.pythonhosted.org/packages/56/c7/ba22748fb59f7f896b609cd3e568d28a0a367a6d953c24c461fe04fc4433/ninja-1.13.0-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:60056592cf495e9a6a4bea3cd178903056ecb0943e4de45a2ea825edb6dc8d3e", size = 202736, upload-time = "2025-08-11T15:09:55.745Z" },
-    { url = "https://files.pythonhosted.org/packages/79/22/d1de07632b78ac8e6b785f41fa9aad7a978ec8c0a1bf15772def36d77aac/ninja-1.13.0-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:1c97223cdda0417f414bf864cfb73b72d8777e57ebb279c5f6de368de0062988", size = 179034, upload-time = "2025-08-11T15:09:57.394Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/de/0e6edf44d6a04dabd0318a519125ed0415ce437ad5a1ec9b9be03d9048cf/ninja-1.13.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fb46acf6b93b8dd0322adc3a4945452a4e774b75b91293bafcc7b7f8e6517dfa", size = 180716, upload-time = "2025-08-11T15:09:58.696Z" },
-    { url = "https://files.pythonhosted.org/packages/54/28/938b562f9057aaa4d6bfbeaa05e81899a47aebb3ba6751e36c027a7f5ff7/ninja-1.13.0-py3-none-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4be9c1b082d244b1ad7ef41eb8ab088aae8c109a9f3f0b3e56a252d3e00f42c1", size = 146843, upload-time = "2025-08-11T15:10:00.046Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/fb/d06a3838de4f8ab866e44ee52a797b5491df823901c54943b2adb0389fbb/ninja-1.13.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6739d3352073341ad284246f81339a384eec091d9851a886dfa5b00a6d48b3e2", size = 154402, upload-time = "2025-08-11T15:10:01.657Z" },
-    { url = "https://files.pythonhosted.org/packages/31/bf/0d7808af695ceddc763cf251b84a9892cd7f51622dc8b4c89d5012779f06/ninja-1.13.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11be2d22027bde06f14c343f01d31446747dbb51e72d00decca2eb99be911e2f", size = 552388, upload-time = "2025-08-11T15:10:03.349Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/70/c99d0c2c809f992752453cce312848abb3b1607e56d4cd1b6cded317351a/ninja-1.13.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aa45b4037b313c2f698bc13306239b8b93b4680eb47e287773156ac9e9304714", size = 472501, upload-time = "2025-08-11T15:10:04.735Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/43/c217b1153f0e499652f5e0766da8523ce3480f0a951039c7af115e224d55/ninja-1.13.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5f8e1e8a1a30835eeb51db05cf5a67151ad37542f5a4af2a438e9490915e5b72", size = 638280, upload-time = "2025-08-11T15:10:06.512Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/45/9151bba2c8d0ae2b6260f71696330590de5850e5574b7b5694dce6023e20/ninja-1.13.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:3d7d7779d12cb20c6d054c61b702139fd23a7a964ec8f2c823f1ab1b084150db", size = 642420, upload-time = "2025-08-11T15:10:08.35Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/fb/95752eb635bb8ad27d101d71bef15bc63049de23f299e312878fc21cb2da/ninja-1.13.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:d741a5e6754e0bda767e3274a0f0deeef4807f1fec6c0d7921a0244018926ae5", size = 585106, upload-time = "2025-08-11T15:10:09.818Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/31/aa56a1a286703800c0cbe39fb4e82811c277772dc8cd084f442dd8e2938a/ninja-1.13.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:e8bad11f8a00b64137e9b315b137d8bb6cbf3086fbdc43bf1f90fd33324d2e96", size = 707138, upload-time = "2025-08-11T15:10:11.366Z" },
-    { url = "https://files.pythonhosted.org/packages/34/6f/5f5a54a1041af945130abdb2b8529cbef0cdcbbf9bcf3f4195378319d29a/ninja-1.13.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b4f2a072db3c0f944c32793e91532d8948d20d9ab83da9c0c7c15b5768072200", size = 581758, upload-time = "2025-08-11T15:10:13.295Z" },
-    { url = "https://files.pythonhosted.org/packages/95/97/51359c77527d45943fe7a94d00a3843b81162e6c4244b3579fe8fc54cb9c/ninja-1.13.0-py3-none-win32.whl", hash = "sha256:8cfbb80b4a53456ae8a39f90ae3d7a2129f45ea164f43fadfa15dc38c4aef1c9", size = 267201, upload-time = "2025-08-11T15:10:15.158Z" },
-    { url = "https://files.pythonhosted.org/packages/29/45/c0adfbfb0b5895aa18cec400c535b4f7ff3e52536e0403602fc1a23f7de9/ninja-1.13.0-py3-none-win_amd64.whl", hash = "sha256:fb8ee8719f8af47fed145cced4a85f0755dd55d45b2bddaf7431fa89803c5f3e", size = 309975, upload-time = "2025-08-11T15:10:16.697Z" },
-    { url = "https://files.pythonhosted.org/packages/df/93/a7b983643d1253bb223234b5b226e69de6cda02b76cdca7770f684b795f5/ninja-1.13.0-py3-none-win_arm64.whl", hash = "sha256:3c0b40b1f0bba764644385319028650087b4c1b18cdfa6f45cb39a3669b81aa9", size = 290806, upload-time = "2025-08-11T15:10:18.018Z" },
 ]
 
 [[package]]
@@ -667,9 +555,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
-    { name = "pytype" },
     { name = "ruff" },
     { name = "sqlalchemy-utils" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -704,9 +592,9 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },
     { name = "pytest-cov", specifier = ">=6.0.0,<7" },
     { name = "pytest-xdist", specifier = ">=3.6,<4" },
-    { name = "pytype", specifier = ">=2024.10.11" },
     { name = "ruff", specifier = ">=0.9.9,<0.10" },
     { name = "sqlalchemy-utils", specifier = ">=0.41.2,<0.42" },
+    { name = "ty", specifier = ">=0.0.28" },
 ]
 
 [[package]]
@@ -906,15 +794,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycnite"
-version = "2024.7.31"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/55/7f412c01675a8c77a9ace64a37d557faebe6740cf7fd619c9bda82b33341/pycnite-2024.7.31.tar.gz", hash = "sha256:5125f1c95aef4a23b9bec3b32fae76873dcd46324fa68e39c10fa852ecdea340", size = 24189, upload-time = "2024-07-31T12:43:15.814Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/af/7ba371f966657f6e7b1c9876cae7e9f1c5d3635c3df1329636b99e615494/pycnite-2024.7.31-py3-none-any.whl", hash = "sha256:9ff9c09d35056435b867e14ebf79626ca94b6017923a0bf9935377fa90d4cbb3", size = 22939, upload-time = "2024-07-31T12:43:14.248Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -988,18 +867,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydot"
-version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyparsing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
-]
-
-[[package]]
 name = "pygithub"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1059,15 +926,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
     { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
     { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -1166,32 +1024,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
-]
-
-[[package]]
-name = "pytype"
-version = "2024.10.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "immutabledict" },
-    { name = "importlab" },
-    { name = "jinja2" },
-    { name = "libcst" },
-    { name = "msgspec" },
-    { name = "networkx" },
-    { name = "ninja" },
-    { name = "pycnite" },
-    { name = "pydot" },
-    { name = "tabulate" },
-    { name = "toml" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/7a/6fd33673f9c7b9e5f4f8107028c323b1c72acc0f909f1b9b3391a31ea604/pytype-2024.10.11.tar.gz", hash = "sha256:ae5ff82f0b07d5ad68d4ec32a3e8de44fad6ed565a821a76aca50a14df382274", size = 2789497, upload-time = "2024-10-11T08:28:46.068Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/a2/cf47d02d846f6d837e1023b2c19588127c4d9dfc577b8eceb4870def32f4/pytype-2024.10.11-cp312-cp312-macosx_10_14_universal2.whl", hash = "sha256:cdc881cce9541a475ec48989a5ab889e6274a85afbf6da0e30266d0823f66d42", size = 4709678, upload-time = "2024-10-11T08:28:41.081Z" },
-    { url = "https://files.pythonhosted.org/packages/04/51/5925fe8992f02adab358ce9e8068defdae1e58393bfd767e035509da9872/pytype-2024.10.11-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13327d0d17b981fe2660dd3a69f97bf09a526f93debc40bb44b240628e0b55c1", size = 4682184, upload-time = "2024-10-11T08:28:32.128Z" },
-    { url = "https://files.pythonhosted.org/packages/20/10/52422fdb5a6b4a04938f47a76c655325775b7dd8cc71bd3557aae87b40e1/pytype-2024.10.11-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb98711679e631b01b09b09185504fbf38d60f119280918e244a602cf843b0fe", size = 4695132, upload-time = "2024-10-11T08:28:23.525Z" },
 ]
 
 [[package]]
@@ -1322,24 +1154,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tabulate"
-version = "0.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
-]
-
-[[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1349,6 +1163,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.51"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ce/352fcdba5c72ea20e5d2e46e28809cdb617575b71209d971eff2ace8e6c4/ty-0.0.51.tar.gz", hash = "sha256:b90172d46365bb9d51a7011cbb5c60cc4f514f42c86635df6c092b717f85e1ac", size = 5953151, upload-time = "2026-06-19T01:48:58.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/8f/8fe7cab79a45320b2cdcd602f16d44c8108d2f418ff7ec316c6212f1f0cc/ty-0.0.51-py3-none-linux_armv6l.whl", hash = "sha256:947986bd82d324b3a5c58ce03f1dad160cdf36443d3e8f64b3484b861ba9bc64", size = 11884805, upload-time = "2026-06-19T01:48:20.184Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b4/56fdc39a3f44c0564fd157e1e59e1f9c3fc5ba57ae4472ded85c67c63d74/ty-0.0.51-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25a5b31e6f23fd5dc63ad29087ded09932409e4154e2fe07bbaed015035990bb", size = 11633593, upload-time = "2026-06-19T01:48:22.998Z" },
+    { url = "https://files.pythonhosted.org/packages/33/57/136e83f24fc04f5afdcabff42f40fa27eae5ac3f0e3f12627d072a55f679/ty-0.0.51-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2faed19a8f1505370de071c008df52a994fc03a204f3267c3a33a32ca26f854f", size = 11063076, upload-time = "2026-06-19T01:48:25.223Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f8/5d32f0df5692446440ab781b9b119aa3e0c0dbfa78c583fe9be8417d54fa/ty-0.0.51-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08adbe53fb8bc9e7f00e89bf1d3c875a02cda76d83f109d2e6ab1ff35a7bfa8c", size = 11579542, upload-time = "2026-06-19T01:48:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0c/4f54ef338e9623886809ecd508931b0cd5b3aba1e591586a2f6aeaa8bd11/ty-0.0.51-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dc5e93695ab5dcbf1eef663aee60ec23a413547cc9cb06adcb0d842e9166bd0f", size = 11676189, upload-time = "2026-06-19T01:48:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/56/27/31729066f9b9d3596941edaf267894eefc0b30df4518f003dba5f7276258/ty-0.0.51-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd92913bc90d1705ef9391ff8c6822b61e2e827fa295eb30bf0dfabcf815645", size = 12188154, upload-time = "2026-06-19T01:48:31.68Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/38/d4301aa12d2283c7130908baf1417a37dfe3e10f5669cb4ce2853c2540b4/ty-0.0.51-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:429a997394dac73870d71b87cc90efc54da3efaf319e72ca18aeef35a78aef90", size = 12780597, upload-time = "2026-06-19T01:48:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/52/4b2e67e53f126d39abe201bd2299e467e27463a284e965ad195cbc217fa0/ty-0.0.51-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62d94f06e8c317e89b6884f2bde443040e596b88c7c79bd944c84c105b06257a", size = 12491115, upload-time = "2026-06-19T01:48:36.169Z" },
+    { url = "https://files.pythonhosted.org/packages/74/50/aabfe55c132ebe72b4d639cbf772d931e11b0990d29c1f691922b6ccabc1/ty-0.0.51-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8f52952cff665bc52a36147e610c10f5699d30007d7a14ab7f345cff93476ff", size = 12230135, upload-time = "2026-06-19T01:48:38.445Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1b/9aa428052dbed91c50919cd080426a313cf20ce14c6bfe2b71345e548671/ty-0.0.51-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c1bd1355aee86af01e4e21b0bc16fc460fb05905761f0d8b8d70841de0feade8", size = 12468123, upload-time = "2026-06-19T01:48:40.47Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5a/f6ce69f2575259386c950c40e02578d0902760cb61f95045e9971182c24e/ty-0.0.51-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:79d1877e93460f936bc10ed1a31525702b7ce51075763ccba993be17f0b9e905", size = 11541672, upload-time = "2026-06-19T01:48:42.635Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3a/2af48924a683e959e95e5cc4dc88e5a8595206a0812b869032b95196f2b0/ty-0.0.51-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:cc233a6235fb23e2a44b14731a10043e37ba2f30f2c361cf49ad3633c5b9da9c", size = 11694015, upload-time = "2026-06-19T01:48:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/12/899875d8a60b198c8121cb92ce18e18cc072d23ca2130fcdaa176383ef72/ty-0.0.51-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bc7459348a253247bbfb2669a021e614281b86bbea24c36112b8a6e1a2499a16", size = 11832856, upload-time = "2026-06-19T01:48:47.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a2/88f681d826d97cc96ef9f6cadd4935f775758944cee07340aa46113bce28/ty-0.0.51-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49a21237f6fd1de56beaff0a3e85fe022a09a3401e67e3abec41ce838a5d4d2e", size = 12333449, upload-time = "2026-06-19T01:48:49.091Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/535a4163b4452c6978c31fedfd7b5803cf3a2253e9455cde350f86638d6a/ty-0.0.51-py3-none-win32.whl", hash = "sha256:61b4b6a003c3ebe53a63a1125c9b6542aa01bc1b6c9a235d01ee328d000d61a9", size = 11177338, upload-time = "2026-06-19T01:48:51.433Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4d/2334fbb74291a20129fa7aaa8f789619ec9b6883b27f997b8baa27e4674f/ty-0.0.51-py3-none-win_amd64.whl", hash = "sha256:608d417cd1eaf79bcbd713d9830d5e3db9d57ec225c3af3e4ac9a9ff66b45d70", size = 12325675, upload-time = "2026-06-19T01:48:53.774Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b5/d49096cd5f3694becb86a5a6ccd0f229ead695fc7430d6bc4dd0a104c6fe/ty-0.0.51-py3-none-win_arm64.whl", hash = "sha256:62ced5e380284f12b2dc4802a3e4ed3dac39913fc6719afde7978814a4c7f169", size = 11657350, upload-time = "2026-06-19T01:48:55.904Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Completes #681: clears the final **22 `ty check ord_app` diagnostics to zero** and switches the `check_python` type-check gate (CI + pre-commit) from **pytype → ty** (Astral), matching the sibling `ord-schema` tooling. `ty` is pinned via `uv.lock` (resolved **0.0.51**).

## Notes

- **pytype is fully removed** (dev dep, `[tool.pytype]`, CI step), matching the issue's "replacing pytype in CI" goal and ord-schema's tooling.
- **One observed coverage gap:** when I annotated the repo getters as `| None`, **pytype caught 3 latent `.id`-on-`None` accesses** in `resources/v1/datasets.py` (`upload`/`enumerate`/`extend_enumerate`) that **ty did not flag** (ty doesn't propagate Optional through the unannotated use-case returns the same way). All 3 are fixed here, so both checkers are green — flagging it only as a known difference in case ty's strictness here matters later.

## Diagnostic fixes (real safety vs. tool limitations)

**Real improvements:**
- `ReactionModel.validation` declared as a non-mapped transient attribute (`__allow_unmapped__`) so the response-only field has a real type instead of being attached ad-hoc.
- None-safety guards/asserts at `scalar()`-returning repo-getter call sites (datasets create/update/upload/enumerate/extend, reaction update); `current_user` + userinfo-endpoint guards in the user use case; `file.filename` + `err.orig` guards.
- Truthful `... | None` return annotations on the getters that return `scalar()`.
- `sqlalchemy.true()` for conditional `where()` clauses (replacing bare `True`, which isn't a column expression).
- Distinct dict locals in the template use case (stop reassigning typed params with a dict).

**`# ty: ignore` for genuine tool limitations:**
- `rdkit.RDLogger.DisableLog` (rdkit ships no stubs — same ignore ord-schema uses).
- `CursorResult.rowcount` (typed as `Result` by SQLAlchemy).
- The intentional `create()` override signatures in the reaction/group repos.

## Wiring
- `pyproject.toml`: drop `pytype` + `[tool.pytype]`; add `ty>=0.0.28`.
- `.github/workflows/checks.yml`: `pytype` step → `uv run ty check ord_app`.
- `.pre-commit-config.yaml`: new local `ty` hook scoped to `ord_app/*.py`.
- `CLAUDE.md` + `ISSUE_TRIAGE_PLAN.md` updated.

## Test plan
- [x] `uv run ty check ord_app` — **All checks passed** (0 diagnostics)
- [x] `ruff` + `ruff format --check` clean
- [x] **75 backend tests pass**
- [x] App imports cleanly; `ReactionModel` maps the expected columns (`validation` stays transient, not a DB column)
- [x] pre-commit `ty` hook passes

Closes #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrates the Python type-check gate from pytype to ty (Astral), clearing all 22 ty diagnostics to zero. As a byproduct the PR also ships a set of genuine safety fixes uncovered during the annotation work.

- **Tooling swap**: `pytype` is removed from dev deps and CI; `ty>=0.0.28` (resolved 0.0.51) is added and wired into both GitHub Actions and pre-commit.
- **None-safety hardening**: Return types on several repository getters are widened to `| None`, with corresponding guards (either `assert` for \"just-created\" objects or `raise EntityNotFoundError` for external IDs) added at every call site in the domain layer — except `DatasetUseCases.extend`, which passes the result of `get()` directly to `add_reactions` without a check.
- **`ReactionModel.validation`** is promoted to a class-level `__allow_unmapped__` attribute, preventing SQLAlchemy from accidentally treating it as a mapped column.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changed paths are guarded by existing authorization middleware and the fixes are additive None-safety improvements.

The tooling change is straightforward, the None-safety fixes are correct, and the one inconsistency (missing guard in `DatasetUseCases.extend`) does not constitute a live bug because `dataset_authorization` middleware enforces dataset existence before the handler runs. No data-path regressions were found.

`ord_app/service_api/domain/datasets.py` — the `extend` method lacks the None guard that every other updated call site received; worth a follow-up for consistency.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_app/service_api/domain/datasets.py | Adds None guards for `extend_enumerate` and `update` (correct EntityNotFoundError), uses `assert` for "just-created" re-fetches, but the `extend` method is missing a None guard on the `get()` result before `add_reactions` is called — unlike every other updated call site. |
| ord_app/service_api/models.py | Promotes `validation` from an ad-hoc instance attribute to a declared `__allow_unmapped__` class-level annotation, correctly preventing SQLAlchemy from treating it as a mapped column. |
| ord_app/service_api/repositories/datasets.py | Widens `get` and `get_with_reactions` return types to `| None`; replaces direct tuple-unpack with a variable + assert in `get_with_sharable_info` to appease ty while documenting the upstream auth invariant. |
| ord_app/service_api/repositories/reactions.py | Replaces bare Python `True` with `sqlalchemy.true()` in conditional WHERE clauses and adds `ty: ignore` for the intentional `create` signature override — both changes are correct. |
| ord_app/service_api/main.py | Guards `err.orig` None-ness before dereferencing `.__context__`, avoiding an AttributeError on DBAPIError instances where `orig` is unset. |
| pyproject.toml | Drops `pytype` and `[tool.pytype]` config, adds `ty>=0.0.28` — clean migration matching the PR goal. |
| .github/workflows/checks.yml | Replaces the `uv run pytype -j auto` CI step with `uv run ty check ord_app`. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(be): 404 instead of 500 when a user-..."](https://github.com/open-reaction-database/ord-app/commit/7f5fea57abbcdef87958a6c230bb9c320a04955e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38817045)</sub>

<!-- /greptile_comment -->