### PR TITLE
feat: look up compounds by name, SMILES, or InChI (#465)

### DIFF
--- a/ord_app/service_api/resources/v1/utilities.py
+++ b/ord_app/service_api/resources/v1/utilities.py
@@ -68,11 +68,25 @@ async def resolve_input(input_string: str) -> str | Response:
 
 @router.post("/resolve-compound", response_model=ResolveCompoundOutputs)
 async def resolve_compound(inputs: ResolveCompoundInputs) -> dict | Response:
-    """Resolves a compound identifier into a SMILES string."""
+    """Resolves a compound identifier (name/SMILES/InChI) into a canonical SMILES string.
+
+    A SMILES is already a structure, so it is canonicalized locally without a remote lookup;
+    other identifier types (name, InChI) are resolved via the external services, with the type
+    threaded through so e.g. PubChem searches by InChI rather than treating it as a name. (#465)
+    """
     try:
-        resolver, smiles = await name_resolve_cached(
-            inputs.identifier_type, inputs.identifier
-        )
+        if inputs.identifier_type == "smiles":
+            return {
+                "smiles": canonicalize_smiles_cached(inputs.identifier),
+                "resolver": "RDKit",
+            }
+        result = await name_resolve_cached(inputs.identifier_type, inputs.identifier)
+        if result is None:
+            # Every resolver failed/returned nothing -- a clean 400, not a 500 from unpacking None.
+            return Response(
+                "Could not resolve the compound identifier.", status_code=400
+            )
+        resolver, smiles = result
         return {"smiles": canonicalize_smiles_cached(smiles), "resolver": resolver}
     except ValueError as error:
         return Response(str(error), status_code=400)

--- a/ord_app/service_api/resources/v1/utilities_test.py
+++ b/ord_app/service_api/resources/v1/utilities_test.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the compound-resolution endpoint, focused on identifier-type routing (#465)."""
+
+from fastapi import status
+
+from ord_app.service_api.resources.v1 import utilities
+
+
+def test_resolve_compound_smiles_canonicalizes_locally(
+    api_client, mock_authenticated_user, monkeypatch
+):
+    # A SMILES is already a structure: canonicalize locally, never hit the remote resolvers.
+    remote_calls = []
+
+    async def fake_remote(value_type, identifier):
+        remote_calls.append((value_type, identifier))
+        return ("PubChem API", "unused")
+
+    monkeypatch.setattr(utilities, "name_resolve_cached", fake_remote)
+    monkeypatch.setattr(
+        utilities, "canonicalize_smiles_cached", lambda smiles: f"canon:{smiles}"
+    )
+
+    response = api_client.post(
+        "/api/v1/resolve-compound",
+        json={"identifier_type": "smiles", "identifier": "C(C)O"},
+    ).raise_for_status()
+
+    assert response.json() == {"smiles": "canon:C(C)O", "resolver": "RDKit"}
+    assert remote_calls == []  # no remote lookup for a SMILES
+
+
+def test_resolve_compound_threads_identifier_type(
+    api_client, mock_authenticated_user, monkeypatch
+):
+    # Non-SMILES types (name/InChI) go to the remote resolvers with the type passed through.
+    remote_calls = []
+
+    async def fake_remote(value_type, identifier):
+        remote_calls.append((value_type, identifier))
+        return ("PubChem API", "O")
+
+    monkeypatch.setattr(utilities, "name_resolve_cached", fake_remote)
+    monkeypatch.setattr(utilities, "canonicalize_smiles_cached", lambda smiles: smiles)
+
+    response = api_client.post(
+        "/api/v1/resolve-compound",
+        json={"identifier_type": "inchi", "identifier": "InChI=1S/H2O/h1H2"},
+    ).raise_for_status()
+
+    assert response.json() == {"smiles": "O", "resolver": "PubChem API"}
+    assert remote_calls == [("inchi", "InChI=1S/H2O/h1H2")]
+
+
+def test_resolve_compound_unresolvable_returns_400(
+    api_client, mock_authenticated_user, monkeypatch
+):
+    # Every resolver failing yields None; surface a clean 400 rather than a 500 from unpacking None.
+    async def fake_remote(value_type, identifier):
+        return None
+
+    monkeypatch.setattr(utilities, "name_resolve_cached", fake_remote)
+
+    response = api_client.post(
+        "/api/v1/resolve-compound",
+        json={"identifier_type": "name", "identifier": "nonexistent-compound"},
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsLookup/ComponentsLookup.tsx
+++ b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsLookup/ComponentsLookup.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Form, useForm } from '@mantine/form';
-import { Anchor, Button, Flex, Modal, Text, TextInput } from '@mantine/core';
+import { Anchor, Button, Flex, Modal, Select, Text, TextInput } from '@mantine/core';
 import { useAppDispatch } from 'store/useAppDispatch.ts';
 import { addIdentifierByName } from 'store/entities/reactions/reactionsInputs/reactionInputs.thunks.ts';
 import { useContext, useEffect, type FormEvent } from 'react';
@@ -32,6 +32,13 @@ interface ComponentsLookupProps {
   onClose: () => void;
 }
 
+// Resolver identifier types. Values match what the backend / PubChem expect (#465).
+const IDENTIFIER_TYPE_OPTIONS = [
+  { value: 'name', label: 'Name' },
+  { value: 'smiles', label: 'SMILES' },
+  { value: 'inchi', label: 'InChI' },
+];
+
 export function ComponentsLookup({ onClose }: Readonly<ComponentsLookupProps>) {
   const dispatch = useAppDispatch();
   const { reactionId, pathComponents } = useContext(reactionEntityContext);
@@ -43,6 +50,7 @@ export function ComponentsLookup({ onClose }: Readonly<ComponentsLookupProps>) {
     clearInputErrorOnChange: true,
     initialValues: {
       search: '',
+      identifierType: 'name',
     },
   });
 
@@ -60,7 +68,10 @@ export function ComponentsLookup({ onClose }: Readonly<ComponentsLookupProps>) {
     }
   }, [dispatch, hasError, values.search]);
 
