### PR TITLE
chore(be): add flake8-bandit (ruff `S`) for Python SAST

### DIFF
--- a/ord_app/service_api/domain/datasets.py
+++ b/ord_app/service_api/domain/datasets.py
@@ -58,7 +58,7 @@ class DatasetUseCases:
     async def create(self, group_id: int, payload: DatasetCreateSchema) -> DatasetModel:
         dataset = await self.dataset_repository.create(group_id, self.current_user.id, payload.model_dump())
         dataset = await self.dataset_repository.get(dataset.id)
-        assert dataset is not None  # just created above
+        assert dataset is not None  # just created above  # noqa: S101 (type-narrowing guard)
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
@@ -68,7 +68,7 @@ class DatasetUseCases:
         await self.add_reactions(dataset, [Reaction.FromString(i) for i in payload.reactions])
 
         dataset = await self.dataset_repository.get(dataset.id)
-        assert dataset is not None  # just created above
+        assert dataset is not None  # just created above  # noqa: S101 (type-narrowing guard)
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 
@@ -120,7 +120,7 @@ class DatasetUseCases:
         )
         await self.add_reactions(dataset, dataset_pb.reactions)
         dataset = await self.dataset_repository.get(dataset.id)
-        assert dataset is not None  # just created above
+        assert dataset is not None  # just created above  # noqa: S101 (type-narrowing guard)
         await self.dataset_repository.enrich_datasets_with_user_roles([dataset], self.current_user.id)
         return dataset
 

--- a/ord_app/service_api/repositories/datasets.py
+++ b/ord_app/service_api/repositories/datasets.py
@@ -97,7 +97,7 @@ class DatasetsRepository:
             .group_by(DatasetModel.id)
         )
         row = (await self.db.execute(stmt)).first()
