### PR TITLE
fix(ui): show measured value in per-record measurement summaries (#603)

### DIFF
--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/reactionConditions.model.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/reactionConditions.model.tsx
@@ -139,6 +139,12 @@ export const reactionTemperatureCondition: ReactionFormNode = {
           label: 'Type',
           render: item => item.type,
         },
+        {
+          // Show the measured value so multiple records are distinguishable. (#603)
+          label: 'Temperature',
+          render: item =>
+            item.temperature ? renderValuePrecisionUnit(item.temperature) : '',
+        },
       ],
     ),
   ],
@@ -318,6 +324,12 @@ export const reactionConditions: Array<ReactionFormNode> = [
             label: 'Type',
             render: item => item.type,
           },
+          {
+            // Show the measured value so multiple records are distinguishable. (#603)
+            label: 'Pressure',
+            render: item =>
+              item.pressure ? renderValuePrecisionUnit(item.pressure) : '',
+          },
         ],
       ),
     ],
@@ -486,6 +498,17 @@ export const reactionConditions: Array<ReactionFormNode> = [
           {
             label: 'Time',
             render: item => (item.time ? renderValuePrecisionUnit(item.time) : ''),
+          },
+          {
+            // Show the measured values so multiple records are distinguishable. (#603)
+            label: 'Voltage',
+            render: item =>
+              item.voltage ? renderValuePrecisionUnit(item.voltage) : '',
+          },
+          {
+            label: 'Current',
+            render: item =>
+              item.current ? renderValuePrecisionUnit(item.current) : '',
           },
         ],
       ),


### PR DESCRIPTION
Closes #603.

Each measurement record's summary line under Conditions only showed **Type** (temperature/pressure) or **Time** (electrochemistry), so records with multiple entries were indistinguishable at a glance. This adds the measured value to each summary in [reactionConditions.model.tsx](ui/src/features/reactions/ReactionEntities/entityFormConfiguration/reactionConditions.model.tsx):
- **Temperature** records show their measured **Temperature**
- **Pressure** records show their measured **Pressure**
- **Electrochemistry** records show **Voltage** and **Current** (alongside the existing Time)

All records already rendered; this only enriches each per-record summary. `tsc -b` + lint + entity-form unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enriches the per-record summary lines shown under Conditions by appending the actual measured value alongside the existing Type/Time label, making multiple measurement records distinguishable at a glance.

- **Temperature measurements** now display the measured `Temperature` value next to `Type`.
- **Pressure measurements** now display the measured `Pressure` value next to `Type`.
- **Electrochemistry measurements** now display `Voltage` and `Current` alongside the existing `Time`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive-only, touches a single file, and all new fields follow the existing rendering pattern already established by the Time field.

Three small, parallel additions that mirror the pre-existing `item.time ? renderValuePrecisionUnit(item.time) : ''` pattern exactly. All referenced types match what `renderValuePrecisionUnit` accepts. No logic is removed or restructured.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/reactionConditions.model.tsx | Adds measured value fields (Temperature, Pressure, Voltage, Current) to per-record measurement summaries so users can distinguish records at a glance; follows the exact existing pattern used for the Time field |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show measured value in per-reco..."](https://github.com/open-reaction-database/ord-app/commit/18961ec67a2e3149d7e9ae1a0d03845fa1d33447) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39198201)</sub>

<!-- /greptile_comment -->