### PR TITLE
fix(ui): red OK button on destructive confirm popovers (#314)

### DIFF
--- a/ui/src/common/components/interactions/ConfirmPopover/ConfirmPopover.test.tsx
+++ b/ui/src/common/components/interactions/ConfirmPopover/ConfirmPopover.test.tsx
@@ -40,4 +40,32 @@ describe('ConfirmPopover', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
+
+  const renderPopover = (destructive?: boolean) =>
+    renderWithMantine(
+      <ConfirmPopover
+        opened
+        destructive={destructive}
+        target={<button>open</button>}
+        title="Remove?"
+        text="x"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+  it('renders a red OK button for destructive confirmations (#314)', () => {
+    renderPopover(true);
+    // Mantine color="red" inlines the red color custom properties on the button element.
+    expect(
+      screen.getByRole('button', { name: 'OK' }).getAttribute('style') ?? '',
+    ).toContain('red');
+  });
+
+  it('renders a default (non-red) OK button when not destructive', () => {
+    renderPopover(false);
+    expect(
+      screen.getByRole('button', { name: 'OK' }).getAttribute('style') ?? '',
+    ).not.toContain('red');
+  });
 });

--- a/ui/src/common/components/interactions/ConfirmPopover/ConfirmPopover.tsx
+++ b/ui/src/common/components/interactions/ConfirmPopover/ConfirmPopover.tsx
@@ -23,6 +23,8 @@ interface ConfirmPopoverProps extends PopoverProps {
   text: string;
   onConfirm: () => void;
   onCancel: () => void;
+  // Render the confirm (OK) button in red for destructive actions (remove/delete/unshare). (#314)
+  destructive?: boolean;
 }
 
 export function ConfirmPopover({
@@ -31,6 +33,7 @@ export function ConfirmPopover({
   text,
   onConfirm,
   onCancel,
+  destructive,
   ...rest
 }: Readonly<ConfirmPopoverProps>) {
   return (
@@ -79,6 +82,7 @@ export function ConfirmPopover({
             <Button
               className={classes.popoverButton}
               size="xs"
+              color={destructive ? 'red' : undefined}
               onClick={onConfirm}
             >
               OK

--- a/ui/src/features/datasets/DatasetHeader/DatasetHeader.tsx
+++ b/ui/src/features/datasets/DatasetHeader/DatasetHeader.tsx
@@ -148,6 +148,7 @@ export function DatasetHeader({ dataset }: Readonly<DatasetHeaderProps>) {
       >
         {canDatasetBeDeleted && (
           <ConfirmPopover
+            destructive
             opened={removeConfirmOpened}
             position="right"
             offset={8}

--- a/ui/src/features/datasets/ShareDataset/ShareDatasetSidebar.tsx
+++ b/ui/src/features/datasets/ShareDataset/ShareDatasetSidebar.tsx
@@ -78,6 +78,7 @@ function GroupListItem({ group, onUnshareWithGroup }: Readonly<GroupsListItemPro
         />
       </Flex>
       <ConfirmPopover
+        destructive
         opened={popoverOpened}
         onCancel={close}
         onConfirm={() => onUnshareWithGroup(group.id)}

--- a/ui/src/features/reactions/ReactionEntities/ReactionEntityDelete/ReactionEntityDelete.tsx
+++ b/ui/src/features/reactions/ReactionEntities/ReactionEntityDelete/ReactionEntityDelete.tsx
@@ -68,6 +68,7 @@ export function ReactionEntityDelete({
 
   return (
     <ConfirmPopover
+      destructive
       title={`Remove ${entityName}`}
       text={`Are you sure to remove this ${entityName}?`}
       opened={confirmationOpened}

--- a/ui/src/features/reactions/RemoveReaction/RemoveReaction.tsx
+++ b/ui/src/features/reactions/RemoveReaction/RemoveReaction.tsx
@@ -46,6 +46,7 @@ export function RemoveReaction({ reactionId }: Readonly<RemoveReactionProps>) {
 
   return (
     <ConfirmPopover
+      destructive
       title={`Remove this ${entityToRemove}`}
       text={`Are you sure you want to remove this ${entityToRemove}?`}
       opened={confirmationOpened}


### PR DESCRIPTION
Closes #314.

The destructive **Remove** buttons already turn red on hover (#776); this makes the confirmation popover match. Adds an optional `destructive` prop to [`ConfirmPopover`](ui/src/common/components/interactions/ConfirmPopover/ConfirmPopover.tsx) that renders the **OK** button in red, applied to the remove/delete/unshare confirmations:
- `RemoveReaction`, `ReactionEntityDelete` (reaction + entity remove)
- `DatasetHeader` (remove dataset)
- `ShareDatasetSidebar` (unshare dataset from a group)

Non-destructive confirmations (enumeration cancel, role change, share) are unchanged. Added unit tests asserting the OK button is red with `destructive` and default without. `tsc -b` + lint + affected component tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional `destructive` boolean prop to `ConfirmPopover` that renders the OK button in red (`color="red"`) for irreversible actions, and applies it to all four remove/delete/unshare call-sites. Non-destructive confirmations are untouched.

- `ConfirmPopover` receives `destructive?` in its props interface, destructures it before `...rest`, and passes `color={destructive ? 'red' : undefined}` to the Mantine `Button` — clean and minimal.
- Two new unit tests cover the red and non-red cases; they rely on Mantine serialising the colour as inline CSS custom properties containing `"red"`, which works today but could drift with a Mantine version bump.
- All four destructive call-sites (`DatasetHeader`, `ShareDatasetSidebar`, `ReactionEntityDelete`, `RemoveReaction`) are updated consistently.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small additive UI prop with no logic or data-flow implications.

All four destructive call-sites are updated consistently, the new prop is fully optional so existing non-destructive uses need no changes, and the implementation is a single ternary. The only note is that the new tests sniff a raw style-attribute string, which could drift with a Mantine upgrade, but that is a test-maintenance concern rather than a functional defect.

No files require special attention, though the style-attribute assertions in `ConfirmPopover.test.tsx` are worth keeping in mind if Mantine is upgraded.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/common/components/interactions/ConfirmPopover/ConfirmPopover.tsx | Adds optional `destructive` prop; passes `color="red"` to the OK Button when truthy. Clean prop destructuring before `...rest` spread. |
| ui/src/common/components/interactions/ConfirmPopover/ConfirmPopover.test.tsx | Adds two tests for the new prop. Tests inspect the inline `style` attribute for "red", which works but couples the test to Mantine's CSS-custom-property injection — could break silently on a Mantine upgrade. |
| ui/src/features/datasets/DatasetHeader/DatasetHeader.tsx | Adds `destructive` to the remove-dataset `ConfirmPopover`; no other changes. |
| ui/src/features/datasets/ShareDataset/ShareDatasetSidebar.tsx | Adds `destructive` to the unshare-group `ConfirmPopover`; no other changes. |
| ui/src/features/reactions/ReactionEntities/ReactionEntityDelete/ReactionEntityDelete.tsx | Adds `destructive` to the entity-delete `ConfirmPopover`; no other changes. |
| ui/src/features/reactions/RemoveReaction/RemoveReaction.tsx | Adds `destructive` to the remove-reaction `ConfirmPopover`; no other changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): red OK button on destructive co..."](https://github.com/open-reaction-database/ord-app/commit/a9f7efdc969cfe2b67a0da7c798d7089f8f9682e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39197185)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->