### PR TITLE
chore: add jscpd copy-paste detection (replaces Sonar's duplication metric)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,3 +67,21 @@ jobs:
           sudo apt update && sudo apt install clang-format --yes
           # NOTE(kearnes): Run clang-format before installing anything with npm.
           find . -name '*.js' -exec clang-format -n -Werror {} +
+
+  # Cross-language copy-paste detection (replaces SonarCloud's duplication metric).
+  # jscpd is pinned as a ui/ devDependency; run from the repo root so it scans both
+  # ord_app/ (Python) and ui/src/ (TS/TSX) per .jscpd.json. Runs on every PR (not
+  # path-filtered) so Python-only changes are covered too.
+  check_duplication:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: Install jscpd (via ui devDependencies)
+        run: npm --prefix ui ci
+      - name: jscpd
+        run: ui/node_modules/.bin/jscpd --config .jscpd.json

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -11,6 +11,8 @@
   ],
   "gitignore": true,
   "threshold": 2,
+  "minLines": 5,
+  "minTokens": 50,
   "reporters": ["console"],
   "absolute": false
 }

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,16 @@
+{
+  "//": "Cross-language copy-paste detection (replaces SonarCloud's duplication metric). Scoped to code (Python + TS/TSX); stylesheets are excluded because scoped CSS modules legitimately repeat layout declarations (~80% 'duplication') and markup/json carry no logic.",
+  "path": ["ord_app", "ui/src"],
+  "format": ["python", "typescript", "tsx"],
+  "ignore": [
+    "**/tests/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/testdata/**",
+    "**/__pycache__/**"
+  ],
+  "gitignore": true,
+  "threshold": 2,
+  "reporters": ["console"],
+  "absolute": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,3 +73,15 @@ repos:
         language: system
         files: ^ui/.*\.s?css$
         pass_filenames: false
+
+  # Cross-language copy-paste detection (replaces SonarCloud's duplication metric).
+  # Uses the jscpd binary installed under ui/ (run `npm ci` in ui/ first) with the
+  # root .jscpd.json; scans the configured trees rather than just the staged files.
+  - repo: local
+    hooks:
+      - id: jscpd
+        name: jscpd (duplication)
+        entry: ui/node_modules/.bin/jscpd --config .jscpd.json
+        language: system
+        files: ^(ord_app|ui/src)/.*\.(py|ts|tsx)$
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Run hooks via [pre-commit](https://pre-commit.com): `uv run pre-commit install` 
 ## CI gates (a PR is not mergeable until these are green)
 
 - **Tests**: `test_python` (ubuntu + macos), `test_ui`, `test_e2e` (boots the full no-auth stack).
-- **Checks**: `check_python` (ruff / ruff-format / ty), `check_javascript` (clang-format), `lint_and_build_ui` (`lint:check` + `npm run build`), `check_license_headers`.
+- **Checks**: `check_python` (ruff / ruff-format / ty), `check_javascript` (clang-format), `check_duplication` (jscpd copy-paste detection, root `.jscpd.json`; also `make duplication`), `lint_and_build_ui` (`lint:check` + `npm run build`), `check_license_headers`.
 - **SonarCloud quality gate** and **Greptile review** also gate merges — never merge over a red Sonar check; address Greptile findings (and read its PR-body summary for sub-threshold notes) before merging.
 
 ## Conventions

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Cross-language copy-paste detection (replaces SonarCloud's duplication metric).
+# Requires `npm ci` under ui/ so the pinned jscpd binary is available.
+.PHONY: duplication
+duplication:
+	ui/node_modules/.bin/jscpd --config .jscpd.json
+
 check-ruff:
 	ruff check ord_app/
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -55,6 +55,7 @@
         "eslint-plugin-react-refresh": "^0.4.14",
         "globals": "^15.11.0",
         "happy-dom": "^20.9.0",
+        "jscpd": "^5.0.11",
         "postcss": "^8.4.49",
         "postcss-preset-mantine": "^1.17.0",
         "postcss-simple-vars": "^7.0.1",
@@ -5097,6 +5098,90 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cpd-darwin-arm64": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-darwin-arm64/-/cpd-darwin-arm64-5.0.11.tgz",
+      "integrity": "sha512-3QvH+4Dv7A7esVFM2tsRVWN3kn9EDu8dMYog6gYAVsCtxEf4xyxAwS/ef6LjC7/dh4+ATADFbg3H09A2fD//Qw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/cpd-darwin-x64": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-darwin-x64/-/cpd-darwin-x64-5.0.11.tgz",
+      "integrity": "sha512-OvgM2ps0OFR5jUzx7+FK9URdJGxUzzM5KKk2F1V3vf1LooGDKwkivfIDyKsqEwp37zcbyUo7COvBpJXOT0dZmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/cpd-linux-arm64-gnu": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-linux-arm64-gnu/-/cpd-linux-arm64-gnu-5.0.11.tgz",
+      "integrity": "sha512-pXMINibAeruglni8ZajlXEefZHDs7QFSG+vPtkBDu7uiIMpNU8aoktgO2vP+PbIRFD0vHkqTMb64kDtIOqQcwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/cpd-linux-x64-gnu": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-linux-x64-gnu/-/cpd-linux-x64-gnu-5.0.11.tgz",
+      "integrity": "sha512-rQ7DuF0lH1HLzjGxlE0aEP2ycfhXgZH/CLSeS7FXNJ38lRVp+iXkrlcrrY6mC4WW/NgbL+DkF7/0lv3tFvGmvg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/cpd-linux-x64-musl": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-linux-x64-musl/-/cpd-linux-x64-musl-5.0.11.tgz",
+      "integrity": "sha512-Yh+7Go5+fA++I5ssAZg7gUkDCT5CxnzCPvrspbwDrfnwaY6nNM5g1C6Vs0+GJhsspuAKwydJl4nf7jkxzMwRQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/cpd-windows-x64-msvc": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-windows-x64-msvc/-/cpd-windows-x64-msvc-5.0.11.tgz",
+      "integrity": "sha512-uV6w85qdfE0WJsrLcGw9A4Kv9ovSnlXZCybMK0esvuiJ7clgaZmDiDPozt5PvrOOShkK/NxzTZSORBSdVnquHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -8212,6 +8297,27 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jscpd": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-5.0.11.tgz",
+      "integrity": "sha512-NfLrFJHRM6rIf3oVcdZ4sfhMVop1qxi5r8aC99lpj55YC8hiWaN4VmzU2wcXTwoAo+NS4npXPs9EVEQJ6jyRlg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jscpd": "run-jscpd.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "cpd-darwin-arm64": "5.0.11",
+        "cpd-darwin-x64": "5.0.11",
+        "cpd-linux-arm64-gnu": "5.0.11",
+        "cpd-linux-x64-gnu": "5.0.11",
+        "cpd-linux-x64-musl": "5.0.11",
+        "cpd-windows-x64-msvc": "5.0.11"
       }
     },
     "node_modules/jsdom": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.11.0",
     "happy-dom": "^20.9.0",
+    "jscpd": "^5.0.11",
     "postcss": "^8.4.49",
     "postcss-preset-mantine": "^1.17.0",
     "postcss-simple-vars": "^7.0.1",


### PR DESCRIPTION
## What

Cross-language **copy-paste / duplication detection** via [jscpd](https://github.com/kucherenko/jscpd), run from the repo root so a single config covers both `ord_app/` (Python) and `ui/src/` (TS/TSX). This is the local replacement for **SonarCloud's duplication metric**.

Third of several PRs migrating SonarCloud's value into local tooling, ahead of retiring the Sonar merge gate.

## Design

- **`.jscpd.json`** scoped to **code** formats (`python`, `typescript`, `tsx`). Stylesheets are deliberately excluded: scoped CSS modules legitimately repeat layout declarations (measured at **~82% token "duplication"**), which is not the copy-paste-logic this metric is meant to catch. Tests / testdata / generated dirs are ignored.
- **`threshold: 2`** — current baseline is **0.70% duplicated tokens (16 clones)**, so this passes with headroom while still failing on significant new duplication. Intended to be ratcheted down over time.
- **CI**: new `check_duplication` job in `checks.yml`, **not** path-filtered, so Python-only PRs are covered too. Uses the jscpd binary pinned as a `ui/` devDependency (`npm ci`, then the local binary), with npm caching.
- **pre-commit**: local `jscpd` hook that scans the configured trees.
- **Makefile**: `make duplication` for local runs.

jscpd lives in `ui/package.json` (the only npm home — the repo has no root `package.json`) and is invoked from the root via its binary path.

## Verification

- `make duplication` / the CI invocation pass at threshold 2 (0.70% tokens).
- Confirmed the gate is real: forcing `--threshold 0` exits 1.
- pre-commit hook validates green.

## Risk

Additive tooling only — new config + CI job + hook. No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds [jscpd](https://github.com/kucherenko/jscpd) as a cross-language copy-paste detection gate, replacing SonarCloud's duplication metric. No application code is touched; the change is purely additive tooling.

- **`.jscpd.json`**: config scoped to `ord_app/` (Python) and `ui/src/` (TS/TSX) with explicit `minLines`/`minTokens` thresholds, a 2% token-duplication ceiling, and intentional exclusion of stylesheets and test trees.
- **CI** (`checks.yml`): new `check_duplication` job, unpathfiltered, that installs jscpd via `npm --prefix ui ci` and runs the pinned binary; npm cache is keyed on `ui/package-lock.json`, consistent with the repo's single-npm-home design.
- **Pre-commit & Makefile**: `jscpd` local hook follows the same `language: system` / `pass_filenames: false` pattern as existing ui hooks; `make duplication` mirrors the CI invocation for local runs.

<h3>Confidence Score: 5/5</h3>

Purely additive tooling — no application code changed. All integration points (CI job, pre-commit hook, Makefile target) follow existing patterns in the repo.

Every changed file is configuration or dependency metadata. The CI job, pre-commit hook, and Makefile target are internally consistent, match the repo's existing conventions, and have been verified to pass at the stated threshold.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/checks.yml | Adds `check_duplication` CI job: checks out, installs Node 22 with npm cache keyed on `ui/package-lock.json`, runs `npm --prefix ui ci`, then invokes the pinned jscpd binary. Pattern is consistent with existing jobs; no path filter so Python-only PRs are covered. |
| .jscpd.json | New jscpd config scoped to `ord_app/` and `ui/src/` for Python + TS/TSX. Explicitly sets `minLines: 5` and `minTokens: 50`, 2% threshold, ignores tests/testdata/__pycache__, and honours `.gitignore`. Stylesheets are deliberately excluded with sound justification. |
| .pre-commit-config.yaml | New `jscpd` local hook with `language: system` and `pass_filenames: false`, consistent with the existing `ty`, `prettier`, `eslint`, and `stylelint` hooks. Triggers on the right file pattern; requires `ui/node_modules` to be present, which is already documented for the other ui hooks. |
| Makefile | Adds a `duplication` phony target that invokes the local jscpd binary. Simple and correct; mirrors the CI invocation. |
| ui/package.json | Adds `jscpd@^5.0.11` as a devDependency. Lock file pins the exact version and all optional platform binaries. |
| CLAUDE.md | CI gates list updated to include `check_duplication` with its local `make duplication` equivalent. Accurate and concise. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: pin jscpd minLines/minTokens to t..."](https://github.com/open-reaction-database/ord-app/commit/90fe663fd75a6fc809281764d81db02a2331336c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38843783)</sub>

<!-- /greptile_comment -->