### PR TITLE
fix(ui): show observation attachments under a numbered "Observation N" name (#613)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/AppDataDisplay.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/AppDataDisplay.test.tsx
@@ -44,4 +44,16 @@ describe('AppDataDisplay', () => {
     );
     expect(screen.getByText('No file')).toBeInTheDocument();
   });
+
+  it('uses fileNameOverride for the file name, keeping the format extension (#613)', () => {
+    renderWithMantine(
+      <AppDataDisplay
+        appData={appData({ type: AppDataType.Upload, value: 'YWJj', format: 'json' }, 'f2f073f90dc84c60989affda5ab')}
+        fileNameOverride="Observation 1"
+      />,
+    );
+    const link = screen.getByRole('link', { name: 'Observation 1.json' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('download', 'Observation 1.json');
+  });
 });

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/AppDataDisplay.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/AppDataDisplay.tsx
@@ -19,10 +19,15 @@ import type { FileControlValue } from 'common/components/inputs/FileControl/file
 
 interface AppDataDisplayProps {
   appData: AppData;
+  // Overrides the base file name shown/downloaded (the extension is still derived from the data
+  // format). Observations have no name field, so the view passes the positional "Observation N"
+  // here, making the file read as a numbered name like Features do instead of the raw stored
+  // filename. (#613)
+  fileNameOverride?: string;
 }
 
-function AppDataFileDisplay({ appData }: Readonly<AppDataDisplayProps>) {
-  const { fileName, href } = useFileNameHref(appData.name, appData.data as FileControlValue);
+function AppDataFileDisplay({ appData, fileNameOverride }: Readonly<AppDataDisplayProps>) {
+  const { fileName, href } = useFileNameHref(fileNameOverride ?? appData.name, appData.data as FileControlValue);
   return appData.data.value ? (
     <a
       download={fileName}
@@ -35,7 +40,7 @@ function AppDataFileDisplay({ appData }: Readonly<AppDataDisplayProps>) {
   );
 }
 
-export function AppDataDisplay({ appData }: Readonly<AppDataDisplayProps>) {
+export function AppDataDisplay({ appData, fileNameOverride }: Readonly<AppDataDisplayProps>) {
   switch (appData.data.type) {
     case AppDataType.Url: {
       const url = (appData.data.value as string) || '';
@@ -53,6 +58,11 @@ export function AppDataDisplay({ appData }: Readonly<AppDataDisplayProps>) {
     case AppDataType.Number:
       return <span>{appData.data.value}</span>;
     case AppDataType.Upload:
-      return <AppDataFileDisplay appData={appData} />;
+      return (
+        <AppDataFileDisplay
+          appData={appData}
+          fileNameOverride={fileNameOverride}
+        />
+      );
   }
 }

--- a/ui/src/features/reactions/ReactionView/Observation/Observation.tsx
+++ b/ui/src/features/reactions/ReactionView/Observation/Observation.tsx
@@ -91,7 +91,14 @@ export function Observation({ reactionId }: ReactionViewSectionProps) {
               {
                 label: 'Data',
                 render: ({ image }) => {
-                  return <AppDataDisplay appData={image} />;
+                  // Observations have no name field; show the attached file under the positional
+                  // "Observation N" name so it reads as a numbered name like Features do. (#613)
+                  return (
+                    <AppDataDisplay
+                      appData={image}
+                      fileNameOverride={`Observation ${index + 1}`}
+                    />
+                  );
                 },
               },
             ]}


### PR DESCRIPTION
Closes #613.

## Problem

In the Observations tab, an attached file showed its raw stored name rather than a numbered name. Every observation gets the constant `image.name = "Observation"` from `ordObservationToReaction`, and reactions imported from JSON carry an opaque hash filename — so the file never read as a numbered name the way **Features** do (Features get a numbered unique `data.name` at creation).

## Fix

Observations have no name field, so the view now shows the attached file under the **positional "Observation N"** name (matching the entity's list title), with the extension still derived from the data format.

- `AppDataDisplay` gains an optional `fileNameOverride` prop (Features and all other callers are unchanged).
- The Observation view passes `fileNameOverride={`Observation ${index + 1}`}`.

Non-destructive — the underlying ORD `image.name` is untouched, so this also corrects **already-imported** observations (the issue's repro), not just newly created ones.

## Verification

Runtime-verified on the live no-auth stack: an observation with an uploaded `.json` renders in the list as **`Observation 1.json`** (link text and `download` attribute). Added an `AppDataDisplay` unit test for the override (keeps the format extension). `tsc -b`, vitest, prettier, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the Observations tab so that attached files display under a positional "Observation N" name (matching the entity's list title) instead of the raw stored filename or the constant `"Observation"` string injected by `ordObservationToReaction`. The underlying ORD `image.name` is left untouched, so the fix applies retroactively to already-imported observations.

- `AppDataDisplay` gains an optional `fileNameOverride` prop that replaces the base name passed to `useFileNameHref`; the format extension is still appended by the hook, and all existing callers are unaffected.
- `Observation` passes `` `Observation ${index + 1}` `` as the override for its `image` field, mirroring how Features surface a numbered name.
- A new unit test asserts that the override replaces the raw stored name while keeping the correct file extension in both the link text and the `download` attribute.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it is a minimal, additive display fix with no mutations to stored data.

All three changed files are narrow in scope: a new optional prop, a single call-site usage, and a covering unit test. The `fileNameOverride` is only applied when explicitly passed, leaving every other caller of `AppDataDisplay` untouched. `useFileNameHref` already handles the name-plus-extension logic correctly, so the override slots in without any behavioral risk elsewhere. No state, no API calls, no migrations are involved.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/AppDataDisplay.tsx | Adds optional `fileNameOverride` prop that is threaded through to `AppDataFileDisplay` and passed as the `name` argument to `useFileNameHref`; all existing callers are unaffected since the prop defaults to `undefined`. |
| ui/src/features/reactions/ReactionView/Observation/Observation.tsx | Passes `fileNameOverride={\`Observation ${index + 1}\`}` to `AppDataDisplay` for the image field; index comes directly from the `observations.map` callback so the displayed number always matches the entity's list title. |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/AppDataDisplay.test.tsx | Adds a unit test that verifies the override replaces the raw stored filename while preserving the format extension; both the link text and the `download` attribute are asserted. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show observation attachments un..."](https://github.com/open-reaction-database/ord-app/commit/7a373474a3134a4b410010b81357c5b1efe3d7f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38843019)</sub>

<!-- /greptile_comment -->