### PR TITLE
fix(ui): eliminate Mantine nested-button hydration warnings

### DIFF
--- a/ui/src/common/components/SelectableButton/selectableButton.module.scss
+++ b/ui/src/common/components/SelectableButton/selectableButton.module.scss
@@ -39,13 +39,4 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-
-  & button {
-    transition: opacity 0.15s ease-out;
-    opacity: 0;
-  }
-
-  &:hover button {
-    opacity: 1;
-  }
 }

--- a/ui/src/features/groups/GroupsList/GroupsList.module.scss
+++ b/ui/src/features/groups/GroupsList/GroupsList.module.scss
@@ -48,7 +48,7 @@
 
 /* The group select button and its "Edit group" ActionIcon are siblings (a <button>
    cannot nest inside another <button> without a hydration error). The icon overlays the
-   right edge of the full-width select button and reveals on row hover. */
+   right edge of the full-width select button and reveals on row hover or keyboard focus. */
 .groupRow {
   position: relative;
 }
@@ -62,7 +62,8 @@
   transition: opacity 0.15s ease-out;
 }
 
-.groupRow:hover .editIcon {
+.groupRow:hover .editIcon,
+.groupRow:focus-within .editIcon {
   opacity: 1;
 }
 

--- a/ui/src/features/groups/GroupsList/GroupsList.module.scss
+++ b/ui/src/features/groups/GroupsList/GroupsList.module.scss
@@ -46,6 +46,30 @@
   margin-right: 8px;
 }
 
