### PR TITLE
fix(ui): collapse the empty label band under wrapper-grouped fields (#555)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/reactionEntityNode/reactionFormNode.module.scss
+++ b/ui/src/features/reactions/ReactionEntities/reactionEntityNode/reactionFormNode.module.scss
@@ -17,3 +17,13 @@
   display: grid;
   grid-column-gap: var(--mantine-spacing-sm);
 }
+
+/*
+ * Value fields grouped under a wrapper heading (e.g. "Limiting reactant conversion") carry only a
+ * templateLabel, so their per-field label renders empty outside template mode. Mantine still
+ * reserves the label band, leaving stray vertical space under the heading; collapse it. (#555)
+ */
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown -- :global is CSS-modules syntax */
+.wrapper :global(.mantine-InputWrapper-label):empty {
+  display: none;
+}


### PR DESCRIPTION
Closes #555.

## Problem

In the Outcome sidebar, under the **Limiting reactant conversion** heading there's stray vertical space between the heading and the Value/Precision inputs.

**Root cause:** the two value fields under that heading are defined with only a `templateLabel` (no `label`), so in non-template (dataset reaction) mode their per-field label component renders `null`. Mantine still emits the `.mantine-InputWrapper-label` element, which reserves an ~8px band per field — the stray space. (The same phantom band also affected the **Flow rate** field in the Inputs sidebar.)

## Fix

One scoped CSS rule in `reactionFormNode.module.scss` (the wrapper-node grid):

```scss
.wrapper :global(.mantine-InputWrapper-label):empty { display: none; }
```

`:empty` only matches labels with no content, so labeled fields are untouched. I audited every `ReactionFormNodeType.wrapper` grid: each is either fully labeled, all-empty, or single-child — so no labeled/unlabeled row gets misaligned.

## Verification

Runtime-verified against the live no-auth stack (Outcome sidebar of a seeded reaction): the empty `.mantine-InputWrapper-label` heights go **8px → 0px** and the inputs sit directly under the heading. stylelint + prettier clean.

Before (gap under heading) → After (collapsed):
- empty label band heights measured `[8, 8]` → `[0, 0]`

CSS-only change; no behavior or markup change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes stray vertical space in wrapper-grouped fields (e.g. **Limiting reactant conversion**, **Flow rate**) caused by Mantine always rendering the `.mantine-InputWrapper-label` element even when no label text is present. The fix is a single scoped CSS rule that collapses those empty label bands to zero height without touching labeled fields.

- Adds `.wrapper :global(.mantine-InputWrapper-label):empty { display: none; }` to `reactionFormNode.module.scss`, scoped so it only affects wrapper-grid containers.
- The `stylelint-disable-next-line` comment correctly documents that `:global` is intentional CSS Modules syntax rather than a lint error.

<h3>Confidence Score: 5/5</h3>

Safe to merge — CSS-only change with no markup or behavior modifications.

The rule is tightly scoped to `.wrapper` elements, uses the well-supported `:empty` pseudo-class which only fires when the label element has zero child nodes, and the stylelint suppression is correctly explained. The PR author audited all wrapper grids to confirm no labeled/unlabeled field is mixed in the same row, and runtime verification confirmed the fix. One speculative future risk: if a future Mantine version injects any whitespace inside empty label elements, `:empty` would silently stop matching — but that is not a current defect.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/reactionEntityNode/reactionFormNode.module.scss | Adds a single scoped CSS rule to collapse empty Mantine InputWrapper label bands inside wrapper-grid elements; no behavior or markup change. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): collapse the empty label band u..."](https://github.com/open-reaction-database/ord-app/commit/6398d6edcc0bf177a8b46073f7d7cddcf3ac68e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38841625)</sub>

<!-- /greptile_comment -->