### PR TITLE
chore: enforce coverage locally + gate new-code coverage via Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,13 +18,18 @@
 
 coverage:
   status:
-    # Report-only: surface project/patch coverage without failing the PR.
+    # Project (total) coverage stays report-only so PRs aren't blocked by base-branch
+    # drift; the enforced per-PR gate is on patch (new-code) coverage below.
     project:
       default:
         informational: true
+    # Patch = coverage of the lines changed in the PR. This is the enforced
+    # "coverage on new code" gate that replaces SonarCloud's coverage quality gate.
+    # target: auto -> new code must be covered at least as well as the project average.
     patch:
       default:
-        informational: true
+        target: auto
+        informational: false
 
 flag_management:
   default_rules:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,13 @@ package = false
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
+# Local total-coverage floor (a regression backstop; the per-PR new-code gate is
+# Codecov's patch status). pytest-cov honors this on every `pytest --cov` run. Set a
+# few points below current (~83% total, which includes the test modules) so routine
+# churn doesn't trip it; ratchet up over time.
+[tool.coverage.report]
+fail_under = 80
+
 # Ruff config lives here (single source of truth); the former root ruff.toml
 # took precedence over [tool.ruff] and has been folded in.
 [tool.ruff]

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -45,8 +45,8 @@ export default defineConfig({
       // Codecov's patch status). Set a few points below current (lines/statements 66%,
       // branches 84%, functions 63%) so routine churn doesn't trip it; ratchet up later.
       thresholds: {
-        lines: 64,
-        statements: 64,
+        lines: 60,
+        statements: 60,
         branches: 80,
         functions: 60,
       },

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -41,6 +41,15 @@ export default defineConfig({
       reportsDirectory: './coverage',
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/**/*.test.{ts,tsx}', 'src/**/*.d.ts', 'src/test/**', 'src/**/*.module.scss'],
+      // Local total-coverage floor (a regression backstop; the per-PR new-code gate is
+      // Codecov's patch status). Set a few points below current (lines/statements 66%,
+      // branches 84%, functions 63%) so routine churn doesn't trip it; ratchet up later.
+      thresholds: {
+        lines: 64,
+        statements: 64,
+        branches: 80,
+        functions: 60,
+      },
     },
   },
   preview: {


### PR DESCRIPTION
## What

Make coverage enforcement stand on its own — the **one replacement that closes a real gap**. Today Codecov is report-only (`informational: true`), so **SonarCloud is currently the only enforcing coverage-on-new-code gate**. This PR replaces it.

> ⚠️ Unlike PRs #790/#793/#794 (additive checks), this one **changes merge semantics** for every future PR. Holding for explicit review rather than auto-merge.

## Changes

| File | Change | Role |
|---|---|---|
| `codecov.yml` | patch status `informational: true` → `target: auto`, enforcing | **The new-code gate** (direct Sonar replacement): changed lines must be covered ≥ project average. Project/total stays report-only to avoid blocking on base drift. |
| `pyproject.toml` | `[tool.coverage.report] fail_under = 80` | Local total-coverage backstop, honored by pytest-cov on every `pytest --cov` |
| `ui/vite.config.ts` | Vitest `coverage.thresholds` (lines/statements 64, branches 80, functions 60) | Local UI total-coverage backstop |

Floors are set a few points below current coverage (Python **83.4%**, UI **66% lines / 84% branches / 63% funcs**) so they catch regressions without blocking routine work. The per-PR new-code bar is the Codecov patch status; ratchet the floors up over time.

## Verified

- **Python**: `fail_under=80` honored by pytest-cov — *"Required test coverage of 80.0% reached. Total coverage: 83.41%"*; forcing `--cov-fail-under=99` fails (*"total of 83 is less than fail-under=99"*).
- **UI**: passes at the configured thresholds (712 tests); forcing `lines=99` fails (*"Coverage for lines (66%) does not meet global threshold (99%)"*).

## Sequencing

Enabled **now, alongside Sonar** (brief intentional double-gating) to prove the replacement works before Sonar's gate is removed in Phase 2. Per the agreed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts Codecov's patch (new-code) status check from report-only to enforcing, and adds local total-coverage floors for both the Python suite (`fail_under = 80` via pytest-cov) and the UI Vitest suite (lines/statements 60 %, branches 80 %, functions 60 %).

- **`codecov.yml`**: `patch.default` gains `target: auto` + `informational: false`, requiring new lines to be covered at least as well as the project average; project (total) coverage stays report-only to avoid blocking on base-branch drift.
- **`pyproject.toml`**: Adds `[tool.coverage.report] fail_under = 80`, a backstop ~3 points below current Python coverage (~83 %).
- **`ui/vite.config.ts`**: Adds Vitest `thresholds` a few points below current coverage (lines/statements 66 %, branches 84 %, functions 63 %) as a local regression backstop.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three changes are purely additive configuration that tightens CI gates without altering application logic.

The changes are narrow config adjustments: promoting Codecov patch coverage to enforcing, and adding local coverage floors for Python and UI. Thresholds are intentionally set below current measured coverage, verified in both directions by the author. No application code is touched, and the PR description clearly documents the rationale and sequencing.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| codecov.yml | Promotes patch coverage from informational to enforcing (`target: auto`, `informational: false`); project/total coverage remains report-only to avoid base-drift blocking. |
| pyproject.toml | Adds `[tool.coverage.report] fail_under = 80` as a local total-coverage floor; set a few points below current ~83.4% as an intentional regression backstop. |
| ui/vite.config.ts | Adds Vitest `thresholds` (lines/statements 60, branches 80, functions 60) below current coverage (66%/84%/63%) as a local regression backstop for the UI suite. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: set UI lines/statements coverage ..."](https://github.com/open-reaction-database/ord-app/commit/f33e249ab671b469740e673253e29c5670dcdee6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38844599)</sub>

<!-- /greptile_comment -->