### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Actions in .github/workflows are pinned to commit SHAs. Dependabot rewrites
+# both the SHA and its trailing version comment, which is what keeps a pinned
+# workflow from freezing on whatever was current the day it was written.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      # One pull request per month for all actions rather than one per action.
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
The workflows here are pinned to commit SHAs, which is the right call — mutable version tags are what made the `tj-actions/changed-files` compromise so wide, and SHA pinning is what protected the repositories that had it. But nothing keeps those pins current, and the drift is already measurable: `astral-sh/setup-uv` sits at **v5.4.2** while ord-data and ord-schema run **v7**, and `actions/checkout` is behind even within its own v4 major.

Dependabot understands SHA-pinned actions and rewrites the SHA together with its trailing `# vN` comment, so the pins keep their security property without freezing. That is the missing half of the pattern this repository already adopted.

Updates are grouped so this arrives as one pull request a month rather than one per action. **Expect a first round of catch-up pull requests once this lands** — that backlog is the point.

Part of an org-wide sweep: [ord-schema#910](https://github.com/Open-Reaction-Database/ord-schema/pull/910), [ord-data#264](https://github.com/open-reaction-database/ord-data/pull/264), and [ord-interface#214](https://github.com/Open-Reaction-Database/ord-interface/pull/214) add the same config alongside the SHA pins those repositories were missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds Dependabot configuration for GitHub Actions.
- Checks monthly for updates to SHA-pinned actions.
- Groups all action updates into one pull request.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The configuration uses the correct GitHub Actions ecosystem, repository-root directory, required schedule fields, and wildcard grouping to cover the existing SHA-pinned workflow actions.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds a valid Dependabot v2 configuration covering the repository's GitHub Actions workflows with monthly grouped updates. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Dependabot for GitHub Actions"](https://github.com/open-reaction-database/ord-app/commit/fe5c0f8f52abd72e652f52fca17f5d0da06639a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48150562)</sub>

<!-- /greptile_comment -->