+/* The group select button and its "Edit group" ActionIcon are siblings (a <button>
+   cannot nest inside another <button> without a hydration error). The icon overlays the
+   right edge of the full-width select button and reveals on row hover. */
+.groupRow {
+  position: relative;
+}
+
+.editIcon {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
+  opacity: 0;
+  transition: opacity 0.15s ease-out;
+}
+
+.groupRow:hover .editIcon {
+  opacity: 1;
+}
+
+.selectedRow .editIcon svg {
+  color: var(--color-background-white);
+}
+
 .emptyContainer {
   display: flex;
   align-items: center;

--- a/ui/src/features/groups/GroupsList/GroupsList.tsx
+++ b/ui/src/features/groups/GroupsList/GroupsList.tsx
@@ -28,6 +28,7 @@ import {
   SearchIcon,
   SettingsIcon,
 } from 'common/icons';
+import clsx from 'clsx';
 import { setGroupSearchAction } from 'store/entities/groups/groups.actions.ts';
 import { useAppDispatch } from 'store/useAppDispatch.ts';
 import {
@@ -108,26 +109,36 @@ export function GroupsList() {
           type="auto"
         >
           {groups.map(group => (
-            <SelectableButton
+            <div
               key={group.id}
-              isSelected={selectedGroupId === group.id}
-              onClick={() => selectGroup(group.id)}
+              className={clsx(
+                classes.groupRow,
+                selectedGroupId === group.id && classes.selectedRow,
+              )}
             >
-              <div className={classes.buttonName}>
-                <GroupArrowIcon />
-                <Tooltip label={group.name}>
-                  <div>{group.name}</div>
-                </Tooltip>
-              </div>
+              <SelectableButton
+                isSelected={selectedGroupId === group.id}
+                onClick={() => selectGroup(group.id)}
+              >
+                <div className={classes.buttonName}>
+                  <GroupArrowIcon />
+                  <Tooltip label={group.name}>
+                    <div>{group.name}</div>
+                  </Tooltip>
+                </div>
+              </SelectableButton>
 
+              {/* Sibling of the button, not a child: a <button> cannot nest inside the
+                  SelectableButton's <button> without a hydration error. */}
               <ActionIcon
+                className={classes.editIcon}
                 onClick={e => openGroupInformation(e, group.id)}
                 variant="transparent"
                 title="Edit group"
               >
                 <SettingsIcon />
               </ActionIcon>
-            </SelectableButton>
+            </div>
           ))}
         </ScrollArea>
       </Flex>

--- a/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputComponentsListItem/InputComponentsListItem.tsx
+++ b/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputComponentsListItem/InputComponentsListItem.tsx
@@ -52,17 +52,17 @@ export function InputComponentsListItem({
       key={input.id}
       value={input.id}
     >
-      <Accordion.Control
-        icon={
-          <ViewDeleteButtonsComponent
-            pathComponents={pathComponents}
-            historyPathComponents={historyPathComponents}
-            entityName="Input"
-          />
-        }
-      >
-        {name}
-      </Accordion.Control>
+      {/* The view/delete buttons sit beside Accordion.Control rather than in its `icon`
+          slot: Accordion.Control renders a <button>, and a nested <button> triggers a
+          hydration error. */}
+      <div className={classes.controlRow}>
+        <ViewDeleteButtonsComponent
+          pathComponents={pathComponents}
+          historyPathComponents={historyPathComponents}
+          entityName="Input"
+        />
+        <Accordion.Control className={classes.control}>{name}</Accordion.Control>
+      </div>
       <Accordion.Panel>
         <ComponentsListOrEmpty componentsAmount={input.components.length}>
           {input.components.map((component, index) => (

--- a/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/inputsComponentsList.module.scss
+++ b/ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/inputsComponentsList.module.scss
@@ -19,6 +19,17 @@
   grid-template-columns: repeat(5, 1fr) 120px;
 }
 
+/* Lays the view/delete buttons beside Accordion.Control (siblings, to avoid a nested
+   <button>); the control fills the remaining width so its chevron stays right-aligned. */
+.controlRow {
+  display: flex;
+  align-items: center;
+}
+
+.control {
+  flex: 1;
+}
+
 .input {
   grid-area: input;
 }

--- a/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItemHeader.tsx
+++ b/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItemHeader.tsx
@@ -38,53 +38,56 @@ export function OutcomeListItemHeader({
 }: Readonly<OutcomeListItemHeaderProps>) {
   const { ViewDeleteButtonsComponent } = useContext(reactionContext);
   return (
-    <Accordion.Control
-      classNames={{ label: classes.label }}
-      icon={
-        <ViewDeleteButtonsComponent
-          entityName="Outcome"
-          pathComponents={pathComponents}
-        />
-      }
-    >
-      <Flex
-        align="center"
-        gap="xs"
+    // The view/delete buttons sit beside Accordion.Control rather than in its `icon` slot:
+    // Accordion.Control renders a <button>, and a nested <button> triggers a hydration error.
+    <div className={classes.controlRow}>
+      <ViewDeleteButtonsComponent
+        entityName="Outcome"
+        pathComponents={pathComponents}
+      />
+      <Accordion.Control
+        className={classes.control}
+        classNames={{ label: classes.label }}
       >
-        <TitleDelimiterAmount
-          title="Outcome"
-          amount={outcome.products.length}
-        />
-      </Flex>
-      {outcome.reactionTime?.value && (
         <Flex
           align="center"
           gap="xs"
         >
-          <TimeIcon className={classes.shortInfoIcon} />
-          <Text className={clsx(classes.shortInfoText, typographyClasses.secondary2)}>
-            Time:{' '}
-          </Text>
-          <Text className={classes.shortInfoText}>
-            {renderValuePrecisionUnit(outcome.reactionTime)}
-          </Text>
+          <TitleDelimiterAmount
+            title="Outcome"
+            amount={outcome.products.length}
+          />
         </Flex>
-      )}
-      {outcome.conversion?.value && (
-        <Flex
-          align="center"
-          gap="xs"
-        >
-          <FlaskIcon className={classes.shortInfoIcon} />
-          <Text className={clsx(classes.shortInfoText, typographyClasses.secondary2)}>
-            Limiting reactant conversion:{' '}
-          </Text>
-          <Text className={classes.shortInfoText}>
-            {renderValuePrecisionUnit({ ...outcome.conversion, units: '' })}
-          </Text>
-        </Flex>
-      )}
-      <Flex></Flex>
-    </Accordion.Control>
+        {outcome.reactionTime?.value && (
+          <Flex
+            align="center"
+            gap="xs"
+          >
+            <TimeIcon className={classes.shortInfoIcon} />
+            <Text className={clsx(classes.shortInfoText, typographyClasses.secondary2)}>
+              Time:{' '}
+            </Text>
+            <Text className={classes.shortInfoText}>
+              {renderValuePrecisionUnit(outcome.reactionTime)}
+            </Text>
+          </Flex>
+        )}
+        {outcome.conversion?.value && (
+          <Flex
+            align="center"
+            gap="xs"
+          >
+            <FlaskIcon className={classes.shortInfoIcon} />
+            <Text className={clsx(classes.shortInfoText, typographyClasses.secondary2)}>
+              Limiting reactant conversion:{' '}
+            </Text>
+            <Text className={classes.shortInfoText}>
+              {renderValuePrecisionUnit({ ...outcome.conversion, units: '' })}
+            </Text>
+          </Flex>
+        )}
+        <Flex></Flex>
+      </Accordion.Control>
+    </div>
   );
 }

--- a/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/outcomeListItem.module.scss
+++ b/ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/outcomeListItem.module.scss
@@ -19,6 +19,17 @@
   grid-gap: var(--mantine-spacing-sm);
 }
 
+/* Lays the view/delete buttons beside Accordion.Control (siblings, to avoid a nested
+   <button>); the control fills the remaining width so its chevron stays right-aligned. */
+.controlRow {
+  display: flex;
+  align-items: center;
+}
+
+.control {
+  flex: 1;
+}
+
 .analysesItem {
   border: 1px solid var(--color-border-1);
   border-radius: 8px;


### PR DESCRIPTION
Fixes the React hydration warnings ("In HTML, `<button>` cannot be a descendant of `<button>`") that fire on the datasets and reaction pages. Three spots nested an interactive control inside another `<button>`:

| Site | Nested control | Fix |
|---|---|---|
| `GroupsList` | "Edit group" `ActionIcon` inside the group-select `SelectableButton` | Moved to a **sibling** that overlays the row's right edge and reveals on hover (same look) |
| `InputComponentsListItem` | view/delete buttons in `Accordion.Control`'s `icon` slot (renders inside the control's `<button>`) | Moved **beside** `Accordion.Control` in a flex row (`.controlRow`); control takes remaining width so its chevron stays right-aligned |
| `OutcomeListItemHeader` | same `Accordion.Control` `icon` pattern | same flex-row fix |

Also drops the now-dead nested-button hover CSS from `SelectableButton`.

This is the Mantine-recommended "control with actions" structure — the action buttons are siblings of `Accordion.Control`, not descendants.

## Verification
- ✅ `npm run build` (tsc -b + vite)
- ✅ 728 unit tests (incl. GroupsList / InputComponentsListItem / OutcomeListItem)
- ✅ `npm run lint:check`
- ✅ **Real-browser pass** over the group sidebar, the Inputs accordion (List view), and the Outcomes tab → **0 nested-button warnings**, layouts unchanged (delete/Edit on the left of each input row; edit-gear reveals on group-row hover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes React hydration warnings caused by `<button>` elements nested inside other `<button>` elements in three UI locations (`GroupsList`, `InputComponentsListItem`, `OutcomeListItemHeader`). Each fix restructures the problematic component so interactive controls are siblings rather than descendants of the parent button.

- **`GroupsList`**: The "Edit group" `ActionIcon` is lifted out of `SelectableButton` into a sibling `<div>` wrapper; it remains visually overlaid at the row's right edge via absolute positioning, revealing on hover and keyboard focus (`:focus-within`).
- **`InputComponentsListItem` / `OutcomeListItemHeader`**: View/delete buttons are moved from `Accordion.Control`'s `icon` slot (which renders inside the control's `<button>`) to a sibling flex row; `Accordion.Control` is given `flex: 1` so its chevron stays right-aligned.
- **`SelectableButton`**: Removes the now-dead nested-button hover CSS that was no longer relevant after the `GroupsList` restructure.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are purely structural HTML/CSS refactors with no logic changes, and all three fixes follow the Mantine-recommended sibling pattern.

All changes reorganize element nesting to fix invalid HTML (nested buttons) without touching any data-fetching, state management, or business logic. Mantine's accordion uses React context (not DOM traversal) to connect `Accordion.Control` to its `Accordion.Item`, so the added `<div>` wrapper is transparent to the accordion's behavior. The `GroupsList` overlay approach correctly handles both hover and keyboard-focus visibility. The PR author verified zero hydration warnings in a real browser, and 728 unit tests pass.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/groups/GroupsList/GroupsList.tsx | Wraps each group row in a relative-positioned `<div>` so `ActionIcon` is a sibling (not child) of `SelectableButton`, eliminating the nested-button hydration error; `clsx` used to apply `selectedRow` class on the wrapper. |
| ui/src/features/groups/GroupsList/GroupsList.module.scss | Adds `.groupRow` (relative positioning), `.editIcon` (absolute overlay at right edge with opacity transition), and visibility rules for both `:hover` and `:focus-within`; also targets `.selectedRow .editIcon svg` to keep the icon white when the row is selected. |
| ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/InputComponentsListItem/InputComponentsListItem.tsx | Moves `ViewDeleteButtonsComponent` out of `Accordion.Control`'s `icon` slot into a sibling flex row, fixing the nested-button hydration error; `Accordion.Control` keeps `flex: 1` to remain full width with right-aligned chevron. |
| ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/OutcomeListItemHeader.tsx | Same sibling flex-row fix as `InputComponentsListItem`: `ViewDeleteButtonsComponent` moved beside `Accordion.Control` rather than inside its `icon` slot. |
| ui/src/features/reactions/ReactionView/Inputs/InputsComponentsList/inputsComponentsList.module.scss | Adds `.controlRow` (flex row) and `.control` (flex: 1) to support the sibling button layout for the input accordion header. |
| ui/src/features/reactions/ReactionView/Outcomes/OutcomeListItem/outcomeListItem.module.scss | Adds the same `.controlRow` and `.control` CSS as `inputsComponentsList.module.scss` for the outcome accordion header layout. |
| ui/src/common/components/SelectableButton/selectableButton.module.scss | Removes the now-dead nested-button hover CSS (`& button { opacity: 0 }` / `&:hover button { opacity: 1 }`) from `.buttonLabel`, since the `ActionIcon` is no longer a descendant of `SelectableButton`. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): reveal group edit icon on keybo..."](https://github.com/open-reaction-database/ord-app/commit/d12dda7634d9463cd7b84123b23dd7a613daeed2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38945489)</sub>

<!-- /greptile_comment -->