### PR TITLE
fix(ui): exclude Measurement Type from template Set-Variables (#513)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/reactionMeasurements.model.ts
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/reactionMeasurements.model.ts
@@ -50,6 +50,9 @@ export const reactionMeasurements: Array<ReactionFormNode> = [
         name: 'type',
         wrapperConfig: {
           label: 'Type',
+          // A measurement's Type drives which sub-fields appear; it isn't a templatable value,
+          // so don't offer "Set Variables" for it (matches Component Identifier Type / Analysis). (#513)
+          cannotBeVariable: true,
         },
       },
     ],


### PR DESCRIPTION
Closes #513.

A measurement's **Type** select drives which sub-fields render, so it isn't a templatable value. This adds `cannotBeVariable: true` to its `wrapperConfig` ([reactionMeasurements.model.ts](ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/reactionMeasurements.model.ts)) so that in templates it shows a plain label with no "Set Variables" link — matching the existing opt-out already used on Component Identifier Type, Analysis name, and "Based on".

`tsc -b` + lint + measurements unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a template UI bug where the measurement **Type** dropdown incorrectly offered a "Set Variables" link, even though its value controls which sub-fields are rendered and therefore cannot be left variable. The fix adds `cannotBeVariable: true` to the field's `wrapperConfig`, which causes `ReactionValueLabelWrapper` to render a plain `ViewOnlyLabelComponent` instead of the interactive template control.

- The one-line change exactly mirrors the existing opt-outs already applied to Component Identifier Type (`reactionComponentIdentifiers.model.ts`), Analysis name (`reactionAnalyses.models.ts`), and "Based on" (`MeasurementsBasedOn.tsx`).
- No logic, rendering path, or type definition is altered; only the model configuration for this single field changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-flag addition to an existing configuration pattern with no side-effects outside template mode.

The change is one `cannotBeVariable: true` flag on a field config object, matching an identical pattern already used in three other places in the same codebase. The consuming component (`ReactionValueLabelWrapper`) only checks this flag when `isTemplate` is true, so non-template rendering is entirely unaffected. There are no new code paths, no conditional logic changes, and no type mismatches to worry about.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/reactionMeasurements.model.ts | Adds `cannotBeVariable: true` to the measurement `type` field's `wrapperConfig`, preventing the "Set Variables" link from appearing in template mode — consistent with identical opt-outs on Component Identifier Type, Analysis name, and "Based on". |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): exclude Measurement Type from t..."](https://github.com/open-reaction-database/ord-app/commit/f7d02fbfec3db54c334bf20fa9c080c02def1cca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39196618)</sub>

<!-- /greptile_comment -->