### PR TITLE
fix(ui): left-align the component structure preview in the list and sidebar (#605)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/ComponentPreview/componentPreview.module.scss
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/ComponentPreview/componentPreview.module.scss
@@ -15,7 +15,9 @@
  */
 .previewWrapper {
   display: flex;
-  justify-content: center;
+
+  /* Left-align so the structure isn't shifted right of the otherwise left-aligned sidebar form. (#605) */
+  justify-content: flex-start;
   align-items: center;
 
   &,

--- a/ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRowCustomActions.tsx
+++ b/ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRowCustomActions.tsx
@@ -50,7 +50,7 @@ export function ComponentDisplayRowCustomActions<T extends ReactionComponentBase
       </Flex>
       <Flex
         align="center"
-        justify="center"
+        justify="flex-start"
         className={clsx(classes.preview, classes.imagePreview)}
       >
         <ReactionComponentPreview previewState={previewState[component.id]} />


### PR DESCRIPTION
Addresses #605.

## Problem

The component structure preview was **centered** while everything around it is left-aligned, so it read as "shifted to the right":
- In the component **list**, the preview cell used `justify="center"`, but the `Preview` column header and the other columns (identifiers / role / details) are left-aligned.
- In the component **sidebar**, `componentPreview.module.scss` centered the structure while the form fields below it (Reaction role, Amount, …) are left-aligned.

## Fix

Left-align the preview in both places:
- `ComponentDisplayRowCustomActions.tsx` — preview cell `justify-content: center → flex-start`
- `componentPreview.module.scss` — `justify-content: center → flex-start`

## Verification

Runtime-verified against the live no-auth stack:
- **List**: the preview's left edge now matches the `Preview` header (measured `imgX` moved from mid-column to the column's left edge).
- **Sidebar**: the structure now sits at the left edge of the drawer (`imgX == wrapperX`) instead of centered mid-width.

CSS-only; `tsc -b`, vitest (component-list + preview suites), eslint, stylelint, prettier all clean.

## Not included (kept #605 open)

The issue's separate bullet — *"extra space under the molecular structure in the component sidebar"* — is **not** fixed here. It only reproduces with a real **wide** structure (the fixed `height: 120px` reserves vertical space when a wide SVG scales down under `max-width: 100%`). The safe fix (let the wrapper shrink while keeping a sensible structure size) needs that repro to verify — removing the fixed height naively shrinks small structures (e.g. H₂O) to an unreadable size. Tracking it as a follow-up rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a visual misalignment where the molecular structure preview was centered while all surrounding elements (column headers, form fields) were left-aligned — in both the component list table and the component sidebar drawer.

- **`ComponentDisplayRowCustomActions.tsx`**: switches the preview cell's Mantine `Flex` `justify` prop from `"center"` to `"flex-start"`, aligning the structure image with the `Preview` column header.
- **`componentPreview.module.scss`**: changes `justify-content: center` to `justify-content: flex-start` (with a clarifying comment) so the structure sits at the left edge of the sidebar instead of floating mid-width.

<h3>Confidence Score: 5/5</h3>

Two isolated CSS alignment changes with no logic, state, or data-flow impact — safe to merge.

Both changes are single-property CSS tweaks (justify-content/justify) that only affect visual positioning. No component logic, Redux state, API calls, or type definitions are touched. The PR description documents runtime verification, and the author confirms tsc, vitest, eslint, stylelint, and prettier all pass.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/ComponentPreview/componentPreview.module.scss | Changes justify-content from center to flex-start with an explanatory comment referencing issue #605; introduces an extra blank line before the comment. |
| ui/src/features/reactions/ReactionView/ComponentsList/ComponentDisplayRowCustomActions.tsx | Changes the Mantine Flex component's justify prop from "center" to "flex-start" in the preview cell, left-aligning the structure image with the column header. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): left-align the component struct..."](https://github.com/open-reaction-database/ord-app/commit/8f5d4c77b4c1e39096c882ec8593f15213295c26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38848615)</sub>

<!-- /greptile_comment -->