### PR TITLE
chore: gitignore local *_PLAN.md working-note docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ cython_debug/
 .vite/
 # personal, machine-local Claude rules (e.g. admin-merge workflow)
 .claude/rules/*.local.md
+
+# Local plan / working-note docs (e.g. Claude-authored plans). Also covers the
+# already-untracked ISSUE_TRIAGE_PLAN.md, which is synced to issue #656.
+*_PLAN.md


### PR DESCRIPTION
## What

Ignore `*_PLAN.md` — plan / working-note docs (e.g. Claude-authored plans) are local artifacts, not source.

This also covers the already-untracked `ISSUE_TRIAGE_PLAN.md` (synced to issue #656), so it stops appearing as an untracked file in `git status`. Nothing currently tracked matches the pattern, so no files are removed.

## Risk

`.gitignore`-only, trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a single `.gitignore` entry to exclude `*_PLAN.md` files — local planning and working-note documents (e.g. Claude-authored plans) that are not part of the source history.

- The glob `*_PLAN.md` covers any filename ending in `_PLAN.md`, including the already-untracked `ISSUE_TRIAGE_PLAN.md` referenced in issue #656, so it will no longer appear in `git status`.
- No currently-tracked files match the pattern, so this is a purely additive change with no file deletions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is limited to a single `.gitignore` addition that does not touch any tracked file.

Only one line added to `.gitignore` with a well-scoped glob (`*_PLAN.md`). No tracked files match the pattern, no source code or configuration is affected, and the intent is clearly documented in both the inline comment and PR description.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .gitignore | Adds `*_PLAN.md` glob pattern to ignore local planning/working-note documents from version control; no tracked files are affected. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: gitignore local \*\_PLAN.md working..."](https://github.com/open-reaction-database/ord-app/commit/183312b729eb9515225a8140d1d26ac378dea7cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38844632)</sub>

<!-- /greptile_comment -->