### PR TITLE
fix(ui): reject invalid dates during enumeration instead of silently coercing them (#544)

### DIFF
--- a/ui/src/store/features/enumerationWorker/worker.test.ts
+++ b/ui/src/store/features/enumerationWorker/worker.test.ts
@@ -157,11 +157,28 @@ describe('value coercion by VariableType', () => {
     expect(lastMergedTemplate().valueField).toBe('2024-01-15T08:30:00');
   });
 
-  it('accepts a plain ISO date and common human-authored formats', () => {
-    for (const input of ['2025-04-01', '04/01/2025', '4/1/2025', '01.04.2025', 'April 1, 2025', 'Apr 1 2025']) {
+  it('accepts a plain ISO date, single-digit European, and common human-authored formats', () => {
+    for (const input of [
+      '2025-04-01',
+      '04/01/2025',
+      '4/1/2025',
+      '1.4.2025',
+      '01.04.2025',
+      'April 1, 2025',
+      'Apr 1 2025',
+    ]) {
       const result = run({ variables: [makeVariable(VariableType.Date)], rows: [{ col1: input }] });
       expect(result.errors).toEqual([]);
       expect(lastMergedTemplate().valueField).toBe('2025-04-01');
+    }
+  });
+
+  it('accepts timezone-offset ISO 8601 datetimes for a Date variable', () => {
+    // Valid ISO with a Z/offset/milliseconds was previously accepted by lenient dayjs; it must still be.
+    for (const input of ['2025-04-01T12:00:00Z', '2025-04-01T12:00:00+05:30', '2025-04-01T00:30:00.123Z']) {
+      const result = run({ variables: [makeVariable(VariableType.Date)], rows: [{ col1: input }] });
+      expect(result.errors).toEqual([]);
+      expect(lastMergedTemplate().valueField).toMatch(/^2025-(03-31|04-01)$/);
     }
   });
 
@@ -171,8 +188,9 @@ describe('value coercion by VariableType', () => {
   });
 
   it('rejects a garbage date that the lenient parser would silently coerce (#544)', () => {
-    // dayjs(value) without strict mode parses these as April 1 / month-overflow; strict mode must not.
-    for (const input of ['Aprillllll, 2025', 'MayMayMay, 2025', '2025-13-45']) {
+    // dayjs(value) without strict mode parses these as April 1 / month-overflow; we must not. The
+    // ISO-shaped values have out-of-range month/day, which the ISO regex bounds reject.
+    for (const input of ['Aprillllll, 2025', 'MayMayMay, 2025', '2025-13-45', '2025-00-10', '2025-04-32']) {
       const result = run({ variables: [makeVariable(VariableType.Date)], rows: [{ col1: input }] });
       expect(result.reactions).toEqual([]);
       expect(result.errors[0].message).toBe('Expected date value for variable v1');

--- a/ui/src/store/features/enumerationWorker/worker.test.ts
+++ b/ui/src/store/features/enumerationWorker/worker.test.ts
@@ -157,9 +157,26 @@ describe('value coercion by VariableType', () => {
     expect(lastMergedTemplate().valueField).toBe('2024-01-15T08:30:00');
   });
 
+  it('accepts a plain ISO date and common human-authored formats', () => {
+    for (const input of ['2025-04-01', '04/01/2025', '4/1/2025', '01.04.2025', 'April 1, 2025', 'Apr 1 2025']) {
+      const result = run({ variables: [makeVariable(VariableType.Date)], rows: [{ col1: input }] });
+      expect(result.errors).toEqual([]);
+      expect(lastMergedTemplate().valueField).toBe('2025-04-01');
+    }
+  });
+
   it('rejects an invalid date', () => {
     const result = run({ variables: [makeVariable(VariableType.Date)], rows: [{ col1: 'not-a-date' }] });
     expect(result.errors[0].message).toBe('Expected date value for variable v1');
+  });
+
+  it('rejects a garbage date that the lenient parser would silently coerce (#544)', () => {
+    // dayjs(value) without strict mode parses these as April 1 / month-overflow; strict mode must not.
+    for (const input of ['Aprillllll, 2025', 'MayMayMay, 2025', '2025-13-45']) {
+      const result = run({ variables: [makeVariable(VariableType.Date)], rows: [{ col1: input }] });
+      expect(result.reactions).toEqual([]);
+      expect(result.errors[0].message).toBe('Expected date value for variable v1');
+    }
   });
 
   it('rejects a non-string date value', () => {

--- a/ui/src/store/features/enumerationWorker/worker.ts
+++ b/ui/src/store/features/enumerationWorker/worker.ts
@@ -39,17 +39,22 @@ import { DATE_FORMAT, DATE_TIME_FORMAT } from 'common/constants.ts';
 // 2025" into April 1 — see issue #544. Strict mode rejects anything that doesn't match a format.
 dayjs.extend(customParseFormat);
 
-// Date/date-time formats accepted for enumeration CSV cells. Covers the app's own output
-// (YYYY-MM-DD / ISO date-time) plus common human-authored formats. Extend this list if a legitimate
-// CSV format is rejected.
+// Strict ISO 8601 (the app's own output plus tz-aware inputs): date, optional time with optional
+// milliseconds, and an optional Z or ±HH:mm offset. Month/day ranges are bounded here because
+// dayjs's ISO parser would otherwise roll overflow values (e.g. 2025-13-45 → 2026-02-14). The 'Z'
+// offset token isn't honored by customParseFormat's strict mode, so ISO is gated by this regex and
+// parsed with dayjs's default (ISO) parser; non-ISO human formats go through the strict list below.
+const ISO_8601 =
+  /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])([T ]([01]\d|2[0-3]):[0-5]\d(:[0-5]\d(\.\d+)?)?(Z|[+-]([01]\d|2[0-3]):[0-5]\d)?)?$/;
+
+// Non-ISO date formats accepted for enumeration CSV cells: common human-authored formats (US slash,
+// European dot, and named-month). Extend this list if a legitimate CSV format is rejected.
 const ACCEPTED_DATE_FORMATS = [
-  'YYYY-MM-DD',
-  'YYYY-MM-DDTHH:mm:ss',
-  'YYYY-MM-DDTHH:mm',
   'YYYY/MM/DD',
   'MM/DD/YYYY',
   'M/D/YYYY',
   'DD.MM.YYYY',
+  'D.M.YYYY',
   'MMMM D, YYYY',
   'MMMM D YYYY',
   'MMM D, YYYY',
@@ -67,7 +72,7 @@ function getDateOrError(value: ValueType, variable: Variable): string {
   if (typeof value !== 'string') {
     throw produceValueTypeError('date', variable);
   }
-  const date = dayjs(value, ACCEPTED_DATE_FORMATS, true);
+  const date = ISO_8601.test(value) ? dayjs(value) : dayjs(value, ACCEPTED_DATE_FORMATS, true);
   if (!date.isValid()) {
     throw produceValueTypeError('date', variable);
   }

--- a/ui/src/store/features/enumerationWorker/worker.ts
+++ b/ui/src/store/features/enumerationWorker/worker.ts
@@ -39,13 +39,13 @@ import { DATE_FORMAT, DATE_TIME_FORMAT } from 'common/constants.ts';
 // 2025" into April 1 — see issue #544. Strict mode rejects anything that doesn't match a format.
 dayjs.extend(customParseFormat);
 
-// Strict ISO 8601 (the app's own output plus tz-aware inputs): date, optional time with optional
-// milliseconds, and an optional Z or ±HH:mm offset. Month/day ranges are bounded here because
-// dayjs's ISO parser would otherwise roll overflow values (e.g. 2025-13-45 → 2026-02-14). The 'Z'
-// offset token isn't honored by customParseFormat's strict mode, so ISO is gated by this regex and
-// parsed with dayjs's default (ISO) parser; non-ISO human formats go through the strict list below.
-const ISO_8601 =
-  /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])([T ]([01]\d|2[0-3]):[0-5]\d(:[0-5]\d(\.\d+)?)?(Z|[+-]([01]\d|2[0-3]):[0-5]\d)?)?$/;
+// ISO 8601 (the app's own output plus tz-aware inputs): date, optional time, optional Z/±HHMM
+// offset. Month/day ranges are bounded here because dayjs's ISO parser would otherwise silently
+// roll overflow values (e.g. 2025-13-45 → 2026-02-14); the time and offset are matched loosely and
+// left for dayjs to validate. The 'Z'/offset token isn't honored by customParseFormat's strict
+// mode, so ISO is gated by this regex and parsed with dayjs's default (ISO) parser; non-ISO human
+// formats go through the strict list below.
+const ISO_8601 = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])([T ][\d:.]+(Z|[+-]\d\d:?\d\d)?)?$/;
 
 // Non-ISO date formats accepted for enumeration CSV cells: common human-authored formats (US slash,
 // European dot, and named-month). Extend this list if a legitimate CSV format is rejected.

--- a/ui/src/store/features/enumerationWorker/worker.ts
+++ b/ui/src/store/features/enumerationWorker/worker.ts
@@ -31,7 +31,32 @@ import { ord } from 'ord-schema-protobufjs';
 import { reactionToOrdReaction } from 'store/entities/reactions/reactions.converters.ts';
 import { ordBooleanToReaction } from 'store/entities/reactions/reactionEntity/reactionEntity.converters.ts';
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat.js';
 import { DATE_FORMAT, DATE_TIME_FORMAT } from 'common/constants.ts';
+
+// customParseFormat gives dayjs strict parsing against an explicit format list. Without it dayjs
+// falls back to the lenient native Date parser, which silently coerces garbage like "Aprillllll,
+// 2025" into April 1 — see issue #544. Strict mode rejects anything that doesn't match a format.
+dayjs.extend(customParseFormat);
+
+// Date/date-time formats accepted for enumeration CSV cells. Covers the app's own output
+// (YYYY-MM-DD / ISO date-time) plus common human-authored formats. Extend this list if a legitimate
+// CSV format is rejected.
+const ACCEPTED_DATE_FORMATS = [
+  'YYYY-MM-DD',
+  'YYYY-MM-DDTHH:mm:ss',
+  'YYYY-MM-DDTHH:mm',
+  'YYYY/MM/DD',
+  'MM/DD/YYYY',
+  'M/D/YYYY',
+  'DD.MM.YYYY',
+  'MMMM D, YYYY',
+  'MMMM D YYYY',
+  'MMM D, YYYY',
+  'MMM D YYYY',
+  'D MMMM YYYY',
+  'D MMM YYYY',
+];
 
 const produceValueTypeError = (type: string, variable: Variable) =>
   new Error(`Expected ${type} value for variable ${variable.name}`);
@@ -42,7 +67,7 @@ function getDateOrError(value: ValueType, variable: Variable): string {
   if (typeof value !== 'string') {
     throw produceValueTypeError('date', variable);
   }
-  const date = dayjs(value);
+  const date = dayjs(value, ACCEPTED_DATE_FORMATS, true);
   if (!date.isValid()) {
     throw produceValueTypeError('date', variable);
   }

--- a/ui/src/store/features/enumerationWorker/worker.ts
+++ b/ui/src/store/features/enumerationWorker/worker.ts
@@ -39,13 +39,11 @@ import { DATE_FORMAT, DATE_TIME_FORMAT } from 'common/constants.ts';
 // 2025" into April 1 — see issue #544. Strict mode rejects anything that doesn't match a format.
 dayjs.extend(customParseFormat);
 
-// ISO 8601 (the app's own output plus tz-aware inputs): date, optional time, optional Z/±HHMM
-// offset. Month/day ranges are bounded here because dayjs's ISO parser would otherwise silently
-// roll overflow values (e.g. 2025-13-45 → 2026-02-14); the time and offset are matched loosely and
-// left for dayjs to validate. The 'Z'/offset token isn't honored by customParseFormat's strict
-// mode, so ISO is gated by this regex and parsed with dayjs's default (ISO) parser; non-ISO human
-// formats go through the strict list below.
-const ISO_8601 = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])([T ][\d:.]+(Z|[+-]\d\d:?\d\d)?)?$/;
+// ISO-8601-shaped input (the app's own output plus tz-aware inputs): a YYYY-MM-DD date with an
+// optional time and an optional Z/±HHMM offset. The 'Z'/offset token isn't honored by
+// customParseFormat's strict mode, so ISO is gated by this (deliberately simple) regex and parsed
+// with dayjs's default ISO parser; non-ISO human formats go through the strict list below.
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}([T ][\d:.]+(Z|[+-]\d\d:?\d\d)?)?$/;
 
 // Non-ISO date formats accepted for enumeration CSV cells: common human-authored formats (US slash,
 // European dot, and named-month). Extend this list if a legitimate CSV format is rejected.
@@ -68,11 +66,23 @@ const produceValueTypeError = (type: string, variable: Variable) =>
 
 type ValueType = string | number | boolean;
 
+// dayjs's ISO parser silently rolls out-of-range month/day (e.g. 2025-13-45 → 2026-02-14), so bound
+// them numerically. Kept in code rather than the regex to keep the pattern's complexity low.
+function isInRangeIsoDate(value: string): boolean {
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  return month >= 1 && month <= 12 && day >= 1 && day <= 31;
+}
+
 function getDateOrError(value: ValueType, variable: Variable): string {
   if (typeof value !== 'string') {
     throw produceValueTypeError('date', variable);
   }
-  const date = ISO_8601.test(value) ? dayjs(value) : dayjs(value, ACCEPTED_DATE_FORMATS, true);
+  const isIso = ISO_8601.test(value);
+  if (isIso && !isInRangeIsoDate(value)) {
+    throw produceValueTypeError('date', variable);
+  }
+  const date = isIso ? dayjs(value) : dayjs(value, ACCEPTED_DATE_FORMATS, true);
   if (!date.isValid()) {
     throw produceValueTypeError('date', variable);
   }


### PR DESCRIPTION
Closes #544.

## Problem

The enumeration worker parsed CSV date cells with lenient `dayjs(value)` ([worker.ts](ui/src/store/features/enumerationWorker/worker.ts)), which falls back to the native `Date` parser. That parser silently coerces garbage into a real date, so an invalid cell enumerated a wrong reaction with **no warning**:

| Input | Lenient `dayjs(value)` |
|---|---|
| `Aprillllll, 2025` | ✅ → 2025-04-01 |
| `MayMayMay, 2025` | ✅ → 2025-05-01 |
| `2025-13-45` | ✅ → 2026-02-14 (overflow) |

(Verified against the repo's dayjs version.)

## Fix

Enable dayjs's `customParseFormat` plugin and parse in **strict** mode against an explicit allow-list of accepted formats — the app's own output (`YYYY-MM-DD`, ISO date-time) plus common human-authored formats (US `MM/DD/YYYY`, European `DD.MM.YYYY`, named-month `April 1, 2025` / `Apr 1 2025`, etc.). Anything that doesn't match a listed format is rejected and surfaced through the **existing** per-line `Expected date value for variable …` enumeration error shown in the results — i.e. the warning the issue asks for. Legitimate dates still parse.

`customParseFormat` only changes behavior when a format list is passed, so no other dayjs usage is affected.

## ⚠️ For review

The issue's screenshot enumerates the date formats expected to be accepted, which I can't read. The allow-list in [worker.ts](ui/src/store/features/enumerationWorker/worker.ts) is my best-effort superset; **please reconcile it with that screenshot** and tell me if a legitimate format is missing — extending the list is a one-line change. (Being too strict would reject valid CSVs, so I erred generous.)

## Tests

Added to `worker.test.ts`:
- accepts a plain ISO date + US/European/named-month formats (all → `2025-04-01`)
- rejects the issue's garbage strings (`Aprillllll, 2025`, `MayMayMay, 2025`, `2025-13-45`) with the per-line error and no emitted reaction

Verification: `npx vitest run` (714 passing), `npx tsc -b --force` (clean), prettier + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes silent date coercion in the enumeration worker by replacing the lenient `dayjs(value)` call with strict parsing: ISO-8601-shaped strings go through a bounding regex + dayjs's native ISO parser, while all other strings are matched against an explicit allow-list of human-authored formats using `dayjs/plugin/customParseFormat`. Invalid inputs now throw the existing per-line error instead of silently producing a wrong reaction date.

- `worker.ts`: registers `customParseFormat`, defines `ISO_8601` regex with month/day range guard (`isInRangeIsoDate`), and rewires `getDateOrError` to use the two-path parser.
- `worker.test.ts`: adds acceptance tests for plain ISO, US/European/named-month formats, and timezone-offset ISO 8601 datetimes, plus rejection tests for the garbage strings from issue #544.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to date parsing in the enumeration worker, previous review concerns are fully addressed, and the test suite covers both the acceptance and rejection paths.

The two-path ISO/non-ISO parsing approach is sound: the ISO regex combined with `isInRangeIsoDate` correctly gates month (1–12) and day (1–31) before handing off to dayjs, while `customParseFormat` strict mode handles non-ISO formats without ambiguity. The previous concerns about timezone-offset strings and single-digit European dot dates were both fixed and covered by new tests. The deliberate looseness in `[\d:.]+` (time component of the ISO regex) is safe because `date.isValid()` acts as the final gate. No other code paths are affected by enabling `customParseFormat`.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/store/features/enumerationWorker/worker.ts | Adds strict date parsing via dayjs customParseFormat and an ISO-8601 regex guard; the two prior review concerns (timezone offsets, single-digit European dots) are both resolved. |
| ui/src/store/features/enumerationWorker/worker.test.ts | New tests cover ISO dates, timezone-offset datetimes, common human-authored formats, and the garbage strings from the issue; all valid dates resolve to the expected 2025-04-01 output. |

</details>

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ui): move ISO date range-check into ..."](https://github.com/open-reaction-database/ord-app/commit/d10f6602eb58347050d1dc9d4f7d1468e311c970) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38840270)</sub>

<!-- /greptile_comment -->