### PR TITLE
chore: require full type annotations (ANN) + flake8-fastapi (FAST)

### DIFF
--- a/ord_app/service_api/domain/auth.py
+++ b/ord_app/service_api/domain/auth.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
+
 from fastapi import Depends
 from sqlalchemy import exists, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,18 +31,20 @@ from ord_app.service_api.services.exceptions import EntityNotFoundError, Forbidd
 from ord_app.service_api.services.postgresql import get_db_session
 
 
-async def authenticate(db_session: AsyncSession = Depends(get_db_session), token: dict = Depends(verify_access_token)):
+async def authenticate(
+    db_session: AsyncSession = Depends(get_db_session), token: dict = Depends(verify_access_token)
+) -> UserModel:
     if user := await UserRepository(db_session).get(auth0_id=token["sub"]):
         return user
     raise UnauthenticatedError(detail="Could not validate credentials", headers={"WWW-Authenticate": "Bearer"})
 
 
-def group_authorization(allowed_roles: tuple[UserRolesList, ...]):
+def group_authorization(allowed_roles: tuple[UserRolesList, ...]) -> Callable:
     async def _authorize(
         group_id: int | None,
         user: UserModel = Depends(authenticate),
         db_session: AsyncSession = Depends(get_db_session),
-    ):
+    ) -> None:
         stmt = select(
             exists().where(
                 UserGroupsMembershipModel.user_id == user.id,
@@ -54,12 +58,12 @@ def group_authorization(allowed_roles: tuple[UserRolesList, ...]):
     return _authorize
 
 
-def dataset_authorization(allowed_roles: tuple[UserRolesList, ...]):
+def dataset_authorization(allowed_roles: tuple[UserRolesList, ...]) -> Callable:
     async def _authorize(
         dataset_id: int | None,
         user: UserModel = Depends(authenticate),
         db_session: AsyncSession = Depends(get_db_session),
-    ):
+    ) -> None:
         membership = (
             DatasetGroupAssociationModel.dataset_id == dataset_id,
             DatasetGroupAssociationModel.dataset_id == DatasetModel.id,

--- a/ord_app/service_api/domain/datasets.py
+++ b/ord_app/service_api/domain/datasets.py
@@ -27,7 +27,7 @@ from starlette.concurrency import run_in_threadpool
 
 from ord_app.service_api.domain.auth import authenticate
 from ord_app.service_api.domain.exceptions import EntityDoesNotExist
-from ord_app.service_api.models import DatasetModel, GroupModel, UserModel
+from ord_app.service_api.models import DatasetGroupAssociationModel, DatasetModel, GroupModel, UserModel
 from ord_app.service_api.repositories.datasets import DatasetsRepository
 from ord_app.service_api.repositories.reactions import ReactionsRepository
 from ord_app.service_api.schemas.datasets import (
@@ -48,7 +48,7 @@ from ord_app.service_api.services.postgresql import get_db_session
 
 
 class DatasetUseCases:
-    def __init__(self, db: AsyncSession, current_user: UserModel):
+    def __init__(self, db: AsyncSession, current_user: UserModel) -> None:
         self.db = db
         self.current_user = current_user
         self.dataset_repository = DatasetsRepository(db)
@@ -61,7 +61,7 @@ class DatasetUseCases:
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
-    async def enumerate(self, group_id, payload: DatasetEnumerateCreateSchema):
+    async def enumerate(self, group_id, payload: DatasetEnumerateCreateSchema) -> DatasetModel:
         dataset_payload = {"name": payload.name, "description": payload.description}
         dataset = await self.dataset_repository.create(group_id, self.current_user.id, dataset_payload)
         await self.add_reactions(dataset, [Reaction.FromString(i) for i in payload.reactions])
@@ -71,7 +71,7 @@ class DatasetUseCases:
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
-    async def extend_enumerate(self, dataset_id: int, payload: DatasetEnumerateExtendSchema):
+    async def extend_enumerate(self, dataset_id: int, payload: DatasetEnumerateExtendSchema) -> DatasetModel:
         dataset = await self.dataset_repository.get(dataset_id)
         if dataset is None:
             raise EntityNotFoundError(f"Dataset {dataset_id} not found")
@@ -89,7 +89,7 @@ class DatasetUseCases:
     async def get_dataset_groups(self, dataset_id: int) -> list[GroupModel]:
         return await self.dataset_repository.get_dataset_groups(dataset_id)
 
-    async def extend(self, dataset_id: int, file_data, kind):
+    async def extend(self, dataset_id: int, file_data, kind) -> DatasetModel | None:
         try:
             dataset_pb = await run_in_threadpool(load_message, file_data, Dataset, kind)
         except (DecodeError, JsonParseError, TextParseError) as e:
@@ -102,7 +102,7 @@ class DatasetUseCases:
 
         return dataset
 
-    async def upload(self, group_id: int, file_data, kind):
+    async def upload(self, group_id: int, file_data, kind) -> DatasetModel:
         try:
             dataset_pb = await run_in_threadpool(load_message, file_data, Dataset, kind)
         except (DecodeError, JsonParseError, TextParseError) as e:
@@ -121,7 +121,7 @@ class DatasetUseCases:
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
-    async def add_reactions(self, dataset, reactions):
+    async def add_reactions(self, dataset, reactions) -> None:
         seen_ids = set()
         reactions_ids = []
 
@@ -163,7 +163,7 @@ class DatasetUseCases:
 
         logger.debug(f"Finished processing <Dataset(id={dataset.id})> Reactions.")
 
-    async def paginate_user_datasets(self):
+    async def paginate_user_datasets(self) -> Page[DatasetModel]:
         return await self.dataset_repository.datasets_stmt(self.current_user.id)
 
     async def update(self, dataset_id: int, payload: DatasetCreateSchema) -> DatasetModel:
@@ -174,7 +174,7 @@ class DatasetUseCases:
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
-    async def delete(self, dataset_id: int):
+    async def delete(self, dataset_id: int) -> None:
         return await self.dataset_repository.delete(dataset_id)
 
     async def download(self, dataset_id: int, file_format: DownloadFileFormats) -> tuple[DatasetModel, bytes]:
@@ -192,7 +192,9 @@ class DatasetUseCases:
         data = await run_in_threadpool(write_message, dataset_pb, kind=file_format)
         return dataset, data
 
-    async def share(self, primary_group_id: int, primary_dataset_id: int, payload: DatasetShareCreateSchema):
+    async def share(
+        self, primary_group_id: int, primary_dataset_id: int, payload: DatasetShareCreateSchema
+    ) -> DatasetGroupAssociationModel:
         if primary_group_id == payload.secondary_group_id:
             raise UnprocessableEntityError("Cannot share datasets with the same secondary group")
 
@@ -204,7 +206,7 @@ class DatasetUseCases:
 
         raise ForbiddenError(f"Dataset {primary_dataset_id} not owned by {primary_group_id}")
 
-    async def unshare(self, primary_group_id: int, primary_dataset_id: int, payload: DatasetShareCreateSchema):
+    async def unshare(self, primary_group_id: int, primary_dataset_id: int, payload: DatasetShareCreateSchema) -> None:
         if primary_group_id == payload.secondary_group_id:
             raise UnprocessableEntityError("Cannot unshare datasets with the same secondary group")
 

--- a/ord_app/service_api/domain/datasets.py
+++ b/ord_app/service_api/domain/datasets.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any
 from uuid import uuid4
 
 import orjson
@@ -61,7 +62,7 @@ class DatasetUseCases:
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
-    async def enumerate(self, group_id, payload: DatasetEnumerateCreateSchema) -> DatasetModel:
+    async def enumerate(self, group_id: int, payload: DatasetEnumerateCreateSchema) -> DatasetModel:
         dataset_payload = {"name": payload.name, "description": payload.description}
         dataset = await self.dataset_repository.create(group_id, self.current_user.id, dataset_payload)
         await self.add_reactions(dataset, [Reaction.FromString(i) for i in payload.reactions])
@@ -89,7 +90,7 @@ class DatasetUseCases:
     async def get_dataset_groups(self, dataset_id: int) -> list[GroupModel]:
         return await self.dataset_repository.get_dataset_groups(dataset_id)
 
-    async def extend(self, dataset_id: int, file_data, kind) -> DatasetModel | None:
+    async def extend(self, dataset_id: int, file_data: bytes, kind: str) -> DatasetModel | None:
         try:
             dataset_pb = await run_in_threadpool(load_message, file_data, Dataset, kind)
         except (DecodeError, JsonParseError, TextParseError) as e:
@@ -97,12 +98,13 @@ class DatasetUseCases:
             raise ProtobufDecodeError("An error occurred while reading the file.") from e
 
         dataset = await self.dataset_repository.get(dataset_id)
+        assert dataset is not None  # existence enforced upstream by dataset_authorization
         await self.add_reactions(dataset, dataset_pb.reactions)
         dataset = await self.dataset_repository.update_modified_at(dataset_id)
 
         return dataset
 
-    async def upload(self, group_id: int, file_data, kind) -> DatasetModel:
+    async def upload(self, group_id: int, file_data: bytes, kind: str) -> DatasetModel:
         try:
             dataset_pb = await run_in_threadpool(load_message, file_data, Dataset, kind)
         except (DecodeError, JsonParseError, TextParseError) as e:
@@ -121,7 +123,7 @@ class DatasetUseCases:
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
-    async def add_reactions(self, dataset, reactions) -> None:
+    async def add_reactions(self, dataset: DatasetModel, reactions: Any) -> None:
         seen_ids = set()
         reactions_ids = []
 

--- a/ord_app/service_api/domain/datasets.py
+++ b/ord_app/service_api/domain/datasets.py
@@ -98,7 +98,8 @@ class DatasetUseCases:
             raise ProtobufDecodeError("An error occurred while reading the file.") from e
 
         dataset = await self.dataset_repository.get(dataset_id)
-        assert dataset is not None  # existence enforced upstream by dataset_authorization
+        if dataset is None:
+            raise EntityNotFoundError(f"Dataset {dataset_id} not found")
         await self.add_reactions(dataset, dataset_pb.reactions)
         dataset = await self.dataset_repository.update_modified_at(dataset_id)
 

--- a/ord_app/service_api/domain/groups.py
+++ b/ord_app/service_api/domain/groups.py
@@ -26,39 +26,41 @@ from ord_app.service_api.services.postgresql import get_db_session
 
 
 class GroupUseCases:
-    def __init__(self, db: AsyncSession, current_user: UserModel):
+    def __init__(self, db: AsyncSession, current_user: UserModel) -> None:
         self.db = db
         self.current_user = current_user
         self.group_repository = GroupRepository(db)
 
-    async def create(self, payload: GroupCreateSchema):
+    async def create(self, payload: GroupCreateSchema) -> dict:
         group = await self.group_repository.create(self.current_user.id, payload.model_dump(exclude_unset=True))
         # The creator is added as the group's admin (see GroupRepository.create). (#569)
         return {"id": group.id, "name": group.name, "role": "admin"}
 
-    async def get(self, group_id: int):
+    async def get(self, group_id: int) -> dict:
         group = await self.group_repository.get(id=group_id)
         if group is None:
             raise EntityNotFoundError(f"Group {group_id} not found")
         role = await self.group_repository.get_user_role(self.current_user.id, group_id)
         return {"id": group.id, "name": group.name, "role": role}
 
-    async def user_groups(self):
+    async def user_groups(self) -> list[dict]:
         return await self.group_repository.get_user_groups(self.current_user.id)
 
-    async def update(self, group_id: int, payload: GroupCreateSchema):
+    async def update(self, group_id: int, payload: GroupCreateSchema) -> dict:
         group = await self.group_repository.update(payload.model_dump(), id=group_id)
         if group is None:
             raise EntityNotFoundError(f"Group {group_id} not found")
         role = await self.group_repository.get_user_role(self.current_user.id, group_id)
         return {"id": group.id, "name": group.name, "role": role}
 
-    async def delete(self, group_id: int):
+    async def delete(self, group_id: int) -> None:
         await self.group_repository.delete(id=group_id)
 
 
 class GroupMembersUseCases:
-    def __init__(self, db: AsyncSession = Depends(get_db_session), current_user: UserModel = Depends(authenticate)):
+    def __init__(
+        self, db: AsyncSession = Depends(get_db_session), current_user: UserModel = Depends(authenticate)
+    ) -> None:
         self.db = db
         self.current_user = current_user
         self.group_members_repository = GroupMembersRepository(db)
@@ -67,19 +69,19 @@ class GroupMembersUseCases:
     async def all(self, group_id: int) -> Sequence[UserGroupsMembershipModel]:
         return await self.group_members_repository.all(group_id)
 
-    async def add_member(self, group_id: int, payload: GroupAddMemberSchema):
+    async def add_member(self, group_id: int, payload: GroupAddMemberSchema) -> UserGroupsMembershipModel | None:
         if user := await self.user_repository.search_user_by_identity(payload.identity):
             await self.group_members_repository.add_member(user.id, group_id, payload.role)
             return await self.group_members_repository.get(user.id, group_id)
         raise EntityNotFoundError(f"<User(identity={payload.identity})> not found")
 
-    async def update_member(self, group_id: int, payload: GroupUpdateMemberSchema):
+    async def update_member(self, group_id: int, payload: GroupUpdateMemberSchema) -> UserGroupsMembershipModel | None:
         if user := await self.user_repository.get(id=payload.user_id):
             await self.group_members_repository.update_member(user.id, group_id, payload.role)
             return await self.group_members_repository.get(user.id, group_id)
         raise EntityNotFoundError(f"<User(identity={payload.user_id})> not found")
 
-    async def remove_members(self, group_id: int, members_ids: list[int]):
+    async def remove_members(self, group_id: int, members_ids: list[int]) -> None:
         await self.group_members_repository.remove_members(group_id, members_ids)
 
 

--- a/ord_app/service_api/domain/reactions.py
+++ b/ord_app/service_api/domain/reactions.py
@@ -49,7 +49,7 @@ from ord_app.service_api.services.pb_utils import (
 from ord_app.service_api.services.postgresql import get_db_session
 
 
-async def validate_dataset_reactions(db: AsyncSession, dataset_id: int | None = None):
+async def validate_dataset_reactions(db: AsyncSession, dataset_id: int | None = None) -> None:
     reaction_repo = ReactionsRepository(db)
     async for reactions in reaction_repo.stream_reactions(chunk_size=1000, dataset_id=dataset_id):
         update_values = []
@@ -78,14 +78,14 @@ class CreateReactionsUseCases:
 class ReactionsUseCase:
     model = ReactionModel
 
-    def __init__(self, db: AsyncSession, current_user: UserModel):
+    def __init__(self, db: AsyncSession, current_user: UserModel) -> None:
         self.db = db
         self.current_user = current_user
         self.reaction_repo = ReactionsRepository(db)
         self.dataset_repo = DatasetsRepository(db)
 
     @staticmethod
-    def _enforce_attachment_limit(pb_reaction: Reaction):
+    def _enforce_attachment_limit(pb_reaction: Reaction) -> None:
         """Reject reactions whose cumulative file attachments exceed the size cap."""
         if total_attachment_size(pb_reaction) > MAX_REACTION_ATTACHMENTS_SIZE:
             raise UnprocessableEntityError(
@@ -93,7 +93,7 @@ class ReactionsUseCase:
                 f"{MAX_REACTION_ATTACHMENTS_SIZE // (1024 * 1024)} MB"
             )
 
-    async def _create_reaction(self, dataset_id: int, pb_reaction: Reaction):
+    async def _create_reaction(self, dataset_id: int, pb_reaction: Reaction) -> ReactionModel:
         self._enforce_attachment_limit(pb_reaction)
         # validate reaction id
         if len(pb_reaction.reaction_id) > MAX_CRITICAL_FIELD_LENGTH:
@@ -116,7 +116,7 @@ class ReactionsUseCase:
         db_reaction.validation = {"errors": errors, "warnings": warnings}
         return db_reaction
 
-    async def create(self, dataset_id: int, payload: ReactionCreateSchema):
+    async def create(self, dataset_id: int, payload: ReactionCreateSchema) -> ReactionModel:
         try:
             pb_reaction = cast(Reaction, await run_in_threadpool(load_message, payload.binpb, Reaction, "binpb"))
         except (DecodeError, JsonParseError, TextParseError) as e:
@@ -131,7 +131,7 @@ class ReactionsUseCase:
         await self.dataset_repo.update_modified_at(dataset_id)
         return reaction
 
-    async def create_from_scratch(self, dataset_id: int):
+    async def create_from_scratch(self, dataset_id: int) -> ReactionModel:
         person = Person(
             username=self.current_user.external_id,
             name=self.current_user.name,
@@ -146,7 +146,7 @@ class ReactionsUseCase:
         await self.dataset_repo.update_modified_at(dataset_id)
         return reaction
 
-    async def upload(self, dataset_id: int, file_data, kind):
+    async def upload(self, dataset_id: int, file_data, kind) -> ReactionModel:
         try:
             pb_reaction = cast(Reaction, await run_in_threadpool(load_message, file_data, Reaction, kind))
         except (DecodeError, JsonParseError, TextParseError) as e:
@@ -171,19 +171,19 @@ class ReactionsUseCase:
             self.reaction_repo.all_reactions_stmt(dataset_id, is_valid_query.model_dump(exclude_unset=True)),
         )
 
-    async def get(self, dataset_id: int, reaction_id: int):
+    async def get(self, dataset_id: int, reaction_id: int) -> ReactionModel:
         if reaction := await self.reaction_repo.get(id=reaction_id, dataset_id=dataset_id):
             _, errors, warning = await async_validate_pb_reaction(reaction.pb)
             reaction.validation = {"errors": errors, "warnings": warning}
             return reaction
         raise EntityNotFoundError(f"Reaction with id={reaction_id} not found")
 
-    async def search(self, **kwargs):
+    async def search(self, **kwargs) -> ReactionModel:
         if reaction := await self.reaction_repo.get(**kwargs):
             return reaction
         raise EntityNotFoundError(f"Reaction with {kwargs} not found")
 
-    async def update(self, dataset_id: int, reaction_id: int, payload: ReactionUpdateSchema):
+    async def update(self, dataset_id: int, reaction_id: int, payload: ReactionUpdateSchema) -> ReactionModel:
         pb_reaction = cast(Reaction, await run_in_threadpool(load_message, payload.binpb, Reaction, "binpb"))
         self._enforce_attachment_limit(pb_reaction)
         pb_reaction_id = (pb_reaction.reaction_id or "").strip()
@@ -219,11 +219,13 @@ class ReactionsUseCase:
         reaction.validation = {"errors": errors, "warnings": warning}
         return reaction
 
-    async def delete(self, dataset_id: int, reaction_id: int):
+    async def delete(self, dataset_id: int, reaction_id: int) -> None:
         await self.reaction_repo.delete(dataset_id=dataset_id, id=reaction_id)
         await self.dataset_repo.update_modified_at(dataset_id)
 
-    async def download(self, dataset_id: int, reaction_id: int, file_format: DownloadFileFormats):
+    async def download(
+        self, dataset_id: int, reaction_id: int, file_format: DownloadFileFormats
+    ) -> tuple[ReactionModel, bytes]:
         if reaction := await self.reaction_repo.get(id=reaction_id, dataset_id=dataset_id):
             reaction_pb = await run_in_threadpool(write_message, Reaction.FromString(reaction.binpb), kind=file_format)
             return reaction, reaction_pb

--- a/ord_app/service_api/domain/reactions.py
+++ b/ord_app/service_api/domain/reactions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 from uuid import uuid4
 
 from fastapi import Depends
@@ -146,7 +146,7 @@ class ReactionsUseCase:
         await self.dataset_repo.update_modified_at(dataset_id)
         return reaction
 
-    async def upload(self, dataset_id: int, file_data, kind) -> ReactionModel:
+    async def upload(self, dataset_id: int, file_data: bytes, kind: str) -> ReactionModel:
         try:
             pb_reaction = cast(Reaction, await run_in_threadpool(load_message, file_data, Reaction, kind))
         except (DecodeError, JsonParseError, TextParseError) as e:
@@ -178,7 +178,7 @@ class ReactionsUseCase:
             return reaction
         raise EntityNotFoundError(f"Reaction with id={reaction_id} not found")
 
-    async def search(self, **kwargs) -> ReactionModel:
+    async def search(self, **kwargs: Any) -> ReactionModel:
         if reaction := await self.reaction_repo.get(**kwargs):
             return reaction
         raise EntityNotFoundError(f"Reaction with {kwargs} not found")

--- a/ord_app/service_api/domain/templates.py
+++ b/ord_app/service_api/domain/templates.py
@@ -26,7 +26,7 @@ from ord_app.service_api.services.postgresql import get_db_session
 
 
 class TemplatesUseCase:
-    def __init__(self, db: AsyncSession, current_user: UserModel):
+    def __init__(self, db: AsyncSession, current_user: UserModel) -> None:
         self.db = db
         self.current_user = current_user
         self.template_repo = TemplateRepository(db)
@@ -43,13 +43,13 @@ class TemplatesUseCase:
             return template
         raise EntityNotFoundError("Template not found")
 
-    async def update(self, template_id: int, payload: TemplateUpdateModel):
+    async def update(self, template_id: int, payload: TemplateUpdateModel) -> TemplateModel:
         data = payload.model_dump(exclude_none=True)
         if template := await self.template_repo.update(data, id=template_id, owner_id=self.current_user.id):
             return template
         raise EntityNotFoundError("Template not found")
 
-    async def delete(self, template_id: int):
+    async def delete(self, template_id: int) -> int:
         if count := await self.template_repo.delete(id=template_id, owner_id=self.current_user.id):
             return count
         raise EntityNotFoundError("Template not found")

--- a/ord_app/service_api/domain/users.py
+++ b/ord_app/service_api/domain/users.py
@@ -31,7 +31,7 @@ from ord_app.service_api.services.postgresql import get_db_session
 
 
 class UserUseCase:
-    def __init__(self, db: AsyncSession, current_user: UserModel | None = None):
+    def __init__(self, db: AsyncSession, current_user: UserModel | None = None) -> None:
         self.db = db
         self.current_user = current_user
         self.user_repo = UserRepository(db)
@@ -45,7 +45,7 @@ class UserUseCase:
     async def get_user_by_auth0_id(self, auth0_id: str) -> UserModel | None:
         return await self.user_repo.get(auth0_id=auth0_id)
 
-    async def update(self, user_id: int, payload: UserUpdateSchema):
+    async def update(self, user_id: int, payload: UserUpdateSchema) -> UserModel:
         if self.current_user is None or self.current_user.id != user_id:
             raise ForbiddenError("Action prohibited")
         if user := await self.user_repo.update(payload.model_dump(exclude_unset=True), id=user_id):
@@ -96,7 +96,7 @@ async def _provision_e2e_user(db_session: AsyncSession) -> UserModel:
     return user
 
 
-async def jit_provisioning(db_session: AsyncSession, payload: Auth0CreateSchema):
+async def jit_provisioning(db_session: AsyncSession, payload: Auth0CreateSchema) -> UserModel | None:
     if e2e_auth_enabled():
         return await _provision_e2e_user(db_session)
 

--- a/ord_app/service_api/main.py
+++ b/ord_app/service_api/main.py
@@ -24,6 +24,7 @@ from fastapi_pagination import add_pagination
 from loguru import logger
 from rdkit import RDLogger
 from sqlalchemy.exc import DataError, DBAPIError
+from starlette.middleware.base import RequestResponseEndpoint
 from starlette.responses import JSONResponse
 
 from ord_app.service_api.constants import AppEnvs
@@ -63,7 +64,7 @@ app = FastAPI(root_path="/service_api", swagger_ui_parameters={"tryItOutEnabled"
 
 
 @app.middleware("http")
-async def catch_errors(request: Request, call_next) -> Response:
+async def catch_errors(request: Request, call_next: RequestResponseEndpoint) -> Response:
     try:
         return await call_next(request)
     except (DataError, DBAPIError) as err:

--- a/ord_app/service_api/main.py
+++ b/ord_app/service_api/main.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 import asyncio
 import sys
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 
 import asyncpg
 import psycopg.errors
-from fastapi import APIRouter, FastAPI, Request, status
+from fastapi import APIRouter, FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_pagination import add_pagination
 from loguru import logger
@@ -42,13 +43,13 @@ match RuntimeSettings.app_env:
         logger.add(sys.stdout, level="INFO")
 
 
-async def run_background_task():
+async def run_background_task() -> None:
     async with db_session_maker() as db:
         await validate_dataset_reactions(db)
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Keep a reference so the task isn't garbage-collected before it completes.
     app.state.background_task = asyncio.create_task(run_background_task())
     yield
@@ -62,7 +63,7 @@ app = FastAPI(root_path="/service_api", swagger_ui_parameters={"tryItOutEnabled"
 
 
 @app.middleware("http")
-async def catch_errors(request: Request, call_next):
+async def catch_errors(request: Request, call_next) -> Response:
     try:
         return await call_next(request)
     except (DataError, DBAPIError) as err:
@@ -117,5 +118,5 @@ add_pagination(app)
 
 
 @app.get("/healthcheck")
-async def health_check():
+async def health_check() -> bool:
     return True

--- a/ord_app/service_api/models.py
+++ b/ord_app/service_api/models.py
@@ -30,7 +30,8 @@ class BaseModel(DeclarativeBase):
     modified_at: Mapped[datetime.datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
 
     @declared_attr
-    def __tablename__(cls):
+    # @declared_attr's typing expects an ORM descriptor return, not a plain `-> str`.
+    def __tablename__(cls):  # noqa: ANN204
         return re.sub(r"(?<!^)(?=[A-Z])", "_", cls.__name__.removesuffix("Model")).lower()
 
 
@@ -51,7 +52,7 @@ class UserModel(BaseModel):
 
     templates: Mapped["TemplateModel"] = relationship("TemplateModel", back_populates="owner")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<User(id={self.id}, email={self.email})>"
 
 
@@ -73,7 +74,7 @@ class GroupModel(BaseModel):
         overlaps="groups_member",
     )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<Group(id={self.id}, name={self.name})>"
 
 
@@ -93,7 +94,7 @@ class UserGroupsMembershipModel(BaseModel):
         )
     )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<UserGroup(user_id={self.user_id}, group_id={self.group_id}, role={self.role})>"
 
 
@@ -117,7 +118,7 @@ class DatasetModel(BaseModel):
 
     __table_args__ = (Index("ix_dataset_owner_id", "owner_id", postgresql_using="hash"),)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<Dataset(id={self.id}, name={self.name}, user_id={self.owner_id})>"
 
 
@@ -139,7 +140,7 @@ class DatasetGroupAssociationModel(BaseModel):
     # This flag indicates that this is the main group and that related dataset can be shared with another group.
     is_primary: Mapped[bool] = mapped_column(default=True)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "<DatasetGroupAssociation("
             f"dataset_id={self.dataset_id}, group_id={self.group_id}, is_primary={self.is_primary}"
@@ -157,7 +158,7 @@ class ReactionModel(BaseModel):
     id: Mapped[int] = mapped_column(primary_key=True)
     pb_reaction_id: Mapped[str]
     binpb: Mapped[bytes] = mapped_column(LargeBinary, nullable=True)
-    is_valid: Mapped[bool] = mapped_column(nullable=True)
+    is_valid: Mapped[bool | None] = mapped_column(nullable=True)
 
     dataset_id: Mapped[int] = mapped_column(ForeignKey("dataset.id", ondelete="CASCADE"))
     dataset: Mapped[DatasetModel] = relationship(DatasetModel, back_populates="reactions")
@@ -172,7 +173,7 @@ class ReactionModel(BaseModel):
         Index("ix_reaction_owner_id", "owner_id", postgresql_using="hash"),
     )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<Reaction(id={self.id}, dataset_id={self.dataset_id}, name={self.pb_reaction_id})>"
 
     @property
@@ -191,5 +192,5 @@ class TemplateModel(BaseModel):
 
     __table_args__ = (Index("ix_template_owner_id", "owner_id", postgresql_using="hash"),)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<Template(id={self.id}, name={self.name})>"

--- a/ord_app/service_api/models.py
+++ b/ord_app/service_api/models.py
@@ -57,6 +57,12 @@ class UserModel(BaseModel):
 
 
 class GroupModel(BaseModel):
+    # The current user's role in this group is computed per request and attached for
+    # serialization; it is not persisted. __allow_unmapped__ keeps SQLAlchemy from
+    # treating this plain annotation as a mapped column.
+    __allow_unmapped__ = True
+    role: "UserRolesList | None" = None
+
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(nullable=True)
     owner_id: Mapped[int] = mapped_column(ForeignKey("user.id", ondelete="SET NULL"), nullable=True)

--- a/ord_app/service_api/repositories/base.py
+++ b/ord_app/service_api/repositories/base.py
@@ -38,7 +38,7 @@ class AbstractRepository(ABC, Generic[T]):
         self.current_user = current_user
 
     @abstractmethod
-    async def get(self, **kwargs) -> T | None:
+    async def get(self, **kwargs: Any) -> T | None:
         pass
 
 
@@ -63,17 +63,17 @@ class BaseRepository(AbstractRepository[T]):
         await self.db.refresh(instance)
         return instance
 
-    async def get(self, **kwargs) -> T | None:
+    async def get(self, **kwargs: Any) -> T | None:
         stmt = select(self.model).where(*self._get_filter_stmt(self.model, **kwargs))
         result = await self.db.scalar(stmt)
         return result
 
-    async def filter(self, **kwargs) -> Sequence[T]:
+    async def filter(self, **kwargs: Any) -> Sequence[T]:
         stmt = select(self.model).where(*self._get_filter_stmt(self.model, **kwargs))
         result = await self.db.scalars(stmt)
         return result.all()
 
-    async def update(self, payload: dict, autocommit: bool = True, **kwargs) -> T | None:
+    async def update(self, payload: dict, autocommit: bool = True, **kwargs: Any) -> T | None:
         stmt = (
             update(self.model)
             .where(*self._get_filter_stmt(self.model, **kwargs))
@@ -87,7 +87,7 @@ class BaseRepository(AbstractRepository[T]):
             logger.debug(f"{self.model.__name__} updated with payload: {payload}")
             return obj
 
-    async def delete(self, **kwargs) -> int:
+    async def delete(self, **kwargs: Any) -> int:
         stmt = delete(self.model).where(*self._get_filter_stmt(self.model, **kwargs))
         result = await self.db.execute(stmt)
         await self.db.commit()

--- a/ord_app/service_api/repositories/datasets.py
+++ b/ord_app/service_api/repositories/datasets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlalchemy import paginate
 from loguru import logger
 from sqlalchemy import and_, delete, func, select, update
@@ -37,10 +38,10 @@ SELECT_STMT = (
 
 
 class DatasetsRepository:
-    def __init__(self, db: AsyncSession):
+    def __init__(self, db: AsyncSession) -> None:
         self.db = db
 
-    async def update_modified_at(self, dataset_id: int):
+    async def update_modified_at(self, dataset_id: int) -> DatasetModel | None:
         stmt = (
             update(DatasetModel)
             .where(DatasetModel.id == dataset_id)
@@ -75,7 +76,7 @@ class DatasetsRepository:
         )
         return await self.db.scalar(stmt)
 
-    async def get_with_sharable_info(self, dataset_id: int, user_id: int):
+    async def get_with_sharable_info(self, dataset_id: int, user_id: int) -> DatasetModel:
         stmt = (
             select(*SELECT_STMT)
             .outerjoin(DatasetModel.reactions)
@@ -129,7 +130,7 @@ class DatasetsRepository:
         stmt = select(DatasetModel).where(DatasetModel.id == dataset_id).options(selectinload(DatasetModel.reactions))
         return await self.db.scalar(stmt)
 
-    async def enrich_datasets_with_user_roles(self, datasets, user_id):
+    async def enrich_datasets_with_user_roles(self, datasets, user_id) -> None:
         # Collect all group IDs from the paginated datasets
         group_ids = {group.id for dataset in datasets for group in dataset.groups}
 
@@ -148,7 +149,7 @@ class DatasetsRepository:
             # filter out groups that the user is not a member of
             dataset.groups = [group for group in dataset.groups if group.role is not None]
 
-    async def datasets_stmt(self, user_id: int, group_id: int | None = None):
+    async def datasets_stmt(self, user_id: int, group_id: int | None = None) -> Page[DatasetModel]:
         filters = [DatasetModel.groups.any(GroupModel.members.any(UserModel.id == user_id))]
 
         if group_id is not None:
@@ -167,7 +168,7 @@ class DatasetsRepository:
 
         return paginated_datasets
 
-    async def update(self, dataset_id: int, payload: dict, autocommit: bool = True):
+    async def update(self, dataset_id: int, payload: dict, autocommit: bool = True) -> None:
         stmt = update(DatasetModel).where(DatasetModel.id == dataset_id).values(**payload)
 
         if autocommit:
@@ -175,13 +176,13 @@ class DatasetsRepository:
             await self.db.commit()
             logger.debug(f"{dataset_id} updated with payload: {payload}")
 
-    async def delete(self, dataset_id: int):
+    async def delete(self, dataset_id: int) -> None:
         stmt = delete(DatasetModel).where(DatasetModel.id == dataset_id)
         await self.db.execute(stmt)
         await self.db.commit()
         logger.debug(f"<Dataset(id={dataset_id})> deleted")
 
-    async def get_dataset_group_association(self, group_id, dataset_id: int):
+    async def get_dataset_group_association(self, group_id, dataset_id: int) -> DatasetGroupAssociationModel | None:
         dataset_group_association_stmt = select(DatasetGroupAssociationModel).where(
             DatasetGroupAssociationModel.group_id == group_id,
             DatasetGroupAssociationModel.dataset_id == dataset_id,
@@ -189,7 +190,7 @@ class DatasetsRepository:
         )
         return await self.db.scalar(dataset_group_association_stmt)
 
-    async def share_dataset(self, primary_dataset_id: int, secondary_group_id: int):
+    async def share_dataset(self, primary_dataset_id: int, secondary_group_id: int) -> DatasetGroupAssociationModel:
         dataset_group_association = DatasetGroupAssociationModel(
             dataset_id=primary_dataset_id, group_id=secondary_group_id, is_primary=False
         )
@@ -198,7 +199,7 @@ class DatasetsRepository:
         await self.db.refresh(dataset_group_association)
         return dataset_group_association
 
-    async def unshare_dataset(self, primary_dataset_id: int, secondary_group_id: int):
+    async def unshare_dataset(self, primary_dataset_id: int, secondary_group_id: int) -> None:
         stmt = delete(DatasetGroupAssociationModel).where(
             DatasetGroupAssociationModel.dataset_id == primary_dataset_id,
             DatasetGroupAssociationModel.group_id == secondary_group_id,

--- a/ord_app/service_api/repositories/datasets.py
+++ b/ord_app/service_api/repositories/datasets.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Sequence
+
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlalchemy import paginate
 from loguru import logger
@@ -52,7 +54,7 @@ class DatasetsRepository:
         await self.db.commit()
         return dataset
 
-    async def create(self, group_id: int, owner_id: int, payload: dict, autocommit=True) -> DatasetModel:
+    async def create(self, group_id: int, owner_id: int, payload: dict, autocommit: bool = True) -> DatasetModel:
         dataset = DatasetModel(owner_id=owner_id, **payload)
         dataset_group_association = DatasetGroupAssociationModel(dataset=dataset, group_id=group_id)
         self.db.add_all([dataset, dataset_group_association])
@@ -130,7 +132,7 @@ class DatasetsRepository:
         stmt = select(DatasetModel).where(DatasetModel.id == dataset_id).options(selectinload(DatasetModel.reactions))
         return await self.db.scalar(stmt)
 
-    async def enrich_datasets_with_user_roles(self, datasets, user_id) -> None:
+    async def enrich_datasets_with_user_roles(self, datasets: Sequence[DatasetModel], user_id: int) -> None:
         # Collect all group IDs from the paginated datasets
         group_ids = {group.id for dataset in datasets for group in dataset.groups}
 
@@ -182,7 +184,9 @@ class DatasetsRepository:
         await self.db.commit()
         logger.debug(f"<Dataset(id={dataset_id})> deleted")
 
-    async def get_dataset_group_association(self, group_id, dataset_id: int) -> DatasetGroupAssociationModel | None:
+    async def get_dataset_group_association(
+        self, group_id: int, dataset_id: int
+    ) -> DatasetGroupAssociationModel | None:
         dataset_group_association_stmt = select(DatasetGroupAssociationModel).where(
             DatasetGroupAssociationModel.group_id == group_id,
             DatasetGroupAssociationModel.dataset_id == dataset_id,

--- a/ord_app/service_api/repositories/groups.py
+++ b/ord_app/service_api/repositories/groups.py
@@ -43,7 +43,7 @@ class GroupRepository(BaseRepository[GroupModel]):
 
         return group
 
-    async def get_user_groups(self, user_id: int):
+    async def get_user_groups(self, user_id: int) -> list[dict]:
         stmt = (
             select(GroupModel, UserGroupsMembershipModel)
             .join(UserGroupsMembershipModel, UserGroupsMembershipModel.group_id == GroupModel.id)
@@ -62,7 +62,7 @@ class GroupRepository(BaseRepository[GroupModel]):
 
 
 class GroupMembersRepository:
-    def __init__(self, db: AsyncSession, autocommit: bool = True):
+    def __init__(self, db: AsyncSession, autocommit: bool = True) -> None:
         self.db = db
         self.autocommit = autocommit
 
@@ -87,7 +87,7 @@ class GroupMembersRepository:
         )
         return (await self.db.scalars(stmt)).all()
 
-    async def add_member(self, user_id: int, group_id: int, role: str, autocommit: bool = True):
+    async def add_member(self, user_id: int, group_id: int, role: str, autocommit: bool = True) -> None:
         value = {"user_id": user_id, "group_id": group_id, "role": role}
         stmt = insert(UserGroupsMembershipModel).values(value)
         if autocommit:
@@ -95,7 +95,7 @@ class GroupMembersRepository:
             await self.db.commit()
             logger.debug(f"Member {user_id} added to {group_id} with role: {role}")
 
-    async def update_member(self, user_id: int, group_id: int, role: str, autocommit: bool = True):
+    async def update_member(self, user_id: int, group_id: int, role: str, autocommit: bool = True) -> None:
         stmt = (
             update(UserGroupsMembershipModel)
             .where(
@@ -108,7 +108,7 @@ class GroupMembersRepository:
             await self.db.execute(stmt)
             await self.db.commit()
 
-    async def upsert(self, user_id: int, group_id: int, role: str, autocommit: bool = True):
+    async def upsert(self, user_id: int, group_id: int, role: str, autocommit: bool = True) -> None:
         value = {"user_id": user_id, "group_id": group_id, "role": role}
         stmt = insert(UserGroupsMembershipModel).values(value)
         stmt = stmt.on_conflict_do_update(
@@ -121,7 +121,7 @@ class GroupMembersRepository:
             await self.db.commit()
             logger.debug(f"Members upsert: {value}")
 
-    async def remove_members(self, group_id, members_ids: list[int]):
+    async def remove_members(self, group_id, members_ids: list[int]) -> None:
         stmt = delete(UserGroupsMembershipModel).where(
             UserGroupsMembershipModel.group_id == group_id,
             UserGroupsMembershipModel.user_id.in_(members_ids),

--- a/ord_app/service_api/repositories/groups.py
+++ b/ord_app/service_api/repositories/groups.py
@@ -121,7 +121,7 @@ class GroupMembersRepository:
             await self.db.commit()
             logger.debug(f"Members upsert: {value}")
 
-    async def remove_members(self, group_id, members_ids: list[int]) -> None:
+    async def remove_members(self, group_id: int, members_ids: list[int]) -> None:
         stmt = delete(UserGroupsMembershipModel).where(
             UserGroupsMembershipModel.group_id == group_id,
             UserGroupsMembershipModel.user_id.in_(members_ids),

--- a/ord_app/service_api/repositories/reactions.py
+++ b/ord_app/service_api/repositories/reactions.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import AsyncIterator, Sequence
 from itertools import batched
 
 from loguru import logger
-from sqlalchemy import insert, or_, select, true, update
+from sqlalchemy import Select, insert, or_, select, true, update
 
 from ord_app.service_api.models import ReactionModel
 from ord_app.service_api.repositories.base import BaseRepository
@@ -23,16 +24,20 @@ from ord_app.service_api.repositories.base import BaseRepository
 class ReactionsRepository(BaseRepository[ReactionModel]):
     model = ReactionModel
 
-    async def get_by_reaction_ids_gen(self, dataset_id: int, pb_reaction_ids: list[str], max_num_query_args=10_000):
+    async def get_by_reaction_ids_gen(
+        self, dataset_id: int, pb_reaction_ids: list[str], max_num_query_args=10_000
+    ) -> AsyncIterator[ReactionModel]:
         for batch in batched(pb_reaction_ids, max_num_query_args):
             for item in await self.filter(dataset_id=dataset_id, pb_reaction_id=batch):
                 yield item
 
-    async def bulk_update(self, values):
+    async def bulk_update(self, values) -> None:
         await self.db.execute(update(ReactionModel), values)
         await self.db.commit()
 
-    async def stream_reactions(self, chunk_size: int = 1000, dataset_id: int | None = None):
+    async def stream_reactions(
+        self, chunk_size: int = 1000, dataset_id: int | None = None
+    ) -> AsyncIterator[Sequence[ReactionModel]]:
         last_id = None
         while True:
             stmt = (
@@ -55,7 +60,7 @@ class ReactionsRepository(BaseRepository[ReactionModel]):
     # takes a wider signature than the base create(payload).
     async def create(  # ty: ignore[invalid-method-override]
         self, dataset_id: int, user_id: int, payload: dict, autocommit: bool = True
-    ):
+    ) -> ReactionModel:
         reaction = ReactionModel(owner_id=user_id, dataset_id=dataset_id, **payload)
 
         if autocommit:
@@ -66,7 +71,7 @@ class ReactionsRepository(BaseRepository[ReactionModel]):
 
         return reaction
 
-    def all_reactions_stmt(self, dataset_id: int, is_valid_query: dict | None = None):
+    def all_reactions_stmt(self, dataset_id: int, is_valid_query: dict | None = None) -> Select:
         stmt = select(ReactionModel).where(ReactionModel.dataset_id == dataset_id).order_by(ReactionModel.id)
 
         if is_valid_query is not None:
@@ -78,7 +83,7 @@ class ReactionsRepository(BaseRepository[ReactionModel]):
 
         return stmt
 
-    async def bulk_create(self, payload: list[dict], autocommit: bool = True):
+    async def bulk_create(self, payload: list[dict], autocommit: bool = True) -> None:
         stmt = insert(ReactionModel).values(payload)
         if autocommit:
             await self.db.execute(stmt)
@@ -87,7 +92,7 @@ class ReactionsRepository(BaseRepository[ReactionModel]):
 
     async def find_duplicated_by_pb_reaction_id(
         self, dataset_id: int, pb_reaction_id, exclude_pb_reaction_ids: list[str]
-    ):
+    ) -> ReactionModel | None:
         stmt = (
             select(ReactionModel)
             .where(

--- a/ord_app/service_api/repositories/reactions.py
+++ b/ord_app/service_api/repositories/reactions.py
@@ -25,13 +25,13 @@ class ReactionsRepository(BaseRepository[ReactionModel]):
     model = ReactionModel
 
     async def get_by_reaction_ids_gen(
-        self, dataset_id: int, pb_reaction_ids: list[str], max_num_query_args=10_000
+        self, dataset_id: int, pb_reaction_ids: list[str], max_num_query_args: int = 10_000
     ) -> AsyncIterator[ReactionModel]:
         for batch in batched(pb_reaction_ids, max_num_query_args):
             for item in await self.filter(dataset_id=dataset_id, pb_reaction_id=batch):
                 yield item
 
-    async def bulk_update(self, values) -> None:
+    async def bulk_update(self, values: list[dict]) -> None:
         await self.db.execute(update(ReactionModel), values)
         await self.db.commit()
 
@@ -91,7 +91,7 @@ class ReactionsRepository(BaseRepository[ReactionModel]):
             logger.debug("Bulk reaction created with payload")
 
     async def find_duplicated_by_pb_reaction_id(
-        self, dataset_id: int, pb_reaction_id, exclude_pb_reaction_ids: list[str]
+        self, dataset_id: int, pb_reaction_id: str, exclude_pb_reaction_ids: list[str]
     ) -> ReactionModel | None:
         stmt = (
             select(ReactionModel)

--- a/ord_app/service_api/repositories/users.py
+++ b/ord_app/service_api/repositories/users.py
@@ -34,7 +34,7 @@ class UserRepository(BaseRepository[UserModel]):
 
         return await self.db.scalar(stmt)
 
-    async def create_user(self, payload: dict, autocommit=True) -> UserModel:
+    async def create_user(self, payload: dict, autocommit: bool = True) -> UserModel:
         user = UserModel(**payload)
         if autocommit:
             await self.db.commit()

--- a/ord_app/service_api/resources/v1/auth.py
+++ b/ord_app/service_api/resources/v1/auth.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ord_app.service_api.domain.users import jit_provisioning
+from ord_app.service_api.models import UserModel
 from ord_app.service_api.schemas.auth import Auth0CreateSchema
 from ord_app.service_api.schemas.users import UserResponseSchema
 from ord_app.service_api.services.postgresql import get_db_session
@@ -26,5 +27,5 @@ router = APIRouter(prefix="/auth", tags=["Authorization"])
 async def _jit_provisioning(
     payload: Auth0CreateSchema,
     db_session: AsyncSession = Depends(get_db_session),
-):
+) -> UserModel | None:
     return await jit_provisioning(db_session, payload)

--- a/ord_app/service_api/resources/v1/auth.py
+++ b/ord_app/service_api/resources/v1/auth.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,6 +28,6 @@ router = APIRouter(prefix="/auth", tags=["Authorization"])
 @router.post("/jit-provisioning", status_code=status.HTTP_201_CREATED, response_model=UserResponseSchema)
 async def _jit_provisioning(
     payload: Auth0CreateSchema,
-    db_session: AsyncSession = Depends(get_db_session),
+    db_session: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> UserModel | None:
     return await jit_provisioning(db_session, payload)

--- a/ord_app/service_api/resources/v1/datasets.py
+++ b/ord_app/service_api/resources/v1/datasets.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ord_app.service_api.domain.auth import dataset_authorization, group_authorization
 from ord_app.service_api.domain.datasets import DatasetUseCases, get_dataset_use_case
 from ord_app.service_api.domain.reactions import validate_dataset_reactions
+from ord_app.service_api.models import DatasetGroupAssociationModel, DatasetModel, GroupModel
 from ord_app.service_api.schemas.datasets import (
     DatasetCreateSchema,
     DatasetEnumerateCreateSchema,
@@ -52,7 +53,7 @@ async def create_dataset(
     group_id: int,
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
     payload: DatasetCreateSchema,
-):
+) -> DatasetModel:
     return await use_case.create(group_id, payload)
 
 
@@ -64,7 +65,7 @@ async def create_dataset(
 async def get_group_datasets(
     group_id: int,
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
+) -> Page[DatasetModel]:
     result = await use_case.paginate_group_datasets(group_id)
     return result
 
@@ -80,7 +81,7 @@ async def upload_dataset(
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
     db: Annotated[AsyncSession, Depends(get_db_session)],
     background_tasks: BackgroundTasks,
-):
+) -> DatasetModel:
     file_data, kind = await validate_uploaded_pb_file(file)
     dataset = await use_case.upload(group_id, file_data, kind)
     background_tasks.add_task(validate_dataset_reactions, db, dataset.id)
@@ -99,7 +100,7 @@ async def enumerate_dataset(
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
     db: Annotated[AsyncSession, Depends(get_db_session)],
     background_tasks: BackgroundTasks,
-):
+) -> DatasetModel:
     dataset = await use_case.enumerate(group_id, payload)
     background_tasks.add_task(validate_dataset_reactions, db, dataset.id)
     return dataset
@@ -116,21 +117,23 @@ async def extend_enumerate_dataset(
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
     db: Annotated[AsyncSession, Depends(get_db_session)],
     background_tasks: BackgroundTasks,
-):
+) -> None:
+    # 204 No Content: the extended dataset is computed for the background revalidation
+    # task but not returned in the response body.
     dataset = await use_case.extend_enumerate(dataset_id, payload)
     background_tasks.add_task(validate_dataset_reactions, db, dataset.id)
-    return dataset
 
 
 @router.get(
     "/datasets/{dataset_id}/download",
+    response_model=None,
     dependencies=[Depends(dataset_authorization(("admin", "editor", "viewer")))],
 )
 async def download_dataset(
     dataset_id: int,
     file_format: DownloadFileFormats,
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
+) -> Response:
     dataset, data = await use_case.download(dataset_id, file_format)
     return Response(data, headers={"Content-Disposition": f'attachment; filename="{dataset.name}.{file_format}"'})
 
@@ -138,7 +141,7 @@ async def download_dataset(
 @router.get("/datasets", response_model=Page[DatasetWithReactionCountResponseSchema])
 async def get_user_datasets(
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
+) -> Page[DatasetModel]:
     return await use_case.paginate_user_datasets()
 
 
@@ -151,7 +154,7 @@ async def update_dataset(
     dataset_id: int,
     payload: DatasetCreateSchema,
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
+) -> DatasetModel:
     return await use_case.update(dataset_id, payload)
 
 
@@ -159,7 +162,7 @@ async def update_dataset(
 async def delete_dataset(
     dataset_id: int,
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
+) -> str:
     # TODO: soft deletion needs to be implemented
     await use_case.delete(dataset_id)
     return "Object successfully deleted (or already absent)"
@@ -173,7 +176,7 @@ async def delete_dataset(
 async def get_dataset(
     dataset_id: int,
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
+) -> DatasetModel:
     if dataset := await use_case.get(dataset_id):
         return dataset
     raise EntityNotFoundError("Dataset not found")
@@ -181,6 +184,7 @@ async def get_dataset(
 
 @router.post(
     "/datasets/{dataset_id}/extend",
+    response_model=None,
     dependencies=[Depends(dataset_authorization(("admin", "editor")))],
 )
 async def extend_dataset(
@@ -189,7 +193,7 @@ async def extend_dataset(
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
     db: Annotated[AsyncSession, Depends(get_db_session)],
     background_tasks: BackgroundTasks,
-):
+) -> DatasetModel | None:
     file_data, kind = await validate_uploaded_pb_file(file)
     response = await use_case.extend(dataset_id, file_data, kind)
     background_tasks.add_task(validate_dataset_reactions, db)
@@ -204,7 +208,7 @@ async def extend_dataset(
 async def get_dataset_groups(
     dataset_id: int,
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
+) -> list[GroupModel]:
     if groups := await use_case.get_dataset_groups(dataset_id):
         return groups
     raise EntityNotFoundError("Dataset not found")
@@ -220,7 +224,7 @@ async def share_dataset(
     dataset_id: int,
     payload: DatasetShareCreateSchema,
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
+) -> DatasetGroupAssociationModel:
     return await use_case.share(group_id, dataset_id, payload)
 
 
@@ -234,5 +238,5 @@ async def unshare_dataset(
     dataset_id: int,
     payload: DatasetShareCreateSchema,
     use_case: Annotated[DatasetUseCases, Depends(get_dataset_use_case)],
-):
+) -> None:
     await use_case.unshare(group_id, dataset_id, payload)

--- a/ord_app/service_api/resources/v1/group.py
+++ b/ord_app/service_api/resources/v1/group.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Sequence
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
@@ -22,6 +23,7 @@ from ord_app.service_api.domain.groups import (
     get_group_members_use_case,
     get_group_use_case,
 )
+from ord_app.service_api.models import UserGroupsMembershipModel
 from ord_app.service_api.schemas.groups import (
     GroupAddMemberSchema,
     GroupCreateSchema,
@@ -34,12 +36,14 @@ router = APIRouter(tags=["group"], prefix="/groups")
 
 
 @router.post("", response_model=GroupUserResponseSchema, status_code=status.HTTP_201_CREATED)
-async def create_group(payload: GroupCreateSchema, use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]):
+async def create_group(
+    payload: GroupCreateSchema, use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]
+) -> dict:
     return await use_case.create(payload)
 
 
 @router.get("", response_model=list[GroupUserResponseSchema])
-async def list_current_user_groups(use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]):
+async def list_current_user_groups(use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]) -> list[dict]:
     response = await use_case.user_groups()
     return response
 
@@ -49,7 +53,7 @@ async def list_current_user_groups(use_case: Annotated[GroupUseCases, Depends(ge
     response_model=GroupUserResponseSchema,
     dependencies=[Depends(group_authorization(("admin", "editor", "viewer")))],
 )
-async def get_group(group_id: int, use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]):
+async def get_group(group_id: int, use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]) -> dict:
     return await use_case.get(group_id)
 
 
@@ -61,7 +65,7 @@ async def get_group(group_id: int, use_case: Annotated[GroupUseCases, Depends(ge
 )
 async def update_group(
     group_id: int, payload: GroupCreateSchema, use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]
-):
+) -> dict:
     return await use_case.update(group_id, payload)
 
 
@@ -70,7 +74,7 @@ async def update_group(
     status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(group_authorization(("admin",)))],
 )
-async def delete_group(group_id: int, use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]):
+async def delete_group(group_id: int, use_case: Annotated[GroupUseCases, Depends(get_group_use_case)]) -> None:
     await use_case.delete(group_id)
 
 
@@ -81,7 +85,7 @@ async def delete_group(group_id: int, use_case: Annotated[GroupUseCases, Depends
 )
 async def get_group_members(
     group_id: int, use_case: Annotated[GroupMembersUseCases, Depends(get_group_members_use_case)]
-):
+) -> Sequence[UserGroupsMembershipModel]:
     return await use_case.all(group_id)
 
 
@@ -95,7 +99,7 @@ async def add_member(
     group_id: int,
     payload: GroupAddMemberSchema,
     use_case: Annotated[GroupMembersUseCases, Depends(get_group_members_use_case)],
-):
+) -> UserGroupsMembershipModel | None:
     return await use_case.add_member(group_id, payload)
 
 
@@ -109,7 +113,7 @@ async def update_member(
     group_id: int,
     payload: GroupUpdateMemberSchema,
     use_case: Annotated[GroupMembersUseCases, Depends(get_group_members_use_case)],
-):
+) -> UserGroupsMembershipModel | None:
     return await use_case.update_member(group_id, payload)
 
 
@@ -120,5 +124,5 @@ async def update_member(
 )
 async def remove_group_members(
     group_id: int, payload: list[int], use_case: Annotated[GroupMembersUseCases, Depends(get_group_members_use_case)]
-):
+) -> None:
     await use_case.remove_members(group_id, payload)

--- a/ord_app/service_api/resources/v1/reactions.py
+++ b/ord_app/service_api/resources/v1/reactions.py
@@ -18,6 +18,7 @@ from fastapi_pagination import Page
 
 from ord_app.service_api.domain.auth import dataset_authorization
 from ord_app.service_api.domain.reactions import ReactionsUseCase, get_reaction_use_case
+from ord_app.service_api.models import ReactionModel
 from ord_app.service_api.schemas.datasets import DownloadFileFormats
 from ord_app.service_api.schemas.reactions import (
     ReactionCreateSchema,
@@ -39,7 +40,7 @@ async def create_reaction(
     dataset_id: int,
     payload: ReactionCreateSchema,
     use_case: Annotated[ReactionsUseCase, Depends(get_reaction_use_case)],
-):
+) -> ReactionModel:
     return await use_case.create(dataset_id, payload)
 
 
@@ -50,7 +51,7 @@ async def create_reaction(
 )
 async def create_reaction_from_scratch(
     dataset_id: int, use_case: Annotated[ReactionsUseCase, Depends(get_reaction_use_case)]
-):
+) -> ReactionModel:
     return await use_case.create_from_scratch(dataset_id)
 
 
@@ -63,7 +64,7 @@ async def upload_reaction(
     dataset_id: int,
     file: UploadFile,
     use_case: Annotated[ReactionsUseCase, Depends(get_reaction_use_case)],
-):
+) -> ReactionModel:
     file_data, kind = await validate_uploaded_pb_file(file)
     response = await use_case.upload(dataset_id, file_data, kind)
     return response
@@ -78,7 +79,7 @@ async def reactions(
     dataset_id: int,
     use_case: Annotated[ReactionsUseCase, Depends(get_reaction_use_case)],
     is_valid: Annotated[ReactionsQueryParams, Query()],
-):
+) -> Page[ReactionModel]:
     return await use_case.paginate(dataset_id, is_valid)
 
 
@@ -91,7 +92,7 @@ async def search_reaction(
     dataset_id: int,
     pb_reaction_id: str,
     use_case: Annotated[ReactionsUseCase, Depends(get_reaction_use_case)],
-):
+) -> ReactionModel:
     return await use_case.search(dataset_id=dataset_id, pb_reaction_id=pb_reaction_id)
 
 
@@ -104,7 +105,7 @@ async def reaction(
     dataset_id: int,
     reaction_id: int,
     use_case: Annotated[ReactionsUseCase, Depends(get_reaction_use_case)],
-):
+) -> ReactionModel:
     return await use_case.get(dataset_id, reaction_id)
 
 
@@ -118,7 +119,7 @@ async def update_reaction(
     reaction_id: int,
     payload: ReactionUpdateSchema,
     use_case: Annotated[ReactionsUseCase, Depends(get_reaction_use_case)],
-):
+) -> ReactionModel:
     return await use_case.update(dataset_id, reaction_id, payload)
 
 
@@ -131,12 +132,13 @@ async def delete_reaction(
     dataset_id: int,
     reaction_id: int,
     use_case: Annotated[ReactionsUseCase, Depends(get_reaction_use_case)],
-):
+) -> None:
     return await use_case.delete(dataset_id, reaction_id)
 
 
 @router.get(
     "/{reaction_id}/download",
+    response_model=None,
     dependencies=[Depends(dataset_authorization(("admin", "editor", "viewer")))],
 )
 async def download_reaction(
@@ -144,7 +146,7 @@ async def download_reaction(
     reaction_id: int,
     file_format: DownloadFileFormats,
     use_case: Annotated[ReactionsUseCase, Depends(get_reaction_use_case)],
-):
+) -> Response:
     reaction, data = await use_case.download(dataset_id, reaction_id, file_format)
     filename = f"{reaction.pb_reaction_id}.{file_format}"
     return Response(

--- a/ord_app/service_api/resources/v1/templates.py
+++ b/ord_app/service_api/resources/v1/templates.py
@@ -11,11 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Sequence
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
 from ord_app.service_api.domain.templates import TemplatesUseCase, get_templates_use_case
+from ord_app.service_api.models import TemplateModel
 from ord_app.service_api.schemas.templates import TemplateCreateModel, TemplateResponseModel, TemplateUpdateModel
 
 router = APIRouter(tags=["templates"], prefix="/templates")
@@ -25,14 +27,14 @@ router = APIRouter(tags=["templates"], prefix="/templates")
 async def create_template(
     payload: TemplateCreateModel,
     use_case: Annotated[TemplatesUseCase, Depends(get_templates_use_case)],
-):
+) -> TemplateModel:
     return await use_case.create(payload)
 
 
 @router.get("", response_model=list[TemplateResponseModel])
 async def get_all_templates(
     use_case: Annotated[TemplatesUseCase, Depends(get_templates_use_case)],
-):
+) -> Sequence[TemplateModel]:
     return await use_case.all()
 
 
@@ -40,7 +42,7 @@ async def get_all_templates(
 async def get_template(
     template_id: int,
     use_case: Annotated[TemplatesUseCase, Depends(get_templates_use_case)],
-):
+) -> TemplateModel:
     return await use_case.get(template_id)
 
 
@@ -49,7 +51,7 @@ async def update_template(
     template_id: int,
     payload: TemplateUpdateModel,
     use_case: Annotated[TemplatesUseCase, Depends(get_templates_use_case)],
-):
+) -> TemplateModel:
     return await use_case.update(template_id, payload)
 
 
@@ -57,5 +59,6 @@ async def update_template(
 async def delete_template(
     template_id: int,
     use_case: Annotated[TemplatesUseCase, Depends(get_templates_use_case)],
-):
-    return await use_case.delete(template_id)
+) -> None:
+    # 204 No Content: delete raises if the template is missing; the returned count is unused.
+    await use_case.delete(template_id)

--- a/ord_app/service_api/resources/v1/users.py
+++ b/ord_app/service_api/resources/v1/users.py
@@ -24,7 +24,7 @@ router = APIRouter(tags=["users"], prefix="/users")
 
 
 @router.get("/me", response_model=UserResponseSchema)
-async def read_users_me(current_user: UserModel = Depends(authenticate)) -> UserModel:
+async def read_users_me(current_user: Annotated[UserModel, Depends(authenticate)]) -> UserModel:
     return current_user
 
 

--- a/ord_app/service_api/resources/v1/users.py
+++ b/ord_app/service_api/resources/v1/users.py
@@ -24,17 +24,17 @@ router = APIRouter(tags=["users"], prefix="/users")
 
 
 @router.get("/me", response_model=UserResponseSchema)
-async def read_users_me(current_user: UserModel = Depends(authenticate)):
+async def read_users_me(current_user: UserModel = Depends(authenticate)) -> UserModel:
     return current_user
 
 
 @router.get("/{user_id}", response_model=UserResponseSchema)
-async def get_user(user_id: int, use_case: Annotated[UserUseCase, Depends(get_user_use_case)]):
+async def get_user(user_id: int, use_case: Annotated[UserUseCase, Depends(get_user_use_case)]) -> UserModel:
     return await use_case.get(user_id)
 
 
 @router.patch("/{user_id}", response_model=UserResponseSchema)
 async def update_user(
     user_id: int, payload: UserUpdateSchema, use_case: Annotated[UserUseCase, Depends(get_user_use_case)]
-):
+) -> UserModel:
     return await use_case.update(user_id, payload)

--- a/ord_app/service_api/resources/v1/utilities.py
+++ b/ord_app/service_api/resources/v1/utilities.py
@@ -38,7 +38,7 @@ def adjust_error(error: str) -> str:
 
 
 @router.post("/validate/{message_type}")
-async def validate(message_type: str, request: Request):
+async def validate(message_type: str, request: Request) -> dict:
     """Validates a protocol buffer message."""
     message = create_message(message_type)
     message.ParseFromString(await request.body())
@@ -51,8 +51,8 @@ async def validate(message_type: str, request: Request):
     return {"errors": errors, "warnings": warnings}
 
 
-@router.get("/resolve_input")
-async def resolve_input(input_string: str):
+@router.get("/resolve_input", response_model=None)
+async def resolve_input(input_string: str) -> str | Response:
     """Resolves an input string into a ReactionInput message."""
     try:
         return send_message(resolvers.resolve_input(input_string))
@@ -61,7 +61,7 @@ async def resolve_input(input_string: str):
 
 
 @router.post("/resolve-compound", response_model=ResolveCompoundOutputs)
-async def resolve_compound(inputs: ResolveCompoundInputs):
+async def resolve_compound(inputs: ResolveCompoundInputs) -> dict | Response:
     """Resolves a compound identifier into a SMILES string."""
     try:
         resolver, smiles = await name_resolve_cached(inputs.identifier_type, inputs.identifier)
@@ -70,8 +70,8 @@ async def resolve_compound(inputs: ResolveCompoundInputs):
         return Response(str(error), status_code=400)
 
 
-@router.get("/canonicalize-smiles")
-async def canonicalize_smiles(smiles: str):
+@router.get("/canonicalize-smiles", response_model=None)
+async def canonicalize_smiles(smiles: str) -> str | Response:
     """Canonicalizes a SMILES string."""
     try:
         return resolvers.canonicalize_smiles(smiles)
@@ -79,8 +79,8 @@ async def canonicalize_smiles(smiles: str):
         return Response(str(error), status_code=400)
 
 
-@router.post("/get_molblock")
-async def get_molblock(request: Request):
+@router.post("/get_molblock", response_model=None)
+async def get_molblock(request: Request) -> str | Response:
     """Returns a MolBlock for the given Compound message."""
     compound = Compound.FromString(await request.body())
     try:

--- a/ord_app/service_api/schemas/datasets.py
+++ b/ord_app/service_api/schemas/datasets.py
@@ -89,7 +89,7 @@ class DatasetEnumerateCreateSchema(BaseSchema):
     reactions: list[bytes]
 
     @field_validator("reactions", mode="before")
-    def load_reactions(cls, raw) -> map[bytes]:
+    def load_reactions(cls, raw: Any) -> map[bytes]:
         return map(b64decode, raw)
 
 
@@ -97,7 +97,7 @@ class DatasetEnumerateExtendSchema(BaseSchema):
     reactions: list[bytes]
 
     @field_validator("reactions", mode="before")
-    def load_reactions(cls, raw) -> map[bytes]:
+    def load_reactions(cls, raw: Any) -> map[bytes]:
         return map(b64decode, raw)
 
 

--- a/ord_app/service_api/schemas/datasets.py
+++ b/ord_app/service_api/schemas/datasets.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 from base64 import b64decode
 from datetime import datetime
 from typing import Annotated, Any, Literal
@@ -55,7 +57,7 @@ class DatasetWithReactionCountResponseSchema(DatasetResponseSchema):
 
     @model_validator(mode="before")
     @classmethod
-    def reaction_count(cls, data: Any):  # noqa: F811
+    def reaction_count(cls, data: Any) -> Any:  # noqa: F811
         if isinstance(data, Row | tuple):
             _, rct_total, rct_invalid, rct_valid, rct_none = data
             # first element of the data is Dataset ORM object
@@ -87,7 +89,7 @@ class DatasetEnumerateCreateSchema(BaseSchema):
     reactions: list[bytes]
 
     @field_validator("reactions", mode="before")
-    def load_reactions(cls, raw):
+    def load_reactions(cls, raw) -> map[bytes]:
         return map(b64decode, raw)
 
 
@@ -95,7 +97,7 @@ class DatasetEnumerateExtendSchema(BaseSchema):
     reactions: list[bytes]
 
     @field_validator("reactions", mode="before")
-    def load_reactions(cls, raw):
+    def load_reactions(cls, raw) -> map[bytes]:
         return map(b64decode, raw)
 
 

--- a/ord_app/service_api/schemas/reactions.py
+++ b/ord_app/service_api/schemas/reactions.py
@@ -31,7 +31,7 @@ class ReactionsQueryParams(BaseSchema):
     is_valid: list[bool | None] | None = None
 
     @field_validator("is_valid", mode="before")
-    def convert_str_to_bool(cls, v) -> Any:
+    def convert_str_to_bool(cls, v: Any) -> Any:
         if isinstance(v, str):
             return cls.parse_bool(v)
         elif isinstance(v, list):
@@ -39,14 +39,14 @@ class ReactionsQueryParams(BaseSchema):
         return v
 
 
-def safe_molblock(product) -> str | None:
+def safe_molblock(product: Any) -> str | None:
     try:
         return molblock_from_compound(product)
     except ValueError:
         return None
 
 
-def get_molblocks(pb) -> dict:
+def get_molblocks(pb: Reaction) -> dict:
     outcomes = []
 
     for outcome in pb.outcomes:
@@ -92,7 +92,7 @@ class ReactionResponseSchema(BaseSchema):
 
     @field_validator("binpb", mode="before")
     @classmethod
-    def _binpb(cls, raw) -> str:
+    def _binpb(cls, raw: bytes) -> str:
         return b64encode(raw).decode()
 
     @model_validator(mode="before")
@@ -113,7 +113,7 @@ class ReactionCreateSchema(BaseSchema):
     binpb: bytes
 
     @field_validator("binpb", mode="before")
-    def load_binpb(cls, raw) -> bytes:
+    def load_binpb(cls, raw: Any) -> bytes:
         return b64decode(raw)
 
 
@@ -122,5 +122,5 @@ class ReactionUpdateSchema(BaseSchema):
     binpb: bytes
 
     @field_validator("binpb", mode="before")
-    def load_binpb(cls, raw) -> bytes:
+    def load_binpb(cls, raw: Any) -> bytes:
         return b64decode(raw)

--- a/ord_app/service_api/schemas/reactions.py
+++ b/ord_app/service_api/schemas/reactions.py
@@ -31,7 +31,7 @@ class ReactionsQueryParams(BaseSchema):
     is_valid: list[bool | None] | None = None
 
     @field_validator("is_valid", mode="before")
-    def convert_str_to_bool(cls, v):
+    def convert_str_to_bool(cls, v) -> Any:
         if isinstance(v, str):
             return cls.parse_bool(v)
         elif isinstance(v, list):
@@ -39,14 +39,14 @@ class ReactionsQueryParams(BaseSchema):
         return v
 
 
-def safe_molblock(product):
+def safe_molblock(product) -> str | None:
     try:
         return molblock_from_compound(product)
     except ValueError:
         return None
 
 
-def get_molblocks(pb):
+def get_molblocks(pb) -> dict:
     outcomes = []
 
     for outcome in pb.outcomes:
@@ -92,18 +92,18 @@ class ReactionResponseSchema(BaseSchema):
 
     @field_validator("binpb", mode="before")
     @classmethod
-    def _binpb(cls, raw):
+    def _binpb(cls, raw) -> str:
         return b64encode(raw).decode()
 
     @model_validator(mode="before")
     @classmethod
-    def _fill_molblocks(cls, data: Any):
+    def _fill_molblocks(cls, data: Any) -> Any:
         data.molblocks = get_molblocks(load_message(data.binpb, Reaction, "binpb"))
         return data
 
     @model_validator(mode="before")
     @classmethod
-    def reaction_count(cls, data: Any):  # noqa: F811
+    def reaction_count(cls, data: Any) -> Any:  # noqa: F811
         if hasattr(data, "reactions"):
             data.reaction_count = len(data.reactions)
         return data
@@ -113,7 +113,7 @@ class ReactionCreateSchema(BaseSchema):
     binpb: bytes
 
     @field_validator("binpb", mode="before")
-    def load_binpb(cls, raw):
+    def load_binpb(cls, raw) -> bytes:
         return b64decode(raw)
 
 
@@ -122,5 +122,5 @@ class ReactionUpdateSchema(BaseSchema):
     binpb: bytes
 
     @field_validator("binpb", mode="before")
-    def load_binpb(cls, raw):
+    def load_binpb(cls, raw) -> bytes:
         return b64decode(raw)

--- a/ord_app/service_api/schemas/templates.py
+++ b/ord_app/service_api/schemas/templates.py
@@ -33,18 +33,18 @@ class TemplateResponseModel(BaseSchema):
 
     @model_validator(mode="before")
     @classmethod
-    def _fill_molblocks(cls, data: Any):
+    def _fill_molblocks(cls, data: Any) -> Any:
         data.molblocks = get_molblocks(load_message(data.binpb, Reaction, "binpb"))
         return data
 
     @field_validator("variables", mode="before")
     @classmethod
-    def load_variables(cls, raw):
+    def load_variables(cls, raw) -> bytes:
         return orjson.dumps(raw)
 
     @field_validator("binpb", mode="before")
     @classmethod
-    def load_binpb(cls, raw):
+    def load_binpb(cls, raw) -> bytes:
         return b64encode(raw)
 
 
@@ -55,12 +55,12 @@ class TemplateCreateModel(BaseSchema):
 
     @field_validator("variables", mode="before")
     @classmethod
-    def load_variables(cls, raw):
+    def load_variables(cls, raw) -> bytes:
         return orjson.dumps(raw)
 
     @field_validator("binpb", mode="after")
     @classmethod
-    def load_binpb(cls, raw):
+    def load_binpb(cls, raw) -> Reaction:
         return load_message(b64decode(raw), Reaction, "binpb")
 
     def model_dump(self, *args, **kwargs) -> dict[str, Any]:
@@ -76,7 +76,7 @@ class TemplateUpdateModel(BaseSchema):
 
     @field_validator("binpb", mode="after")
     @classmethod
-    def load_binpb(cls, raw):
+    def load_binpb(cls, raw) -> Reaction | None:
         if raw is not None:
             return load_message(b64decode(raw), Reaction, "binpb")
 
@@ -88,5 +88,5 @@ class TemplateUpdateModel(BaseSchema):
 
     @field_validator("variables", mode="before")
     @classmethod
-    def load_variables(cls, raw):
+    def load_variables(cls, raw) -> bytes:
         return orjson.dumps(raw)

--- a/ord_app/service_api/schemas/templates.py
+++ b/ord_app/service_api/schemas/templates.py
@@ -39,12 +39,12 @@ class TemplateResponseModel(BaseSchema):
 
     @field_validator("variables", mode="before")
     @classmethod
-    def load_variables(cls, raw) -> bytes:
+    def load_variables(cls, raw: Any) -> bytes:
         return orjson.dumps(raw)
 
     @field_validator("binpb", mode="before")
     @classmethod
-    def load_binpb(cls, raw) -> bytes:
+    def load_binpb(cls, raw: Any) -> bytes:
         return b64encode(raw)
 
 
@@ -55,15 +55,15 @@ class TemplateCreateModel(BaseSchema):
 
     @field_validator("variables", mode="before")
     @classmethod
-    def load_variables(cls, raw) -> bytes:
+    def load_variables(cls, raw: Any) -> bytes:
         return orjson.dumps(raw)
 
     @field_validator("binpb", mode="after")
     @classmethod
-    def load_binpb(cls, raw) -> Reaction:
+    def load_binpb(cls, raw: Any) -> Reaction:
         return load_message(b64decode(raw), Reaction, "binpb")
 
-    def model_dump(self, *args, **kwargs) -> dict[str, Any]:
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         data = super().model_dump(*args, **kwargs)
         data["binpb"] = data["binpb"].SerializeToString()
         return data
@@ -76,11 +76,11 @@ class TemplateUpdateModel(BaseSchema):
 
     @field_validator("binpb", mode="after")
     @classmethod
-    def load_binpb(cls, raw) -> Reaction | None:
+    def load_binpb(cls, raw: Any) -> Reaction | None:
         if raw is not None:
             return load_message(b64decode(raw), Reaction, "binpb")
 
-    def model_dump(self, *args, **kwargs) -> dict[str, Any]:
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         data = super().model_dump(*args, **kwargs)
         if data.get("binpb") is not None:
             data["binpb"] = data["binpb"].SerializeToString()
@@ -88,5 +88,5 @@ class TemplateUpdateModel(BaseSchema):
 
     @field_validator("variables", mode="before")
     @classmethod
-    def load_variables(cls, raw) -> bytes:
+    def load_variables(cls, raw: Any) -> bytes:
         return orjson.dumps(raw)

--- a/ord_app/service_api/schemas/users.py
+++ b/ord_app/service_api/schemas/users.py
@@ -27,7 +27,7 @@ class UserResponseSchema(BaseSchema):
 
     @field_validator("external_id", mode="after")
     @classmethod
-    def _external_id(cls, raw) -> str | None:
+    def _external_id(cls, raw: str | None) -> str | None:
         return raw.split("|")[-1] if raw else None  # split auth0 id
 
 

--- a/ord_app/service_api/schemas/users.py
+++ b/ord_app/service_api/schemas/users.py
@@ -27,7 +27,7 @@ class UserResponseSchema(BaseSchema):
 
     @field_validator("external_id", mode="after")
     @classmethod
-    def _external_id(cls, raw):
+    def _external_id(cls, raw) -> str | None:
         return raw.split("|")[-1] if raw else None  # split auth0 id
 
 

--- a/ord_app/service_api/services/exceptions.py
+++ b/ord_app/service_api/services/exceptions.py
@@ -15,30 +15,30 @@ from fastapi import HTTPException, status
 
 
 class ProtobufDecodeError(HTTPException):
-    def __init__(self, detail: str, **kwargs):
+    def __init__(self, detail: str, **kwargs) -> None:
         super().__init__(status.HTTP_400_BAD_REQUEST, detail=detail, **kwargs)
 
 
 class UnauthenticatedError(HTTPException):
-    def __init__(self, detail: str, **kwargs):
+    def __init__(self, detail: str, **kwargs) -> None:
         super().__init__(status.HTTP_401_UNAUTHORIZED, detail=detail, **kwargs)
 
 
 class ForbiddenError(HTTPException):
-    def __init__(self, detail: str, **kwargs):
+    def __init__(self, detail: str, **kwargs) -> None:
         super().__init__(status.HTTP_403_FORBIDDEN, detail=detail, **kwargs)
 
 
 class EntityNotFoundError(HTTPException):
-    def __init__(self, detail: str, **kwargs):
+    def __init__(self, detail: str, **kwargs) -> None:
         super().__init__(status.HTTP_404_NOT_FOUND, detail=detail, **kwargs)
 
 
 class ConflictError(HTTPException):
-    def __init__(self, detail: str, **kwargs):
+    def __init__(self, detail: str, **kwargs) -> None:
         super().__init__(status.HTTP_409_CONFLICT, detail=detail, **kwargs)
 
 
 class UnprocessableEntityError(HTTPException):
-    def __init__(self, detail: str, **kwargs):
+    def __init__(self, detail: str, **kwargs) -> None:
         super().__init__(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail, **kwargs)

--- a/ord_app/service_api/services/exceptions.py
+++ b/ord_app/service_api/services/exceptions.py
@@ -11,34 +11,36 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any
+
 from fastapi import HTTPException, status
 
 
 class ProtobufDecodeError(HTTPException):
-    def __init__(self, detail: str, **kwargs) -> None:
+    def __init__(self, detail: str, **kwargs: Any) -> None:
         super().__init__(status.HTTP_400_BAD_REQUEST, detail=detail, **kwargs)
 
 
 class UnauthenticatedError(HTTPException):
-    def __init__(self, detail: str, **kwargs) -> None:
+    def __init__(self, detail: str, **kwargs: Any) -> None:
         super().__init__(status.HTTP_401_UNAUTHORIZED, detail=detail, **kwargs)
 
 
 class ForbiddenError(HTTPException):
-    def __init__(self, detail: str, **kwargs) -> None:
+    def __init__(self, detail: str, **kwargs: Any) -> None:
         super().__init__(status.HTTP_403_FORBIDDEN, detail=detail, **kwargs)
 
 
 class EntityNotFoundError(HTTPException):
-    def __init__(self, detail: str, **kwargs) -> None:
+    def __init__(self, detail: str, **kwargs: Any) -> None:
         super().__init__(status.HTTP_404_NOT_FOUND, detail=detail, **kwargs)
 
 
 class ConflictError(HTTPException):
-    def __init__(self, detail: str, **kwargs) -> None:
+    def __init__(self, detail: str, **kwargs: Any) -> None:
         super().__init__(status.HTTP_409_CONFLICT, detail=detail, **kwargs)
 
 
 class UnprocessableEntityError(HTTPException):
-    def __init__(self, detail: str, **kwargs) -> None:
+    def __init__(self, detail: str, **kwargs: Any) -> None:
         super().__init__(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail, **kwargs)

--- a/ord_app/service_api/services/pb_utils.py
+++ b/ord_app/service_api/services/pb_utils.py
@@ -77,7 +77,7 @@ MAP_FILE_EXT_TO_PB_KIND = {
 }
 
 
-def validate_pb_kind_by_file_ext(filename):
+def validate_pb_kind_by_file_ext(filename) -> str | None:
     suffixes = Path(filename).suffixes
     if suffixes and suffixes[-1] == ".gz" and len(suffixes) > 1:
         file_ext = suffixes[-2]
@@ -87,7 +87,7 @@ def validate_pb_kind_by_file_ext(filename):
     return MAP_FILE_EXT_TO_PB_KIND.get(file_ext)
 
 
-async def validate_uploaded_pb_file(file: UploadFile):
+async def validate_uploaded_pb_file(file: UploadFile) -> tuple[bytes, str]:
     kind = validate_pb_kind_by_file_ext(file.filename)
     if not kind:
         raise HTTPException(

--- a/ord_app/service_api/services/pb_utils.py
+++ b/ord_app/service_api/services/pb_utils.py
@@ -77,7 +77,9 @@ MAP_FILE_EXT_TO_PB_KIND = {
 }
 
 
-def validate_pb_kind_by_file_ext(filename) -> str | None:
+def validate_pb_kind_by_file_ext(filename: str | None) -> str | None:
+    if filename is None:
+        return None
     suffixes = Path(filename).suffixes
     if suffixes and suffixes[-1] == ".gz" and len(suffixes) > 1:
         file_ext = suffixes[-2]
@@ -112,7 +114,9 @@ def _adjust_error(error: str) -> str:
 
 
 async def validate_pb_reaction(
-    reaction: Reaction | None, raise_on_error=False, options=ValidationOptions(require_provenance=True)
+    reaction: Reaction | None,
+    raise_on_error: bool = False,
+    options: ValidationOptions = ValidationOptions(require_provenance=True),
 ) -> tuple[bool | None, list[str], list[str]]:
     if reaction is None:
         return None, [], []
@@ -128,7 +132,9 @@ async def validate_pb_reaction(
 
 
 async def async_validate_pb_reaction(
-    reaction: Reaction | None, raise_on_error=False, options=ValidationOptions(require_provenance=True)
+    reaction: Reaction | None,
+    raise_on_error: bool = False,
+    options: ValidationOptions = ValidationOptions(require_provenance=True),
 ) -> tuple[bool | None, list[str], list[str]]:
     """
     Asynchronously validate a protocol buffer reaction.

--- a/ord_app/service_api/services/postgresql.py
+++ b/ord_app/service_api/services/postgresql.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from ord_app.service_api.settings import RuntimeSettings
 
@@ -25,6 +27,6 @@ pg_engine = create_async_engine(
 db_session_maker = async_sessionmaker(pg_engine, expire_on_commit=False, autoflush=False, autocommit=False)
 
 
-async def get_db_session():
+async def get_db_session() -> AsyncIterator[AsyncSession]:
     async with db_session_maker() as session:
         yield session

--- a/ord_app/service_api/services/resolvers.py
+++ b/ord_app/service_api/services/resolvers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import asyncio
 from functools import lru_cache
+from typing import Any
 from urllib.parse import quote
 
 from httpx import AsyncClient
@@ -28,14 +29,14 @@ async def _pubchem_resolve(value_type: str, value: str) -> tuple[str, str]:
         return "PubChem API", response.raise_for_status().text.strip()
 
 
-async def _cactus_resolve(*args, value: str) -> tuple[str, str]:
+async def _cactus_resolve(*args: Any, value: str) -> tuple[str, str]:
     """Resolves compound identifiers to SMILES via the CACTUS API."""
     async with AsyncClient(base_url="https://cactus.nci.nih.gov") as client:
         response = await client.get(f"/chemical/structure/{quote(value)}/smiles")
         return "NCI/CADD Chemical Identifier Resolver", response.raise_for_status().text.strip()
 
 
-async def _emolecules_resolve(*args, value: str) -> tuple[str, str]:
+async def _emolecules_resolve(*args: Any, value: str) -> tuple[str, str]:
     """Resolves compound identifiers to SMILES via the eMolecules API."""
     async with AsyncClient(base_url="https://www.emolecules.com") as client:
         response = await client.get(f"lookup?q={quote(value)}")

--- a/ord_app/service_api/services/utils.py
+++ b/ord_app/service_api/services/utils.py
@@ -19,18 +19,18 @@ from typing import Any
 
 
 class LRUCacheDict:
-    def __init__(self, maxsize=None) -> None:
+    def __init__(self, maxsize: int | None = None) -> None:
         self.maxsize = maxsize
         self._data = OrderedDict()
 
-    def get(self, key) -> Any:
+    def get(self, key: Any) -> Any:
         if key in self._data:
             value = self._data.pop(key)
             self._data[key] = value
             return value
         return None
 
-    def set(self, key, value) -> None:
+    def set(self, key: Any, value: Any) -> None:
         if key in self._data:
             self._data.pop(key)
             self._data[key] = value
@@ -40,13 +40,13 @@ class LRUCacheDict:
                 self._data.popitem(last=False)
 
 
-def alru_cache(maxsize=None) -> Callable:
-    def decorator(func) -> Callable:
+def alru_cache(maxsize: int | None = None) -> Callable:
+    def decorator(func: Callable) -> Callable:
         lock = asyncio.Lock()
         cache = LRUCacheDict(maxsize=maxsize)
 
         @wraps(func)
-        async def wrapped(*args, **kwargs) -> Any:
+        async def wrapped(*args: Any, **kwargs: Any) -> Any:
             key = (args, frozenset(kwargs.items()))
             cached = cache.get(key)
             if cached is not None:

--- a/ord_app/service_api/services/utils.py
+++ b/ord_app/service_api/services/utils.py
@@ -13,22 +13,24 @@
 # limitations under the License.
 import asyncio
 from collections import OrderedDict
+from collections.abc import Callable
 from functools import wraps
+from typing import Any
 
 
 class LRUCacheDict:
-    def __init__(self, maxsize=None):
+    def __init__(self, maxsize=None) -> None:
         self.maxsize = maxsize
         self._data = OrderedDict()
 
-    def get(self, key):
+    def get(self, key) -> Any:
         if key in self._data:
             value = self._data.pop(key)
             self._data[key] = value
             return value
         return None
 
-    def set(self, key, value):
+    def set(self, key, value) -> None:
         if key in self._data:
             self._data.pop(key)
             self._data[key] = value
@@ -38,13 +40,13 @@ class LRUCacheDict:
                 self._data.popitem(last=False)
 
 
-def alru_cache(maxsize=None):
-    def decorator(func):
+def alru_cache(maxsize=None) -> Callable:
+    def decorator(func) -> Callable:
         lock = asyncio.Lock()
         cache = LRUCacheDict(maxsize=maxsize)
 
         @wraps(func)
-        async def wrapped(*args, **kwargs):
+        async def wrapped(*args, **kwargs) -> Any:
             key = (args, frozenset(kwargs.items()))
             cached = cache.get(key)
             if cached is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,9 @@ target-version = "py312"
 [tool.ruff.lint]
 # Mirror ord-schema's ruleset: pycodestyle errors+warnings (E/W), pyflakes (F),
 # import sorting (I), bugbear (B), pyupgrade (UP), and flake8-simplify (SIM).
-select = ["E", "F", "W", "I", "B", "UP", "SIM"]
+# Plus return-type annotations (ANN2xx) so type checkers can propagate types
+# through call sites; argument/Any rules (ANN0xx/ANN401) are intentionally off.
+select = ["E", "F", "W", "I", "B", "UP", "SIM", "ANN201", "ANN202", "ANN204", "ANN205", "ANN206"]
 # E501 (line length) is the formatter's job; SIM108 (ternaries aren't always
 # clearer); B008 (function calls in argument defaults are fine here, e.g. FastAPI Depends).
 ignore = ["E501", "SIM108", "B008"]
@@ -85,8 +87,10 @@ unfixable = []
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
-# Tests redefine fixtures and use patterns bugbear dislikes (asserts, blind excepts).
-"ord_app/tests/**" = ["B011", "B017"]
+# Tests trip a couple of flake8-bugbear (the "B" rules) checks -- B011 (`assert False`)
+# and B017 (overly broad `pytest.raises(Exception)`); return-type annotations (ANN2xx)
+# also add little value on test functions. Skip both in tests.
+"ord_app/tests/**" = ["B011", "B017", "ANN201", "ANN202", "ANN204", "ANN205", "ANN206"]
 
 [tool.ruff.lint.isort]
 # ord_schema is an external dependency; pin its classification so import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,14 +73,16 @@ indent-width = 4
 target-version = "py312"
 
 [tool.ruff.lint]
-# Mirror ord-schema's ruleset: pycodestyle errors+warnings (E/W), pyflakes (F),
-# import sorting (I), bugbear (B), pyupgrade (UP), and flake8-simplify (SIM).
-# Plus return-type annotations (ANN2xx) so type checkers can propagate types
-# through call sites; argument/Any rules (ANN0xx/ANN401) are intentionally off.
-select = ["E", "F", "W", "I", "B", "UP", "SIM", "ANN201", "ANN202", "ANN204", "ANN205", "ANN206"]
+# pycodestyle errors+warnings (E/W), pyflakes (F), import sorting (I), bugbear (B),
+# pyupgrade (UP), flake8-simplify (SIM), full type annotations (ANN: arguments,
+# *args/**kwargs, return types, and no bare Any), and flake8-fastapi (FAST).
+select = ["E", "F", "W", "I", "B", "UP", "SIM", "ANN", "FAST"]
 # E501 (line length) is the formatter's job; SIM108 (ternaries aren't always
 # clearer); B008 (function calls in argument defaults are fine here, e.g. FastAPI Depends).
-ignore = ["E501", "SIM108", "B008"]
+# ANN401 (no bare `Any`): off because `Any` is the honest type for **kwargs forwarded to
+# HTTPException/SQLAlchemy filters and for pydantic "before" validators that receive raw
+# input -- annotating those as `object` breaks type checking, so the rule only adds noqas.
+ignore = ["E501", "SIM108", "B008", "ANN401"]
 fixable = ["ALL"]
 unfixable = []
 # Allow unused variables when underscore-prefixed.
@@ -88,9 +90,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests trip a couple of flake8-bugbear (the "B" rules) checks -- B011 (`assert False`)
-# and B017 (overly broad `pytest.raises(Exception)`); return-type annotations (ANN2xx)
-# also add little value on test functions. Skip both in tests.
-"ord_app/tests/**" = ["B011", "B017", "ANN201", "ANN202", "ANN204", "ANN205", "ANN206"]
+# and B017 (overly broad `pytest.raises(Exception)`); type annotations (ANN) also add
+# little value on test functions. Skip both in tests.
+"ord_app/tests/**" = ["B011", "B017", "ANN"]
 
 [tool.ruff.lint.isort]
 # ord_schema is an external dependency; pin its classification so import


### PR DESCRIPTION
## Summary

Builds on the ruff-ruleset alignment (#785) by turning on **all of flake8-annotations (`ANN`)** and **flake8-fastapi (`FAST`)** for `ord_app/`, then annotating production code to satisfy them. Tests are exempt (`per-file-ignores`) — return/arg annotations add little value there.

### Rules added
- `ANN201/202/204/205/206` — return-type annotations on every public/private/special/static/class method.
- `ANN001/002/003` — argument, `*args`, and `**kwargs` annotations.
- `FAST` (flake8-fastapi) — FAST002 autofixed (dependencies use `Annotated[...]`).
- **`ANN401` (no bare `Any`) is intentionally `ignore`d** — `Any` is the honest type for `**kwargs` forwarded to `HTTPException`/SQLAlchemy filters and for pydantic *before* validators that receive raw input; typing those as `object` breaks type-checking, so the rule would only add `# noqa`s. (Easily re-enabled if desired.)

### Notable, beyond mechanical annotation
The annotations made `ty` see through previously-gradual code and surfaced real type facts, all fixed here:
- `ReactionModel.is_valid` → `Mapped[bool | None]` (the column is `nullable=True`).
- `GroupModel.role` declared as a **non-mapped transient attribute** (mirrors `ReactionModel.validation`) — `enrich_datasets_with_user_roles` attaches it per request for serialization.
- **FastAPI interactions**, all behavior-preserving:
  - `204 No Content` handlers (`extend_enumerate_dataset`, `delete_template`) annotated `-> None` (they never sent a body).
  - `response_model=None` on handlers whose return type isn't a pydantic field (`download`, `extend`, the `utilities` resolvers) — they had no response model before either.
- None-safety guards/asserts where arg types exposed possibly-`None` flows (`extend` → `add_reactions`; `validate_pb_kind_by_file_ext` filename).
- `schemas/datasets.py` uses `from __future__ import annotations` so `-> map[bytes]` is evaluated lazily.

## Test plan
- [x] `ruff check` + `ruff format --check` clean (full ANN + FAST)
- [x] `ty check ord_app` clean
- [x] **80 backend tests pass**; app imports (FastAPI route registration OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables `ANN` (flake8-annotations) and `FAST` (flake8-fastapi) ruff rules across `ord_app/`, adding full type annotations to all production code while exempting tests. Beyond the mechanical annotation pass, the annotations caused `ty` to surface a handful of real issues that are fixed here.

- **Correctness fixes**: `ReactionModel.is_valid` corrected to `Mapped[bool | None]` (the column is `nullable=True`); `DatasetUseCases.extend` now raises `EntityNotFoundError` when the dataset is not found instead of passing `None` to `add_reactions`; `validate_pb_kind_by_file_ext` now safely handles a `None` filename rather than raising `TypeError` inside `Path(None).suffixes`.
- **FastAPI alignment**: `extend_enumerate_dataset` and `delete_template` drop their unused return values (their routes already had `status_code=204`); `response_model=None` added to endpoints that return raw `Response` objects; `GroupModel` gets a `__allow_unmapped__` transient `role` attribute for per-request serialization, mirroring the existing `ReactionModel.validation` pattern.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are primarily additive type annotations, and the handful of behavioral changes (None guard in extend, 204 cleanup, nullable is_valid) are all correct and well-tested.

The annotation pass is mechanical and correct throughout. The real code changes are all defensive fixes (null guard, nullable type alignment, unused return removal) that improve rather than alter observable behavior. The 80-test suite passes, ruff and ty are clean, and FastAPI route-registration constraints are satisfied.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_app/service_api/models.py | Two substantive fixes: `is_valid` corrected to `Mapped[bool | None]` (matches the nullable=True column), and `GroupModel` gains a `__allow_unmapped__` transient `role` attribute mirroring the existing `ReactionModel.validation` pattern. |
| ord_app/service_api/domain/datasets.py | Mechanical annotations plus a real bug fix: `extend` now raises `EntityNotFoundError` when `dataset_repository.get()` returns None, preventing a downstream `AttributeError` on `add_reactions(None, ...)`. |
| ord_app/service_api/services/pb_utils.py | Added a None guard to `validate_pb_kind_by_file_ext` (previously would have raised `TypeError` if `file.filename` was None); `validate_uploaded_pb_file`'s `if not kind:` check correctly catches the new `None` return. |
| ord_app/service_api/resources/v1/datasets.py | Return types added throughout; `extend_enumerate_dataset` correctly drops the `return dataset` statement (the route already had `status_code=204`), and `response_model=None` added to download and extend endpoints that return raw `Response` objects. |
| ord_app/service_api/resources/v1/templates.py | `delete_template` now correctly drops the unused `return count` value (route already had `status_code=204`); annotations added throughout. |
| ord_app/service_api/main.py | Mechanical annotations: `lifespan` correctly typed as `AsyncIterator[None]`, `catch_errors` middleware gets proper `RequestResponseEndpoint` type for `call_next`, `health_check` returns `bool`. |
| ord_app/service_api/services/postgresql.py | `get_db_session` annotated as `-> AsyncIterator[AsyncSession]`; correct for an async generator used as a FastAPI dependency. |
| ord_app/service_api/repositories/base.py | Mechanical annotation pass: `**kwargs` on abstract and concrete `get`, `filter`, `update`, `delete` methods typed as `**kwargs: Any`. |
| ord_app/service_api/schemas/datasets.py | Adds `from __future__ import annotations` to enable the `-> map[bytes]` lazy annotation on `load_reactions` validators without a runtime error. |
| pyproject.toml | Adds `ANN` and `FAST` to the ruff lint ruleset; `ANN401` (no bare `Any`) intentionally ignored with clear rationale; tests exempt from `ANN` via `per-file-ignores`. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(be): 404 instead of assert when exte..."](https://github.com/open-reaction-database/ord-app/commit/b34aa54b7734192c21a7fef88abf8b0b9fed87d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38835628)</sub>

<!-- /greptile_comment -->