### PR TITLE
chore: align ruff ruleset with ord-schema (add W/UP/SIM, full E)

### DIFF
--- a/ord_app/service_api/domain/groups.py
+++ b/ord_app/service_api/domain/groups.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Sequence
+from collections.abc import Sequence
 
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/ord_app/service_api/domain/templates.py
+++ b/ord_app/service_api/domain/templates.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/ord_app/service_api/domain/users.py
+++ b/ord_app/service_api/domain/users.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 import httpx
 from fastapi import Depends
@@ -43,7 +42,7 @@ class UserUseCase:
             return user
         raise EntityNotFoundError(f"User {user_id} not found")
 
-    async def get_user_by_auth0_id(self, auth0_id: str) -> Optional[UserModel]:
+    async def get_user_by_auth0_id(self, auth0_id: str) -> UserModel | None:
         return await self.user_repo.get(auth0_id=auth0_id)
 
     async def update(self, user_id: int, payload: UserUpdateSchema):

--- a/ord_app/service_api/repositories/base.py
+++ b/ord_app/service_api/repositories/base.py
@@ -73,7 +73,7 @@ class BaseRepository(AbstractRepository[T]):
         result = await self.db.scalars(stmt)
         return result.all()
 
-    async def update(self, payload: dict, autocommit: bool = True, **kwargs) -> T | None | None:
+    async def update(self, payload: dict, autocommit: bool = True, **kwargs) -> T | None:
         stmt = (
             update(self.model)
             .where(*self._get_filter_stmt(self.model, **kwargs))

--- a/ord_app/service_api/repositories/base.py
+++ b/ord_app/service_api/repositories/base.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from typing import Any, Generic, List, Optional, Sequence, Type, TypeVar
+from collections.abc import Sequence
+from typing import Any, Generic, TypeVar
 
 from loguru import logger
 from sqlalchemy import BinaryExpression, delete, select, update
@@ -30,21 +31,21 @@ filters_map = {
 
 
 class AbstractRepository(ABC, Generic[T]):
-    model: Type[T]
+    model: type[T]
 
     def __init__(self, db: AsyncSession, current_user: UserModel | None = None) -> None:
         self.db = db
         self.current_user = current_user
 
     @abstractmethod
-    async def get(self, **kwargs) -> Optional[T]:
+    async def get(self, **kwargs) -> T | None:
         pass
 
 
 class BaseRepository(AbstractRepository[T]):
     @staticmethod
-    def _get_filter_stmt(model: Any, **kwargs: Any) -> List[BinaryExpression]:
-        filters: List[BinaryExpression] = []
+    def _get_filter_stmt(model: Any, **kwargs: Any) -> list[BinaryExpression]:
+        filters: list[BinaryExpression] = []
         for field_name, field_value in kwargs.items():
             if field_name not in model.__table__.columns:
                 raise AttributeError(f"Field '{model.__name__}.{field_name}' doesn't exist.")
@@ -62,7 +63,7 @@ class BaseRepository(AbstractRepository[T]):
         await self.db.refresh(instance)
         return instance
 
-    async def get(self, **kwargs) -> Optional[T]:
+    async def get(self, **kwargs) -> T | None:
         stmt = select(self.model).where(*self._get_filter_stmt(self.model, **kwargs))
         result = await self.db.scalar(stmt)
         return result
@@ -72,7 +73,7 @@ class BaseRepository(AbstractRepository[T]):
         result = await self.db.scalars(stmt)
         return result.all()
 
-    async def update(self, payload: dict, autocommit: bool = True, **kwargs) -> Optional[T] | None:
+    async def update(self, payload: dict, autocommit: bool = True, **kwargs) -> T | None | None:
         stmt = (
             update(self.model)
             .where(*self._get_filter_stmt(self.model, **kwargs))

--- a/ord_app/service_api/repositories/datasets.py
+++ b/ord_app/service_api/repositories/datasets.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from fastapi_pagination.ext.sqlalchemy import paginate
 from loguru import logger
@@ -149,7 +148,7 @@ class DatasetsRepository:
             # filter out groups that the user is not a member of
             dataset.groups = [group for group in dataset.groups if group.role is not None]
 
-    async def datasets_stmt(self, user_id: int, group_id: Optional[int] = None):
+    async def datasets_stmt(self, user_id: int, group_id: int | None = None):
         filters = [DatasetModel.groups.any(GroupModel.members.any(UserModel.id == user_id))]
 
         if group_id is not None:

--- a/ord_app/service_api/repositories/groups.py
+++ b/ord_app/service_api/repositories/groups.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Sequence
+from collections.abc import Sequence
 
 from loguru import logger
 from sqlalchemy import delete, select, update

--- a/ord_app/service_api/schemas/base.py
+++ b/ord_app/service_api/schemas/base.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -21,7 +20,7 @@ MAX_FIELD_LENGTH = 8192
 
 class BaseSchema(BaseModel):
     @staticmethod
-    def parse_bool(value: str) -> Optional[bool]:
+    def parse_bool(value: str) -> bool | None:
         value_lower = value.lower()
         if value_lower in {"none", "null"}:
             return None

--- a/ord_app/service_api/schemas/datasets.py
+++ b/ord_app/service_api/schemas/datasets.py
@@ -56,7 +56,7 @@ class DatasetWithReactionCountResponseSchema(DatasetResponseSchema):
     @model_validator(mode="before")
     @classmethod
     def reaction_count(cls, data: Any):  # noqa: F811
-        if isinstance(data, (Row, tuple)):
+        if isinstance(data, Row | tuple):
             _, rct_total, rct_invalid, rct_valid, rct_none = data
             # first element of the data is Dataset ORM object
             # second is reactions count

--- a/ord_app/tests/tests_datasets/test_share_dataset.py
+++ b/ord_app/tests/tests_datasets/test_share_dataset.py
@@ -66,12 +66,12 @@ async def test_share_and_unshare_dataset(api_client, mock_authenticated_user, te
         f"/api/v1/groups/{primary_group.id}/datasets/{primary_dataset.id}/share",
         json={"secondary_group_id": foreign_group.id},
     )
-    assert status.HTTP_403_FORBIDDEN == secondary_share_response.status_code
+    assert secondary_share_response.status_code == status.HTTP_403_FORBIDDEN
     secondary_share_response = api_client.post(
         f"/api/v1/groups/{secondary_group.id}/datasets/{primary_dataset.id}/share",
         json={"secondary_group_id": foreign_group.id},
     )
-    assert status.HTTP_403_FORBIDDEN == secondary_share_response.status_code
+    assert secondary_share_response.status_code == status.HTTP_403_FORBIDDEN
 
     # But he can update primary dataset
     payload = {"name": "updated name", "description": "updated description"}
@@ -98,7 +98,7 @@ async def test_share_and_unshare_dataset(api_client, mock_authenticated_user, te
     # Having been unshared, the secondary user has lost access: a 404 (not 403) so we don't reveal
     # that the dataset still exists. (#446)
     secondary_user_response = api_client.get(f"/api/v1/datasets/{primary_dataset.id}")
-    assert status.HTTP_404_NOT_FOUND == secondary_user_response.status_code
+    assert secondary_user_response.status_code == status.HTTP_404_NOT_FOUND
 
 
 async def test_share_dataset_to_the_same_group(api_client, mock_authenticated_user, test_db_session):
@@ -108,4 +108,4 @@ async def test_share_dataset_to_the_same_group(api_client, mock_authenticated_us
     response = api_client.post(
         f"/api/v1/groups/{group.id}/datasets/{dataset.id}/share", json={"secondary_group_id": group.id}
     )
-    assert status.HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/ord_app/tests/tests_reactions/test_update_reactions.py
+++ b/ord_app/tests/tests_reactions/test_update_reactions.py
@@ -44,7 +44,7 @@ async def test_update_nonexistent_reaction(api_client, mock_authenticated_user, 
     payload = {"binpb": b64encode(Reaction(reaction_id="test").SerializeToString()).decode()}
     response_data = api_client.patch(f"/api/v1/datasets/{dataset.id}/reactions/{100500}", json=payload)
 
-    assert status.HTTP_404_NOT_FOUND == response_data.status_code
+    assert response_data.status_code == status.HTTP_404_NOT_FOUND
 
 
 async def test_update_reaction_rejects_oversized_attachments(api_client, mock_authenticated_user, test_db_session):
@@ -57,7 +57,7 @@ async def test_update_reaction_rejects_oversized_attachments(api_client, mock_au
     payload = {"binpb": b64encode(pb_reaction.SerializeToString()).decode()}
     response = api_client.patch(f"/api/v1/datasets/{dataset.id}/reactions/{reaction.id}", json=payload)
 
-    assert status.HTTP_422_UNPROCESSABLE_ENTITY == response.status_code
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert "10 MB" in response.json()["detail"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,13 +73,20 @@ indent-width = 4
 target-version = "py312"
 
 [tool.ruff.lint]
-# Pyflakes (F), a subset of pycodestyle (E), import sorting (I), bugbear (B).
-select = ["E4", "E7", "E9", "F", "I", "B"]
-ignore = ["B008"]
+# Mirror ord-schema's ruleset: pycodestyle errors+warnings (E/W), pyflakes (F),
+# import sorting (I), bugbear (B), pyupgrade (UP), and flake8-simplify (SIM).
+select = ["E", "F", "W", "I", "B", "UP", "SIM"]
+# E501 (line length) is the formatter's job; SIM108 (ternaries aren't always
+# clearer); B008 (function calls in argument defaults are fine here, e.g. FastAPI Depends).
+ignore = ["E501", "SIM108", "B008"]
 fixable = ["ALL"]
 unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+# Tests redefine fixtures and use patterns bugbear dislikes (asserts, blind excepts).
+"ord_app/tests/**" = ["B011", "B017"]
 
 [tool.ruff.lint.isort]
 # ord_schema is an external dependency; pin its classification so import


### PR DESCRIPTION
## Summary

ord-app's ruff `select` had drifted from ord-schema's. ord-app ran only `E4/E7/E9, F, I, B`; ord-schema runs the broader `E, F, W, I, B, UP, SIM`. This adopts the same `select` so the two repos' linters match (part of the standing "mirror ord-schema's Astral tooling" effort).

- Full `E` + `W` added **zero** new violations (ord-app already passed those).
- The real delta is `UP` (pyupgrade) and `SIM` (flake8-simplify): 26 auto-fixed + 1 manual:
  - `Optional[X]`/`Union[...]` → `X | None`
  - `List`/`Dict` → `list`/`dict`; `typing.Sequence` → `collections.abc.Sequence`
  - `isinstance(x, (A, B))` → `isinstance(x, A | B)`
  - a few yoda conditions (`5 == x` → `x == 5`)
- `ignore` is tailored to what ord-app actually trips (`E501` → formatter's job, `SIM108`, `B008`) rather than copying ord-schema's debt-specific suppressions (`B028`, `SIM102/105/110`), which ord-app doesn't hit. Tests keep `B011`/`B017` per-file-ignores like ord-schema.

Return-type annotation rules (`ANN2*`) are intentionally **not** here — they're a separate PR (and net-new for both repos).

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `ty check ord_app` clean
- [x] 80 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns ord-app's ruff ruleset with ord-schema by expanding `select` from `E4/E7/E9, F, I, B` to the full `E, F, W, I, B, UP, SIM`. All 27 violations (26 auto-fixed, 1 manual) are purely mechanical modernisations with no functional impact.

- `UP` fixes: `Optional[X]` → `X | None`, `List`/`Dict` → `list`/`dict`, `Type` → `type`, `typing.Sequence` → `collections.abc.Sequence`, and `isinstance(x, (A, B))` → `isinstance(x, A | B)` — all valid for the project's Python 3.12 target.
- `SIM300` fixes: six yoda-condition assertions in test files flipped to the conventional `actual == expected` form.
- `pyproject.toml` gets a new `[tool.ruff.lint.per-file-ignores]` block suppressing `B011`/`B017` in tests, mirroring ord-schema's config.

<h3>Confidence Score: 5/5</h3>

All changes are purely mechanical linting modernisations with no logic alterations; 80 backend tests pass and ruff/ty checks are clean.

Every changed line is an auto-fix or trivial manual cleanup produced by the new ruff rules — no runtime behaviour is modified, all type annotations remain semantically equivalent, and the isinstance union syntax is valid on the project's Python 3.12 baseline.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Expands ruff ruleset to match ord-schema (adds E, W, UP, SIM); adds per-file ignores for test files; correctly ignores E501/SIM108/B008 |
| ord_app/service_api/repositories/base.py | Migrates Optional[T]/List[X]/Type[T] to modern builtins; fixes pre-existing Optional[T] | None redundancy to T | None; removes unused typing imports |
| ord_app/service_api/schemas/datasets.py | Converts isinstance tuple-form to union syntax (isinstance(data, Row | tuple)); valid for Python 3.10+ and project targets 3.12 |
| ord_app/service_api/domain/users.py | Removes typing.Optional import; updates return annotation to UserModel | None |
| ord_app/service_api/repositories/datasets.py | Removes typing.Optional; updates datasets_stmt parameter annotation to int | None |
| ord_app/tests/tests_datasets/test_share_dataset.py | Corrects four yoda-condition assertions (SIM300): status code on left moved to right |
| ord_app/tests/tests_reactions/test_update_reactions.py | Corrects two yoda-condition assertions (SIM300): status code on left moved to right |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: simplify redundant T | None | Non..."](https://github.com/open-reaction-database/ord-app/commit/f32eccb8b15ae041f2733d373386582cfa0b8c9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38832770)</sub>

<!-- /greptile_comment -->