-  const onSubmit = (values: { search: string }, event?: FormEvent<HTMLFormElement>) => {
+  const onSubmit = (
+    values: { search: string; identifierType: string },
+    event?: FormEvent<HTMLFormElement>,
+  ) => {
     event?.stopPropagation();
     const path = pathComponents.concat('identifiers');
     dispatch(
@@ -68,6 +79,7 @@ export function ComponentsLookup({ onClose }: Readonly<ComponentsLookupProps>) {
         reactionId: reactionId,
         pathComponents: path,
         name: values.search,
+        identifierType: values.identifierType,
       }),
     );
   };
@@ -108,8 +120,15 @@ export function ComponentsLookup({ onClose }: Readonly<ComponentsLookupProps>) {
           </Anchor>
           databases
         </Text>
+        <Select
+          label="Identifier type"
+          data={IDENTIFIER_TYPE_OPTIONS}
+          allowDeselect={false}
+          {...form.getInputProps('identifierType')}
+        />
         <TextInput
-          label="Compound name"
+          label="Compound identifier"
+          placeholder="Name, SMILES, or InChI"
           {...inputProps}
           error={hasError ? 'Compound not found' : inputProps.error}
           data-autofocus

--- a/ui/src/store/entities/reactions/reactionsInputs/reactionInputs.actions.ts
+++ b/ui/src/store/entities/reactions/reactionsInputs/reactionInputs.actions.ts
@@ -20,7 +20,13 @@ import type { ReactionId } from 'store/entities/reactions/reactions.types.ts';
 const { createAsyncAction } = createActionFactory('reactionInputs');
 
 export const addIdentifierByNameActions = createAsyncAction<
-  { reactionId: ReactionId; pathComponents: ReactionPathComponents; name: string },
+  {
+    reactionId: ReactionId;
+    pathComponents: ReactionPathComponents;
+    name: string;
+    // Resolver identifier type — 'name' | 'smiles' | 'inchi' (#465).
+    identifierType: string;
+  },
   void,
   void
 >('add_identifier_by_name');

--- a/ui/src/store/entities/reactions/reactionsInputs/reactionInputs.thunks.test.ts
+++ b/ui/src/store/entities/reactions/reactionsInputs/reactionInputs.thunks.test.ts
@@ -55,6 +55,7 @@ describe('addIdentifierByName', () => {
         reactionId: 99,
         pathComponents,
         name: 'water',
+        identifierType: 'name',
       }) as unknown as UnknownAction,
     );
 
