### PR TITLE
fix(ui): default measurement value-type by measurement type (#604)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.test.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.test.tsx
@@ -19,20 +19,28 @@ import { MeasurementValueControl } from './MeasurementValueControl.tsx';
 import { ReactionMeasurementValueType } from 'store/entities/reactions/reactionComponent/reactionComponent.types.ts';
 import type { ReactionEntityNodeProps } from 'features/reactions/ReactionEntities/reactionEntityNode/reactionEntityNode.types.ts';
 
-const formMethods = {
-  getInputProps: () => ({
-    value: {
-      type: ReactionMeasurementValueType.Number,
-      value: { value: null, precision: null },
-    },
-    onChange: vi.fn(),
-  }),
-} as unknown as ReactionEntityNodeProps['formMethods'];
+// formMethods with a configurable measurement `type` (sibling field) and optional existing value.
+const makeFormMethods = (
+  measurementType?: string,
+  value?: unknown,
+): ReactionEntityNodeProps['formMethods'] =>
+  ({
+    getInputProps: () => ({ value, onChange: vi.fn() }),
+    getValues: () => ({ type: measurementType }),
+  }) as unknown as ReactionEntityNodeProps['formMethods'];
 
-const renderControl = (isViewOnly = false) =>
+const numericValue = {
+  type: ReactionMeasurementValueType.Number,
+  value: { value: null, precision: null },
+};
+
+const renderControl = (
+  formMethods: ReactionEntityNodeProps['formMethods'],
+  isViewOnly = false,
+) =>
   renderInReactionView(
     <MeasurementValueControl
-      name="measurement"
+      name="value"
       formMethods={formMethods}
     />,
     { isViewOnly },
@@ -40,14 +48,38 @@ const renderControl = (isViewOnly = false) =>
 
 describe('MeasurementValueControl', () => {
   it('renders the value and precision inputs for a numeric measurement', () => {
-    const { getByPlaceholderText } = renderControl();
+    const { getByPlaceholderText } = renderControl(
+      makeFormMethods('CUSTOM', numericValue),
+    );
     expect(getByPlaceholderText('Value')).toBeInTheDocument();
     expect(getByPlaceholderText('Precision')).toBeInTheDocument();
   });
 
   it('disables the inputs in view-only mode', () => {
-    const { getByPlaceholderText } = renderControl(true);
+    const { getByPlaceholderText } = renderControl(
+      makeFormMethods('CUSTOM', numericValue),
+      true,
+    );
     expect(getByPlaceholderText('Value')).toBeDisabled();
     expect(getByPlaceholderText('Precision')).toBeDisabled();
   });
+
+  // #604: with no value set yet, the value-type is preselected from the measurement's own type.
+  it.each([
+    { measurementType: 'SELECTIVITY', expected: ReactionMeasurementValueType.Number },
+    { measurementType: 'YIELD', expected: ReactionMeasurementValueType.Percent },
+    { measurementType: 'PURITY', expected: ReactionMeasurementValueType.Percent },
+    { measurementType: 'AMOUNT', expected: ReactionMeasurementValueType.Mass },
+    { measurementType: 'AREA', expected: ReactionMeasurementValueType.Number },
+  ])(
+    'defaults an unset $measurementType value to the $expected value-type (#604)',
+    ({ measurementType, expected }) => {
+      const { container } = renderControl(makeFormMethods(measurementType, undefined));
+      // happy-dom's :checked selector doesn't match property-set state, so read the property.
+      const checked = Array.from(
+        container.querySelectorAll<HTMLInputElement>('input[type="radio"]'),
+      ).find(radio => radio.checked);
+      expect(checked?.value).toBe(expected);
+    },
+  );
 });

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.tsx
@@ -38,6 +38,7 @@ import { AppNumberInput } from 'common/components/inputs/AppNumberInput/AppNumbe
 import { reactionContext } from 'features/reactions/reactions.context.ts';
 import { VariableType } from 'store/entities/templates/templates.types.ts';
 import type { Optional } from 'store/entities/reactions/reactionEntity/reactionEntity.types.ts';
+import type { ReactionMeasurementType } from 'store/entities/reactions/reactionEntityTypes/reactionEntityTypes.types.ts';
 
 const valueTypeOptions = Object.values(ReactionMeasurementValueType);
 
@@ -177,12 +178,30 @@ function handleMeasurementTypeChange(
   return { type: newType, value: newValue } as ReactionMeasurementValue;
 }
 
-const defaultValueType = ReactionMeasurementValueType.Percent;
-
-const defaultMeasurementValue: ReactionMeasurementValueNumber = {
-  type: defaultValueType,
-  value: typeToDefaultValue[defaultValueType],
+// Default value-type per measurement type (#604). A single global "%" default was wrong for
+// non-percentage measurements (e.g. Selectivity ratios). Percentages stay %, amounts default to a
+// mass, and everything else (Selectivity, Area, Counts, Intensity, Custom, …) defaults to Number.
+const measurementTypeToDefaultValueType: Partial<
+  Record<ReactionMeasurementType, ReactionMeasurementValueType>
+> = {
+  YIELD: ReactionMeasurementValueType.Percent,
+  PURITY: ReactionMeasurementValueType.Percent,
+  AMOUNT: ReactionMeasurementValueType.Mass,
 };
+
+const fallbackValueType = ReactionMeasurementValueType.Number;
+
+function buildDefaultMeasurementValue(
+  measurementType: Optional<ReactionMeasurementType>,
+): ReactionMeasurementValue {
+  const valueType =
+    (measurementType && measurementTypeToDefaultValueType[measurementType]) ??
+    fallbackValueType;
+  return {
+    type: valueType,
+    value: typeToDefaultValue[valueType],
+  } as ReactionMeasurementValue;
+}
 
 export function MeasurementValueControl({
   name,
@@ -192,7 +211,12 @@ export function MeasurementValueControl({
   const [measurementValue, onChange] = useUncontrolled<ReactionMeasurementValue>({
     ...formMethods.getInputProps(name),
   });
-  const activeMeasurementValue = measurementValue ?? defaultMeasurementValue;
+  // When no value has been entered yet, preselect the value-type based on the measurement's own
+  // type (sibling `type` field) rather than always defaulting to "%". (#604)
+  const measurementType = (formMethods.getValues()?.type ??
+    null) as Optional<ReactionMeasurementType>;
+  const activeMeasurementValue =
+    measurementValue ?? buildDefaultMeasurementValue(measurementType);
   const { value, type } = activeMeasurementValue;
   const Component = typeToComponent[type];
 


### PR DESCRIPTION
Closes #604.

## Problem
The Product Measurements value field always preselected the **`%`** value-type for *every* measurement type — so e.g. a **Selectivity** measurement defaulted to `%`, which is wrong for a ratio.

## Cause
`MeasurementValueControl` used a single global `defaultValueType = Percent` with no per-type branching.

## Fix
Pick the default value-type from the measurement's own `type` ([MeasurementValueControl.tsx](ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.tsx)):
- **Yield / Purity → `%`**
- **Amount → `Mass`**
- **everything else (Selectivity, Area, Counts, Intensity, Custom, …) → `Number`**

Only applies when no value has been entered yet; saved measurements keep their stored type.

## Tests
Parametrized tests assert the preselected value-type per measurement type (Selectivity→Number, Yield/Purity→%, Amount→Mass, Area→Number); existing numeric-render/view-only tests retained (mock updated for the new `getValues` read). `tsc -b` + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Product Measurements UI always pre-selecting `%` as the value-type regardless of measurement kind. A per-type lookup map (`YIELD`/`PURITY` → Percent, `AMOUNT` → Mass, everything else → Number) now drives the default, applied only when no value has yet been stored.

- Adds `measurementTypeToDefaultValueType` and `buildDefaultMeasurementValue`, reading the sibling `type` field via `formMethods.getValues()`, replacing the former hard-coded `Percent` default.
- Test helper updated with a `getValues` stub and a parametrized `it.each` block asserting the correct pre-selection for Selectivity, Yield, Purity, Amount, and Area; field `name` corrected from `"measurement"` to `"value"` to match the actual form model.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the unset-value path, existing saved measurements are unaffected, and the new lookup map covers all types listed in `valueCompatibleTypes`.

The fix is small, well-bounded, and fully exercised by the updated parametrized tests. The `getValues()` call reads live form state (the parent re-renders on every dropdown change in Mantine's `useForm`, so the snapshot is always fresh on remount). No regressions introduced to saved data or view-only mode.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.tsx | Replaces single Percent default with a per-measurement-type lookup; adds `buildDefaultMeasurementValue` using `getValues()?.type` — logic is sound, types are safe, and only applies when no value has been entered. |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/measurements/MeasurementValueControl/MeasurementValueControl.test.tsx | Adds `makeFormMethods` factory with `getValues` stub, corrects `name` from `"measurement"` to `"value"`, and adds parametrized per-measurement-type default assertions. Coverage is good. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): default measurement value-type ..."](https://github.com/open-reaction-database/ord-app/commit/b89624470066cf50daa2ceb13434f3dfa7800670) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39197776)</sub>

<!-- /greptile_comment -->