-        assert row is not None  # dataset existence is enforced upstream by dataset_authorization
+        assert row is not None  # enforced upstream by dataset_authorization  # noqa: S101 (type-narrowing guard)
         dataset, rct_total, rct_invalid, rct_valid, rct_none = row
         dataset.reactions_count = {
             "total": rct_total,

--- a/ord_app/service_api/services/resolvers.py
+++ b/ord_app/service_api/services/resolvers.py
@@ -56,7 +56,7 @@ async def name_resolve_cached(value_type: str, value: str) -> tuple[str, str] | 
                 if not t.done():
                     t.cancel()
             return response
-        except Exception:
+        except Exception:  # noqa: S112 -- intentional: try the next resolver; a failed/empty lookup is expected (returns None overall)
             continue
 
 

--- a/ord_app/service_api/services/resolvers.py
+++ b/ord_app/service_api/services/resolvers.py
@@ -17,6 +17,7 @@ from typing import Any
 from urllib.parse import quote
 
 from httpx import AsyncClient
+from loguru import logger
 from ord_schema import resolvers
 
 from ord_app.service_api.services.utils import alru_cache
@@ -56,7 +57,9 @@ async def name_resolve_cached(value_type: str, value: str) -> tuple[str, str] | 
                 if not t.done():
                     t.cancel()
             return response
-        except Exception:  # noqa: S112 -- intentional: try the next resolver; a failed/empty lookup is expected (returns None overall)
+        except Exception as e:
+            # A failed/empty lookup is expected; log at debug and try the next resolver.
+            logger.debug(f"resolver failed: {e}")
             continue
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,9 @@ target-version = "py312"
 [tool.ruff.lint]
 # pycodestyle errors+warnings (E/W), pyflakes (F), import sorting (I), bugbear (B),
 # pyupgrade (UP), flake8-simplify (SIM), full type annotations (ANN: arguments,
-# *args/**kwargs, return types, and no bare Any), and flake8-fastapi (FAST).
-select = ["E", "F", "W", "I", "B", "UP", "SIM", "ANN", "FAST"]
+# *args/**kwargs, return types, and no bare Any), flake8-fastapi (FAST), and
+# flake8-bandit (S: security/SAST -- replaces SonarCloud's Python security findings).
+select = ["E", "F", "W", "I", "B", "UP", "SIM", "ANN", "FAST", "S"]
 # E501 (line length) is the formatter's job; SIM108 (ternaries aren't always
 # clearer); B008 (function calls in argument defaults are fine here, e.g. FastAPI Depends).
 # ANN401 (no bare `Any`): off because `Any` is the honest type for **kwargs forwarded to
@@ -91,8 +92,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 [tool.ruff.lint.per-file-ignores]
 # Tests trip a couple of flake8-bugbear (the "B" rules) checks -- B011 (`assert False`)
 # and B017 (overly broad `pytest.raises(Exception)`); type annotations (ANN) also add
-# little value on test functions. Skip both in tests.
-"ord_app/tests/**" = ["B011", "B017", "ANN"]
+# little value on test functions. S101 (flake8-bandit) flags `assert`, which is exactly
+# how pytest expresses checks, so it is pure noise in tests. Skip all of these in tests.
+"ord_app/tests/**" = ["B011", "B017", "ANN", "S101"]
 
 [tool.ruff.lint.isort]
 # ord_schema is an external dependency; pin its classification so import


### PR DESCRIPTION
## What

Enable ruff's **flake8-bandit** ruleset (`S`) so Python security/SAST lint runs **locally** (and in `check_python`), rather than only in the SonarCloud cloud gate.

This is the first of several PRs migrating SonarCloud's value-adding features into local tooling, ahead of retiring the Sonar merge gate. It covers **Sonar's Python security findings**.

## Triage of what `S` surfaces

| Finding | Where | Resolution |
|---|---|---|
| `S101` (assert) | tests (175) | asserts are how pytest expresses checks → added to the existing `ord_app/tests/**` per-file-ignore |
| `S101` (assert) | prod (4 sites) | all type-narrowing guards after a just-created / upstream-guaranteed lookup → inline `# noqa: S101` keeping the reason |
| `S112` (try/except/continue) | `resolvers.py` (1) | intentional fan-out across three resolvers where a failed/empty lookup is expected → **log the swallowed exception at debug level** (matching the codebase's existing `loguru` usage), which resolves the finding properly rather than suppressing it |

## Risk

Lint-config + comments, plus one added `logger.debug(...)` for previously-swallowed resolver exceptions — no change to control flow or outputs. `ruff check`, `ruff format --check`, and `ty` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables ruff's flake8-bandit (`S`) ruleset for Python SAST linting, bringing SonarCloud's Python security findings into local tooling. The changes are lint-config and comment additions only, with one small behavioral addition: a `loguru` debug log in the resolver's except-continue block to properly resolve S112 rather than suppressing it.

- `pyproject.toml`: adds `S` to ruff's `select` list and `S101` to `per-file-ignores` for tests, where `assert` is the standard pytest assertion mechanism.
- `datasets.py` (domain + repository): four `assert … is not None` statements that act as type-narrowing guards after guaranteed lookups receive `# noqa: S101` annotations with explanatory comments.
- `resolvers.py`: the bare `except Exception: continue` block gains a `loguru` debug log, resolving S112 by substance rather than suppression.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are lint configuration, noqa annotations, and a one-line debug log; no runtime logic is altered.

Every change is either a config line in `pyproject.toml`, an inline `# noqa` comment on an existing assert, or a single debug-log statement added to an already-silent except block. None of these touch business logic, database queries, authentication, or API responses. The loguru package is already a declared dependency, so the new import introduces no new risk.

No files require special attention. The PR description's triage table is slightly misleading about how S112 was resolved (logging vs. suppression), but that is a documentation issue only.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Adds flake8-bandit (`S`) to ruff's select ruleset and `S101` to per-file-ignores for tests — config-only change, no runtime impact. |
| ord_app/service_api/services/resolvers.py | Imports loguru and adds a debug log in the except-continue block to resolve S112 without a noqa suppression; loguru is already a declared dependency. |
| ord_app/service_api/domain/datasets.py | Appends `# noqa: S101 (type-narrowing guard)` to three post-creation assert statements — comment-only, no logic change. |
| ord_app/service_api/repositories/datasets.py | Appends `# noqa: S101 (type-narrowing guard)` to one assert statement and shortens inline comment — comment-only, no logic change. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(be): log swallowed resolver except..."](https://github.com/open-reaction-database/ord-app/commit/901216947325a52ea8686e91ceb7a9becae4e2aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38842410)</sub>

<!-- /greptile_comment -->