### PR TITLE
feat: show each template's last-modified date in the user's timezone (#619)

### DIFF
--- a/ord_app/service_api/schemas/templates.py
+++ b/ord_app/service_api/schemas/templates.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from base64 import b64decode, b64encode
+from datetime import datetime
 from typing import Annotated, Any
 
 import orjson
@@ -29,6 +30,7 @@ class TemplateResponseModel(BaseSchema):
     binpb: bytes | Any
     variables: Json
     molblocks: dict
+    modified_at: datetime
     summary: dict = Field(default_factory=lambda: {"provenance": {"doi": "foo"}, "summary": {"yield": 25.5}})
 
     @model_validator(mode="before")

--- a/ord_app/tests/test_templates/test_get_templates.py
+++ b/ord_app/tests/test_templates/test_get_templates.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from faker import Faker
 from fastapi import status
@@ -45,8 +45,11 @@ async def test_get_template(api_client, mock_authenticated_user, test_db_session
 
     response_data = api_client.get(f"/api/v1/templates/{template.id}").raise_for_status().json()
     assert response_data["id"] == template.id
-    # The template carries a server-managed last-modified timestamp (#619); it must be serialized.
-    assert datetime.fromisoformat(response_data["modified_at"])
+    # The server-managed last-modified timestamp must be serialized and match the stored value (#619).
+    returned_modified_at = datetime.fromisoformat(response_data["modified_at"])
+    if returned_modified_at.tzinfo and not template.modified_at.tzinfo:
+        returned_modified_at = returned_modified_at.replace(tzinfo=None)
+    assert abs(returned_modified_at - template.modified_at) < timedelta(seconds=1)
 
 
 async def test_get_foreign_template(api_client, mock_authenticated_user, test_db_session):

--- a/ord_app/tests/test_templates/test_get_templates.py
+++ b/ord_app/tests/test_templates/test_get_templates.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from datetime import datetime
+
 from faker import Faker
 from fastapi import status
 
@@ -43,6 +45,8 @@ async def test_get_template(api_client, mock_authenticated_user, test_db_session
 
     response_data = api_client.get(f"/api/v1/templates/{template.id}").raise_for_status().json()
     assert response_data["id"] == template.id
+    # The template carries a server-managed last-modified timestamp (#619); it must be serialized.
+    assert datetime.fromisoformat(response_data["modified_at"])
 
 
 async def test_get_foreign_template(api_client, mock_authenticated_user, test_db_session):

--- a/ui/src/features/templates/TemplateHeader/TemplateHeader.test.tsx
+++ b/ui/src/features/templates/TemplateHeader/TemplateHeader.test.tsx
@@ -30,7 +30,11 @@ vi.mock('features/templates/TemplateHeaderActions/TemplateHeaderActions', () => 
 const stateWithVariables = (variables: object): { preloadedState: AppState } => ({
   preloadedState: {
     entities: {
-      reactions: { reactionsById: { template_1: { id: 1, data: {}, name: 'My Template', variables } } },
+      reactions: {
+        reactionsById: {
+          template_1: { id: 1, data: {}, name: 'My Template', variables, modified_at: '2025-06-15T14:30:00Z' },
+        },
+      },
     },
   } as unknown as AppState,
 });
@@ -48,5 +52,12 @@ describe('TemplateHeader', () => {
       stateWithVariables({ v1: { name: 'reagent' } }),
     );
     expect(getByText('Template is valid')).toBeInTheDocument();
+  });
+
+  it('shows the last-modified date formatted in the user timezone (#619)', () => {
+    const { getByText } = renderWithProviders(<TemplateHeader templateId="template_1" />, stateWithVariables({}));
+    expect(getByText('Last Modified')).toBeInTheDocument();
+    // DD.MM.YYYY hh:mm a (DATE_TIME_HUMAN_FORMAT); exact value is timezone-dependent, so match the shape.
+    expect(getByText(/\d{2}\.\d{2}\.\d{4} \d{2}:\d{2} (am|pm)/)).toBeInTheDocument();
   });
 });

--- a/ui/src/features/templates/TemplateHeader/TemplateHeader.tsx
+++ b/ui/src/features/templates/TemplateHeader/TemplateHeader.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import { ActionIcon, Flex, Paper, Title } from '@mantine/core';
+import { DataField } from 'common/components/display/DataField/DataField.tsx';
+import { formatUtcDateToDisplay } from 'common/utils';
 import { selectReactionById } from 'store/entities/reactions/reactions.selectors.ts';
 import { useSelector } from 'react-redux';
 import { EditIcon } from 'common/icons';
@@ -93,6 +95,7 @@ export function TemplateHeader({ templateId }: Readonly<TemplateHeaderProps>) {
               </ActionIcon>
             </Flex>
           </Flex>
+          <DataField label="Last Modified">{formatUtcDateToDisplay(template.modified_at)}</DataField>
           <ReactionPreview reaction={template} />
         </Flex>
         {opened && (

--- a/ui/src/store/entities/reactions/reactions.types.ts
+++ b/ui/src/store/entities/reactions/reactions.types.ts
@@ -159,6 +159,7 @@ export interface ReactionTemplate extends BaseReaction {
   id: string;
   name: string;
   variables: Record<string, Variable>;
+  modified_at: string;
 }
 
 export type ReactionOrTemplate = DatasetReaction | ReactionTemplate;

--- a/ui/src/store/entities/templates/templates.types.ts
+++ b/ui/src/store/entities/templates/templates.types.ts
@@ -49,6 +49,7 @@ export interface TemplateResponse {
   variables: string;
   summary: ReactionSummary;
   molblocks: ReactionMolBlocks;
+  modified_at: string;
 }
 
 export interface SaveAsTemplatePayload {


### PR DESCRIPTION
Closes #619.

## Summary

The template page showed no last-modified timestamp, unlike the dataset header. `TemplateModel` already has a server-managed `modified_at` (via `BaseModel`), so this just **surfaces an existing column** — no migration, no new write path.

## Changes
- **Backend:** add `modified_at: datetime` to `TemplateResponseModel`. `test_get_template` now asserts it's serialized.
- **Frontend:** thread `modified_at` through `TemplateResponse` → `ReactionTemplate` (`parseTemplate` already spreads remaining fields) and render it in `TemplateHeader` as a `Last Modified` `DataField` via `formatUtcDateToDisplay`, mirroring `DatasetHeader`. Added a `TemplateHeader` test asserting the field renders (TZ-robust shape match).

## Verification
- Runtime-verified on the live no-auth stack — the template page shows **Last Modified / 20.06.2026 05:58 pm** under the title.
- `pytest ord_app/tests/test_templates` (12 passed), `ty` clean, `vitest` template suite green, `tsc -b` / ruff / prettier / eslint clean.

## Note
This touches the template **response schema** (additive only). Flagging per the data-model review rule — you green-lit #619 directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces the existing server-managed `modified_at` column from `TemplateModel` on the template detail page, matching the behavior already present in `DatasetHeader`. No schema migration is required.

- **Backend:** `modified_at: datetime` added to `TemplateResponseModel`; both the list and single-get endpoints use this schema, so the field is returned consistently. The `test_get_template` assertion handles the naive-vs-aware datetime comparison correctly.
- **Frontend:** `modified_at: string` threaded through `TemplateResponse` → `ReactionTemplate` via the existing `...rest` spread in `parseTemplate`, then rendered in `TemplateHeader` with `formatUtcDateToDisplay` — the same utility used by `DatasetHeader`. The new Vitest test is timezone-robust.

<h3>Confidence Score: 5/5</h3>

Safe to merge — additive schema change with no migration, consistent with the existing DatasetHeader pattern, and verified end-to-end.

The change is purely additive: a new field on the response schema, two new type declarations, and a one-line UI addition. The implementation exactly mirrors the proven DatasetHeader path (`formatUtcDateToDisplay` via `dayjs.utc()`), the `...rest` spread in `parseTemplate` requires no converter changes, and both API endpoints use the same `TemplateResponseModel` so the field is consistently present.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_app/service_api/schemas/templates.py | Adds `modified_at: datetime` to `TemplateResponseModel`; consistent with how other response models expose the server-managed column. |
| ord_app/tests/test_templates/test_get_templates.py | Adds a round-trip assertion for `modified_at` in `test_get_template`; timezone-stripping logic handles the naive-vs-aware mismatch that `func.now()` + Pydantic can produce. |
| ui/src/features/templates/TemplateHeader/TemplateHeader.tsx | Renders `Last Modified` via `DataField` + `formatUtcDateToDisplay`, mirroring the existing `DatasetHeader` pattern exactly. |
| ui/src/features/templates/TemplateHeader/TemplateHeader.test.tsx | New test asserts label and date-shape regex; timezone-robust and correctly seeds `modified_at` in preloaded state. |
| ui/src/store/entities/reactions/reactions.types.ts | Adds required `modified_at: string` to `ReactionTemplate`; the field arrives via `...rest` spread in `parseTemplate` so no converter change is needed. |
| ui/src/store/entities/templates/templates.types.ts | Adds `modified_at: string` to `TemplateResponse`; the API wire type now matches the backend schema for both the list and single-get endpoints. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(be): assert the template response&#39;s..."](https://github.com/open-reaction-database/ord-app/commit/0c8aa071ab9521763acb25df7e69e90bd5cb601f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38842441)</sub>

<!-- /greptile_comment -->