@@ -78,6 +79,23 @@ describe('addIdentifierByName', () => {
     expect(arg.newValue.details).toBe('water');
   });
 
+  it('passes the chosen identifier type through to the resolver (#465)', async () => {
+    const { store } = makeStore();
+    await store.dispatch(
+      addIdentifierByName({
+        reactionId: 99,
+        pathComponents,
+        name: 'InChI=1S/H2O/h1H2',
+        identifierType: 'inchi',
+      }) as unknown as UnknownAction,
+    );
+
+    expect(axiosMock.post).toHaveBeenCalledWith('/resolve-compound', {
+      identifier_type: 'inchi',
+      identifier: 'InChI=1S/H2O/h1H2',
+    });
+  });
+
   it('dispatches failure and does not update the reaction when resolution rejects', async () => {
     axiosMock.post.mockRejectedValueOnce(new Error('not found'));
     const { store, types } = makeStore();
@@ -86,6 +104,7 @@ describe('addIdentifierByName', () => {
         reactionId: 99,
         pathComponents,
         name: 'bogus',
+        identifierType: 'name',
       }) as unknown as UnknownAction,
     );
 

--- a/ui/src/store/entities/reactions/reactionsInputs/reactionInputs.thunks.ts
+++ b/ui/src/store/entities/reactions/reactionsInputs/reactionInputs.thunks.ts
@@ -24,13 +24,13 @@ import { ordCompoundIdentifierToReaction } from 'store/entities/reactions/reacti
 
 export const addIdentifierByName = createThunkWithExplicitResult(
   addIdentifierByNameActions,
-  ({ reactionId, pathComponents, name }) =>
+  ({ reactionId, pathComponents, name, identifierType }) =>
     async (dispatch, getState) => {
       try {
         const result = await axiosInstance.post<{ smiles: string }>(
           '/resolve-compound',
           {
-            identifier_type: 'name',
+            identifier_type: identifierType,
             identifier: name,
           },
         );


### PR DESCRIPTION
Closes #465.

## Problem
"Look up name" hardcoded `identifier_type: 'name'`, so pasting a **SMILES** or **InChI** only resolved when an external service happened to accept it as a free-text name — hence the inconsistent "works for some structures, not others."

## Changes
**Frontend**
- Add a **Name / SMILES / InChI** selector to the lookup dialog ([ComponentsLookup.tsx](ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsLookup/ComponentsLookup.tsx)) and thread the chosen type through `addIdentifierByName` → `/resolve-compound`.

**Backend** ([utilities.py](ord_app/service_api/resources/v1/utilities.py))
- A **SMILES** is canonicalized **locally** (RDKit) with no remote lookup.
- **Name / InChI** are resolved remotely with the type threaded through (so e.g. PubChem searches by InChI, not as a name).
- Fix a latent **500**: when every resolver fails, `name_resolve_cached` returns `None`; the old code unpacked it (`resolver, smiles = None`) → `TypeError`. Now returns a clean **400**.

## Tests
- BE (`utilities_test.py`): SMILES short-circuit (no remote call), identifier-type passthrough, and 400-on-unresolvable.
- FE: the thunk test asserts the selected type reaches `/resolve-compound`.
- `tsc -b`, lint, `ruff`, `ty` all green.

> Note: the live external-resolution behavior for a given InChI depends on PubChem/CACTUS and isn't unit-testable; the routing is what's covered here. A quick manual check against a real InChI is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes compound lookup so that SMILES and InChI identifiers are resolved correctly instead of always being treated as names. A new identifier-type dropdown is wired end-to-end from the UI through the Redux action and thunk to the `/resolve-compound` endpoint, which now short-circuits SMILES to a local RDKit canonicalization and also fixes a latent 500 that occurred when all remote resolvers returned `None`.

- **Backend**: SMILES is canonicalized locally (no external call); name/InChI are forwarded to PubChem/CACTUS/eMolecules with the type threaded through; `None` from exhausted resolvers now returns a 400 instead of a `TypeError`.
- **Frontend**: `ComponentsLookup` gains a Name / SMILES / InChI `Select`; the chosen type travels through the action payload and thunk to the POST body.
- **Tests**: New BE file covers the three routing branches; FE thunk test adds the InChI passthrough case.

<h3>Confidence Score: 4/5</h3>

The core routing logic is correct and well-tested; the only gaps are a missing input constraint in the Pydantic schema and a loose TypeScript type that the frontend dropdown already enforces in practice.

The SMILES short-circuit, the None-guard fix, and the type passthrough all work correctly. The main weakness is that `ResolveCompoundInputs.identifier_type` is an unconstrained `str`, so an out-of-band caller sending an unrecognized type (e.g. wrong case) gets a generic "Could not resolve" error rather than a clear validation failure. The UI dropdown prevents this in the happy path, but a `Literal` constraint would close the gap. Everything else — the thunk change, action typing, and tests — is straightforward.

`ord_app/service_api/schemas/utilites.py` deserves a second look to add the `Literal` constraint on `identifier_type`; `ComponentsLookup.tsx` has a minor UX inaccuracy in the description text when SMILES is selected.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_app/service_api/resources/v1/utilities.py | Adds SMILES short-circuit (local RDKit canonicalization) and fixes latent 500 when all resolvers return None; logic is correct but identifier_type is unconstrained in the schema. |
| ord_app/service_api/schemas/utilites.py | ResolveCompoundInputs.identifier_type is a plain str with no enum/Literal constraint, allowing arbitrary values to pass Pydantic validation and reach remote resolvers. |
| ord_app/service_api/resources/v1/utilities_test.py | New test file covering SMILES short-circuit, identifier-type passthrough, and the 400-on-unresolvable fix; all three paths are well-covered. |
| ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsLookup/ComponentsLookup.tsx | Adds identifier-type selector and wires it through the form; description text claiming external database search is shown even when SMILES (local-only) is selected. |
| ui/src/store/entities/reactions/reactionsInputs/reactionInputs.actions.ts | Adds identifierType to the action payload; typed as string instead of a narrower literal union. |
| ui/src/store/entities/reactions/reactionsInputs/reactionInputs.thunks.ts | Replaces hardcoded 'name' with the user-supplied identifierType in the /resolve-compound POST body; change is minimal and correct. |
| ui/src/store/entities/reactions/reactionsInputs/reactionInputs.thunks.test.ts | Extends existing tests with identifierType and adds a new case verifying InChI type is forwarded to the resolver endpoint. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsLookup/ComponentsLookup.tsx`, line 101-122 ([link](https://github.com/open-reaction-database/ord-app/blob/6304961a42f3ab00223b8d7de7a419ed458cbe7b/ui/src/features/reactions/ReactionEntities/entityFormConfiguration/components/CustomIdentifiers/ComponentsLookup/ComponentsLookup.tsx#L101-L122)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Description text is inaccurate when SMILES is selected**

   When the user picks "SMILES", the text "Searching in PubChem, CACTUS, eMolecules databases" remains visible even though the SMILES path never contacts those services — it is canonicalized locally. Consider hiding or replacing the databases sentence conditionally on `form.values.identifierType === 'smiles'`.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat: look up compounds by name, SMILES,..."](https://github.com/open-reaction-database/ord-app/commit/6304961a42f3ab00223b8d7de7a419ed458cbe7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39198958)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->