### PR TITLE
feat(ui): add a Save and Close button + Cmd/Ctrl+Enter to reaction sidebars (#550)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.saveAndClose.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.saveAndClose.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderInReactionView } from 'test/renderInReactionView.tsx';
+import { ReactionEntityForm } from './ReactionEntityForm.tsx';
+import { reactionSidebarInfo } from 'features/reactions/ReactionEntities/sidebarInfo/sidebarInfo.models.ts';
+import { ReactionNodeEntity } from 'store/entities/reactions/reactions.types.ts';
+
+// The real form registry eagerly imports every node form, including the Ketcher/d3 structure
+// editor (a CJS/ESM break under vitest). Stub the registry to an empty form — the field nodes
+// aren't what's under test here; the save-and-close wiring is.
+vi.mock('features/reactions/ReactionEntities', () => ({
+  ReactionEntityBaseNode: () => null,
+  reactionEntityToForm: new Proxy({}, { get: () => [] }),
+}));
+
+const addUpdateReactionFieldMock = vi.fn((_arg: unknown) => ({ type: 'test/noop' }));
+vi.mock('store/entities/reactions/reactions.thunks.ts', async importActual => ({
+  ...((await importActual()) as Record<string, unknown>),
+  addUpdateReactionField: (arg: unknown) => addUpdateReactionFieldMock(arg),
+}));
+
+const provenanceSidebarInfo = reactionSidebarInfo.find(
+  info => info.entityName === ReactionNodeEntity.Provenance,
+)!;
+
+const onFormClose = vi.fn();
+
+function renderForm() {
+  renderInReactionView(
+    <ReactionEntityForm
+      isHidden={false}
+      reactionPathComponents={provenanceSidebarInfo.pathComponents}
+      sidebarInfo={provenanceSidebarInfo}
+      onFormClose={onFormClose}
+      onSetFormDirty={() => {}}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ReactionEntityForm — Save and Close (#550)', () => {
+  it('saves the form and closes the sidebar when clicked', async () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save and Close' }));
+
+    await waitFor(() => expect(addUpdateReactionFieldMock).toHaveBeenCalledTimes(1));
+    expect(onFormClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves and closes on Cmd/Ctrl+Enter', async () => {
+    renderForm();
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Save and Close' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+
+    await waitFor(() => expect(addUpdateReactionFieldMock).toHaveBeenCalledTimes(1));
+    expect(onFormClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.saveAndClose.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.saveAndClose.test.tsx
@@ -21,11 +21,12 @@ import { reactionSidebarInfo } from 'features/reactions/ReactionEntities/sidebar
 import { ReactionNodeEntity } from 'store/entities/reactions/reactions.types.ts';
 
 // The real form registry eagerly imports every node form, including the Ketcher/d3 structure
-// editor (a CJS/ESM break under vitest). Stub the registry to an empty form — the field nodes
-// aren't what's under test here; the save-and-close wiring is.
+// editor (a CJS/ESM break under vitest). Stub the registry to a single plain text field — the
+// field nodes aren't what's under test here; the save-and-close wiring is. A real input gives
+// the keyboard-shortcut test a realistic focus target (a field, not the button).
 vi.mock('features/reactions/ReactionEntities', () => ({
-  ReactionEntityBaseNode: () => null,
-  reactionEntityToForm: new Proxy({}, { get: () => [] }),
+  ReactionEntityBaseNode: () => <input aria-label="Field" />,
+  reactionEntityToForm: new Proxy({}, { get: () => [{ name: 'field' }] }),
 }));
 
 const addUpdateReactionFieldMock = vi.fn((_arg: unknown) => ({ type: 'test/noop' }));
@@ -66,13 +67,15 @@ describe('ReactionEntityForm — Save and Close (#550)', () => {
     expect(onFormClose).toHaveBeenCalledTimes(1);
   });
 
-  it('saves and closes on Cmd/Ctrl+Enter', async () => {
+  it.each([
+    { label: 'Ctrl+Enter', mods: { ctrlKey: true } },
+    { label: 'Cmd+Enter', mods: { metaKey: true } },
+  ])('saves and closes on $label from a focused field', async ({ mods }) => {
     renderForm();
 
-    fireEvent.keyDown(screen.getByRole('button', { name: 'Save and Close' }), {
-      key: 'Enter',
-      ctrlKey: true,
-    });
+    // Fire from a real form field (where a user would be typing), not the button — the handler
+    // lives on the parent <form> and catches the bubbling keydown.
+    fireEvent.keyDown(screen.getByLabelText('Field'), { key: 'Enter', ...mods });
 
     await waitFor(() => expect(addUpdateReactionFieldMock).toHaveBeenCalledTimes(1));
     expect(onFormClose).toHaveBeenCalledTimes(1);

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.tsx
@@ -24,7 +24,14 @@ import {
   reactionEntityToForm,
 } from 'features/reactions/ReactionEntities';
 import { reactionEntityContext } from 'features/reactions/ReactionEntities/reactionEntity.context.ts';
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  type KeyboardEvent,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import type { ReactionEntityContext } from 'features/reactions/ReactionEntities/reactionEntities.types.ts';
 import type { ReactionSidebarInfo } from 'features/reactions/ReactionEntities/sidebarInfo/sidebarInfo.types.ts';
 import { reactionContext } from '../../reactions.context.ts';
@@ -145,6 +152,28 @@ export function ReactionEntityForm({
     [filterValues, form, onSubmit],
   );
 
+  // Save the form and, only if it validated, return to the parent sidebar level. Mirrors the
+  // validate-then-submit gating the Save button gets from <Form>, then closes on success. (#550)
+  const handleSaveAndClose = useCallback(() => {
+    if (isViewOnly) return;
+    const { hasErrors } = form.validate();
+    if (hasErrors) return;
+    onSubmit(form.getValues());
+    onFormClose();
+  }, [form, isViewOnly, onSubmit, onFormClose]);
+
+  // Cmd/Ctrl+Enter triggers Save and Close. Scoped to this form's DOM subtree (not a global
+  // hotkey) so hidden sibling forms in the mounted sidebar stack don't also fire. (#550)
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLFormElement>) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+        event.preventDefault();
+        handleSaveAndClose();
+      }
+    },
+    [handleSaveAndClose],
+  );
+
   return (
     <reactionEntityContext.Provider value={contextValue}>
       {isHidden ? null : (
@@ -152,6 +181,7 @@ export function ReactionEntityForm({
           className={classes.wrapper}
           form={form}
           onSubmit={onSubmit}
+          onKeyDown={handleKeyDown}
           key={formKey}
         >
           <Flex
@@ -199,6 +229,14 @@ export function ReactionEntityForm({
                 color="primary"
               >
                 Save
+              </Button>
+            )}
+            {!isViewOnly && (
+              <Button
+                color="primary"
+                onClick={handleSaveAndClose}
+              >
+                Save and Close
               </Button>
             )}
           </Flex>


### PR DESCRIPTION
Closes #550.

## What
Adds a **Save and Close** action to the reaction-entity sidebars and a **Cmd/Ctrl+Enter** keyboard shortcut, so users can enter data and return to the parent level in one step (AC#1–3).

## How
In the shared [`ReactionEntityForm`](ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.tsx) (used by every detail sidebar):
- `handleSaveAndClose` validates the form, saves (dispatch `addUpdateReactionField`) only if valid, then calls `onFormClose` — mirroring the validate-then-submit gating the existing Save button gets from `<Form>`.
- `handleKeyDown` maps Cmd/Ctrl+Enter to the same handler, **scoped to the form's DOM subtree** (via `<Form onKeyDown>`) rather than a global hotkey, so hidden sibling forms in the mounted sidebar stack don't also fire.
- The new button is `!isViewOnly`-gated like Save; existing **Save** and **Close** buttons are unchanged (additive).

## Tests
`ReactionEntityForm.saveAndClose.test.tsx` renders the **real** form and asserts both the button click and Cmd/Ctrl+Enter save (dispatch) and close (`onFormClose`). Full UI suite + `tsc -b` + lint green.

> The unit tests exercise the real component (incl. Mantine validation gating). A quick no-auth-stack click-through is welcome before merge if you'd like the visual confirmation — happy to run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a **Save and Close** button and a **Cmd/Ctrl+Enter** keyboard shortcut to every reaction-entity detail sidebar. Both actions share a single `handleSaveAndClose` handler that validates the form, dispatches the save only on success, then calls `onFormClose` — keeping the same guard logic as the existing Save button.

- `handleSaveAndClose` manually calls `form.validate()` + `form.getValues()` to replicate the Mantine `<Form onSubmit>` validate-then-submit path, then unconditionally calls `onFormClose()`. The double `isViewOnly` guard (one in `handleSaveAndClose`, one inside `onSubmit`) is redundant but harmless.
- `handleKeyDown` is attached to the `<Form>` element, scoping the shortcut to the visible form's DOM subtree; hidden sibling forms render `null` so they cannot intercept the event.
- New test covers button-click, Ctrl+Enter, and Cmd+Enter using `it.each`, firing from a real input element rather than the button.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive change that leaves existing Save and Close buttons untouched.

The new handler replicates the existing validate-then-dispatch pattern faithfully; the keyboard shortcut is correctly scoped to the visible form subtree; and the test suite now covers both modifier keys (Ctrl and Cmd) firing from a real input field, addressing both previous review comments.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.tsx | Adds handleSaveAndClose (validate → submit → close) and handleKeyDown (Cmd/Ctrl+Enter) to the shared form wrapper; both are guarded by isViewOnly. Implementation is additive and does not touch existing Save/Close paths. |
| ui/src/features/reactions/ReactionEntities/ReactionEntityForm/ReactionEntityForm.saveAndClose.test.tsx | New test file covering button-click, Ctrl+Enter, and Cmd+Enter paths; uses parameterised it.each for the keyboard cases and fires events from a real form input rather than the button, addressing the two previous review comments. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): fire Save-and-Close shortcut f..."](https://github.com/open-reaction-database/ord-app/commit/99115344bf0fa5efa003e32e7df57c6b76d9c55a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39184027)</sub>

<!-- /greptile_comment -->