### PR TITLE
fix(ui): show a loader on the reaction page while the reaction loads (#312)

### DIFF
--- a/ui/src/pages/ReactionPage/ReactionPage.tsx
+++ b/ui/src/pages/ReactionPage/ReactionPage.tsx
@@ -19,7 +19,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { Breadcrumbs } from 'common/types/breadcrumbs.ts';
 import { getReaction } from 'store/entities/reactions/reactions.thunks.ts';
 import { ReactionHeader } from 'features/reactions/ReactionHeader/ReactionHeader.tsx';
-import { type SegmentedControlItem, Flex, Paper, SegmentedControl } from '@mantine/core';
+import { type SegmentedControlItem, Flex, Loader, Paper, SegmentedControl } from '@mantine/core';
 import { useSelector } from 'react-redux';
 import { selectReactionById } from 'store/entities/reactions/reactions.selectors.ts';
 import { ReactionDetailsSidebar } from 'features/reactions/ReactionDetailsSidebar/ReactionDetailsSidebar.tsx';
@@ -96,7 +96,14 @@ export function ReactionPage({ reactionId, datasetId }: Readonly<ReactionPagePro
   return (
     <PageContainer breadcrumbs={breadcrumbs}>
       <reactionContext.Provider value={reactionContextValue}>
-        {reaction && (
+        {!reaction ? (
+          <Flex
+            justify="center"
+            align="center"
+          >
+            <Loader size="xl" />
+          </Flex>
+        ) : (
           <Flex
             direction="column"
             gap="sm"


### PR DESCRIPTION
Closes #312.

## Problem

The reaction page rendered nothing (`{reaction && …}`) until the single reaction finished loading, so opening a reaction cold — or navigating to one not already in the store — showed a **blank page** instead of a loading indicator (the #264 mockup shows a spinner here).

`getReaction` (the single-reaction fetch) doesn't toggle `areReactionsLoading` — that flag is only for the list/page fetches — so there was no loading state to render.

## Fix

Gate on `!reaction` and show a centered `<Loader size="xl" />`, exactly mirroring `Dataset.page`'s pattern. The early `if (error) return <NotFoundPage/>` already handles failures, so `!reaction` reliably means "still loading."

## Verification

Runtime-verified on the live no-auth stack (single-reaction fetch delayed): a cold reaction-page load now shows the spinner under the breadcrumb until the reaction renders, instead of a blank page. `tsc -b` / prettier / eslint clean.

This was the remaining gap from #209's split — the dataset-info loader already existed; this adds the reaction-info one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the blank-page UX on cold reaction-page loads by showing a `<Loader size="xl" />` while the reaction is still fetching, replacing the previous `{reaction && …}` guard that rendered nothing.

- Adds `Loader` to the Mantine import and wraps it in a centered `<Flex>`, exactly replicating the loading pattern already in `Dataset.page.tsx`.
- The existing `if (error) return <NotFoundPage/>` guard ensures `!reaction` reliably means \"still fetching\" rather than \"fetch failed\", so the spinner cannot hang indefinitely on an errored request.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a one-line import addition and a well-understood ternary swap with no logic changes to fetching, routing, or state management.

The change is a narrow, mechanical UI fix: swap `{reaction && …}` for a ternary that shows a spinner. The loader pattern is identical to the one already proven in `Dataset.page.tsx`, and the error guard before the return correctly bounds what `!reaction` can mean at runtime. No new state, no new side effects, no new async paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/pages/ReactionPage/ReactionPage.tsx | Replaces `{reaction && …}` with a ternary that shows a centered `<Loader size="xl" />` while `!reaction`, mirroring the identical pattern already used in `Dataset.page.tsx`. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show a loader on the reaction p..."](https://github.com/open-reaction-database/ord-app/commit/9ae8046418ce6e662015bcac1fa405833834d152) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38857416)</sub>

<!-- /greptile_comment -->