### PR TITLE
fix(ui): capture full height when copying a reaction preview image (#587)

### DIFF
--- a/ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts
+++ b/ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts
@@ -26,7 +26,7 @@ vi.mock('common/utils/showNotification.tsx', () => ({ showNotification: vi.fn() 
 const toBlobMock = vi.mocked(htmlToImage.toBlob);
 const notifyMock = vi.mocked(showNotification);
 const clipboardWrite = vi.fn().mockResolvedValue(undefined);
-const node = { scrollWidth: 120 } as HTMLDivElement;
+const node = { scrollWidth: 120, scrollHeight: 90 } as HTMLDivElement;
 
 const expectNotified = (variant: NotificationVariant) =>
   expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ variant }));
@@ -55,6 +55,15 @@ describe('copyPreviewAsImage', () => {
     await copyPreviewAsImage(node);
     expect(clipboardWrite).toHaveBeenCalledTimes(1);
     expectNotified(NotificationVariant.SUCCESS);
+  });
+
+  it('captures the full scroll extent in both axes so labels are not clipped (#587)', async () => {
+    toBlobMock.mockResolvedValue(new Blob(['x'], { type: 'image/png' }));
+    await copyPreviewAsImage(node);
+    expect(toBlobMock).toHaveBeenCalledWith(
+      node,
+      expect.objectContaining({ width: 120, height: 90 }),
+    );
   });
 
   it('notifies an error when rendering produces no blob', async () => {

--- a/ui/src/common/components/ReactionPreview/reactionPreview.utils.ts
+++ b/ui/src/common/components/ReactionPreview/reactionPreview.utils.ts
@@ -63,7 +63,10 @@ export async function copyPreviewAsImage(node?: HTMLDivElement | null) {
   try {
     const blob = await htmlToImage.toBlob(node, {
       skipFonts: true,
+      // Capture the full scrollable extent in both axes; pinning only width let labels that
+      // overflow the default capture height clip in the copied PNG (Chrome). (#587)
       width: node.scrollWidth,
+      height: node.scrollHeight,
       backgroundColor: 'white',
     });
 


### PR DESCRIPTION
Closes #587.

## Problem
Copying a reaction preview as an image clipped labels that sat near the bottom of the preview (reported in Chrome).

## Cause
`copyPreviewAsImage` ([reactionPreview.utils.ts](ui/src/common/components/ReactionPreview/reactionPreview.utils.ts)) pinned the `html-to-image` capture **width** to `node.scrollWidth` but left **height** to the library default — so any content overflowing the default capture height was cut off in the PNG.

## Fix
Pass `height: node.scrollHeight` symmetrically with the existing width, so the full scrollable extent is captured. One additive line; no behavior change to anything but the captured image bounds.

## Tests
Extended the existing `toBlob`-mock test to assert both `width` and `height` reach `html-to-image` (regression guard). Full UI suite + `tsc -b` + lint green.

> Note: this is a capture-bounds fix verified by unit test + reasoning. A quick visual confirmation on the live Chrome stack (copy a wide reaction, paste, check bottom labels) is worth a glance before merge — happy to run it if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a clipping bug in `copyPreviewAsImage` where bottom labels were cut off in the copied PNG because only the scroll width was passed to `html-to-image`, leaving the capture height at the library default.

- Adds `height: node.scrollHeight` symmetrically with the existing `width: node.scrollWidth` in the `toBlob` options, so the full scrollable area is captured in both axes.
- Extends the test suite with a dedicated regression test that asserts both dimensions are forwarded to `toBlob`, and adds `scrollHeight` to the shared mock node so all existing tests stay consistent.

<h3>Confidence Score: 5/5</h3>

A single additive line that mirrors an existing pattern; the only behavioral change is the captured image now includes the full scroll height.

The change is minimal and symmetric — `scrollHeight` is the natural counterpart to the already-used `scrollWidth`, and the new test directly asserts the fix. No existing behavior other than the captured image bounds is affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/ReactionPreview/reactionPreview.utils.ts | Adds `height: node.scrollHeight` alongside the existing `width: node.scrollWidth` in the `htmlToImage.toBlob` call, ensuring the full scrollable extent is captured in both axes and bottom labels are no longer clipped. |
| ui/src/common/components/ReactionPreview/reactionPreview.utils.test.ts | Adds `scrollHeight: 90` to the shared mock node and a new dedicated test asserting that both `width` and `height` are forwarded to `toBlob`, providing a regression guard for the fix. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): capture full height when copyin..."](https://github.com/open-reaction-database/ord-app/commit/24559f0e1629a863ff01d0aadc20fb39386deedc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38953915)</sub>

<!-- /greptile_comment -->